### PR TITLE
fix: v2.0.0 instability - pin platform to recover internal heap

### DIFF
--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -33,7 +33,7 @@
 
 // Tasks
 #define ADE7953_METER_READING_TASK_NAME "ade7953_task"
-#define ADE7953_METER_READING_TASK_STACK_SIZE (12 * 1024) // Fine, around 5 kB usage. Increased since we use PSRAM
+#define ADE7953_METER_READING_TASK_STACK_SIZE (8 * 1024) // Week-long peak ~5358 bytes (43.6%); 8 KB leaves ~33% margin and frees 4 KB of internal heap
 #define ADE7953_METER_READING_TASK_PRIORITY 5
 
 #define ADE7953_ENERGY_SAVE_TASK_NAME "energy_save_task"

--- a/source/include/buttonhandler.h
+++ b/source/include/buttonhandler.h
@@ -12,7 +12,7 @@
 #include "utils.h"
 
 #define BUTTON_TASK_NAME "button_task"
-#define BUTTON_TASK_STACK_SIZE (4 * 1024)  // Increased to 4KB due to logging stack usage
+#define BUTTON_TASK_STACK_SIZE (3 * 1024)  // Week-long peak ~796 bytes (19.4%); 3 KB keeps ~73% margin while saving 1 KB internal heap (preserves room for occasional logging)
 #define BUTTON_TASK_PRIORITY 2
 
 // Timing constants

--- a/source/include/customserver.h
+++ b/source/include/customserver.h
@@ -48,8 +48,8 @@
 #define HEALTH_CHECK_TASK_STACK_SIZE (6 * 1024)
 #define HEALTH_CHECK_TASK_PRIORITY 1
 #define HEALTH_CHECK_INTERVAL_MS (30 * 1000)
-#define HEALTH_CHECK_TIMEOUT_MS (5 * 1000)
-#define HEALTH_CHECK_MAX_FAILURES 3 // Maximum consecutive failures before restart
+#define HEALTH_CHECK_TIMEOUT_MS (15 * 1000) // Allow handlers that legitimately take a few seconds (large config dumps, NVS writes)
+#define HEALTH_CHECK_MAX_FAILURES 5 // Maximum consecutive failures before restart. 5 * 30s = 2.5 min of sustained failure - tolerant of transient stalls but still catches a real wedge
 
 // Authentication
 #define PREFERENCES_KEY_PASSWORD "password"

--- a/source/include/customwifi.h
+++ b/source/include/customwifi.h
@@ -22,7 +22,7 @@
 #include "utils.h"
 
 #define WIFI_TASK_NAME "wifi_task"
-#define WIFI_TASK_STACK_SIZE (6 * 1024) // Increased for esp_wifi_set_config() which uses ~500+ bytes stack
+#define WIFI_TASK_STACK_SIZE (8 * 1024) // Week-long high-water mark hit 5580 bytes (only 564 bytes free at 6 KB) - bumped to 8 KB for ~30% safety margin on portal/credential paths
 #define WIFI_TASK_PRIORITY 5
 
 #define WIFI_CONFIG_PORTAL_SSID "EnergyMe"

--- a/source/include/mqtt.h
+++ b/source/include/mqtt.h
@@ -26,7 +26,7 @@
 
 #define MQTT_TASK_NAME "mqtt_task"
 #define MQTT_TASK_STACK_SIZE (7 * 1024) // Around 6 kB usage
-#define MQTT_TASK_PRIORITY 3
+#define MQTT_TASK_PRIORITY 1 // Below AsyncTCP/web (priority 3) so user-facing requests preempt cloud publishing
 
 #define MQTT_LOG_QUEUE_SIZE (256 * 1024) // Generous log size (in bytes) thanks to PSRAM
 #define MQTT_METER_QUEUE_SIZE (64 * 1024) // Size in bytes to allocate to PSRAM

--- a/source/include/utils.h
+++ b/source/include/utils.h
@@ -46,7 +46,7 @@
 #define TASK_RESTART_PRIORITY 5
 
 #define TASK_MAINTENANCE_NAME "maintenance_task"
-#define TASK_MAINTENANCE_STACK_SIZE (5 * 1024)     // Maximum usage close to 5 kB
+#define TASK_MAINTENANCE_STACK_SIZE (6 * 1024)     // Week-long min free hit 11.6% (~594 bytes) at 5 KB - bumped to 6 KB for safer margin during flash I/O bursts
 #define TASK_MAINTENANCE_PRIORITY 3
 #define MAINTENANCE_CHECK_INTERVAL (60 * 1000)
 

--- a/source/platformio.ini
+++ b/source/platformio.ini
@@ -8,7 +8,28 @@
 ; Platform Configuration
 ; NOTE: Official PlatformIO does not support Arduino 3.x yet due to issues with Espressif
 ; (https://github.com/platformio/platform-espressif32/issues/1225), so we use pioarduino
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.38/platform-espressif32.zip
+;
+; ============================================================================
+; IMPORTANT - DO NOT BUMP THIS VERSION WITHOUT EXPLICIT MEMORY TESTING
+; ============================================================================
+; Pinned to 55.03.32 (Arduino Core 3.3.2 / ESP-IDF v5.5.1).
+;
+; Bumping to 55.03.38 (Arduino Core 3.3.8 / ESP-IDF v5.5.4) costs ~50 KB of
+; total internal heap (ESP.getHeapSize() drops from ~320 KB to ~270 KB on
+; ESP32-S3-N16R2). With our request workload that headroom loss caused
+; LWIP/AsyncTCP to silently fail PBUF allocations under web/modbus traffic:
+; the device looked alive (router still saw it, ADE7953 kept reading) but
+; ping/HTTP/MQTT/UDP all silently dropped until WiFi keepalive timeout fired
+; a re-association ~5-10 min later. No crash, no warning, just unreachable.
+;
+; This matches a known recurring pattern in arduino-esp32 (see espressif
+; issues #8482 and #9544 for similar 35 KB+ regressions on prior SDK bumps).
+;
+; Before bumping the platform: build, flash on a real device, and check that
+; ESP.getHeapSize() / ESP.getMaxAllocHeap() do not regress under the
+; navigation/modbus load that previously triggered the freeze.
+; ============================================================================
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.32/platform-espressif32.zip
 board = esp32-s3-devkitc-1                     ; Do not try other boards - ESP32-S3-N16R2 specific config
 framework = arduino
 

--- a/source/src/customwifi.cpp
+++ b/source/src/customwifi.cpp
@@ -15,6 +15,8 @@ namespace CustomWifi
   static uint64_t _lastReconnectAttempt = 0;
   static int32_t _reconnectAttempts = 0; // Increased every disconnection, reset on stable (few minutes) connection
   static uint64_t _lastWifiConnectedMillis = 0; // Timestamp when WiFi was last fully connected (for lwIP stabilization)
+  static IPAddress _lastMdnsIp; // Last IP for which mDNS was initialized; used to skip rebuild when IP unchanged
+  static bool _mdnsInitialized = false;
 
   // WiFi event notification values for task communication
   static const uint32_t WIFI_EVENT_CONNECTED = 1;
@@ -789,11 +791,23 @@ namespace CustomWifi
 
   bool _setupMdns()
   {
+    // Skip rebuild if responder is already running for the current IP. ESP-IDF mDNS
+    // does periodic unsolicited re-announces (~120 s, RFC 6762) on its own, so peers
+    // stay aware as long as the responder is alive. Most WiFi reconnects keep the
+    // same DHCP lease; only rebuild when the IP actually changed.
+    IPAddress currentIp = WiFi.localIP();
+    if (_mdnsInitialized && currentIp == _lastMdnsIp) {
+      LOG_DEBUG("mDNS already running for %s, skipping rebuild", currentIp.toString().c_str());
+      return true;
+    }
+
     LOG_DEBUG("Setting up mDNS...");
 
     // Ensure mDNS is stopped before starting
-    MDNS.end();
-    delay(100);
+    if (_mdnsInitialized) {
+      MDNS.end();
+      delay(100);
+    }
 
     // I would like to check for same MDNS_HOSTNAME on the newtork, but it seems that
     // I cannot do this with consistency. Let's just start the mDNS on the network and
@@ -819,6 +833,8 @@ namespace CustomWifi
       MDNS.addServiceTxt("modbus", "tcp", "version", FIRMWARE_BUILD_VERSION);
       MDNS.addServiceTxt("modbus", "tcp", "channels", "16"); // Cannot use constant since that is a number, not a string
 
+      _lastMdnsIp = currentIp;
+      _mdnsInitialized = true;
       LOG_INFO("mDNS setup done: %s.local", MDNS_HOSTNAME);
       return true;
     }
@@ -841,7 +857,9 @@ namespace CustomWifi
     
     // Stop mDNS
     MDNS.end();
-    
+    _mdnsInitialized = false;
+    _lastMdnsIp = IPAddress();
+
     LOG_DEBUG("WiFi cleanup completed");
   }
 


### PR DESCRIPTION
## Summary

Fixes the v2.0.0 web/MQTT/modbus instability where the device looked alive (router still saw it, ADE7953 kept reading) but ping/HTTP/MQTT/UDP all silently dropped under web/modbus load, recovering only after WiFi keepalive timeout fired a re-association ~5-10 min later.

Root cause: bumping pioarduino platform to 55.03.38 (Arduino Core 3.3.8 / ESP-IDF v5.5.4) lost ~50 KB of total internal heap on ESP32-S3-N16R2 vs the v1.1.3 baseline (~320 KB -> ~270 KB). Under request load LWIP/AsyncTCP silently failed PBUF allocations - alive but unreachable. Matches a known recurring arduino-esp32 pattern (espressif issues #8482, #9544).

## Commits

1. `fix(build): pin pioarduino platform to 55.03.32 to recover internal heap` - the actual fix; recovers ~50 KB. Includes a comment block on the platform line so future bumps require explicit memory testing.
2. `fix(tasks): tune stack sizes based on measured peak high-water marks` - week-long TaskProfiler data shows customWifi was 564 B from overflow; meter task was 60% empty. Net +2 KB heap, two safety risks fixed.
3. `fix(wifi): skip mDNS rebuild when IP unchanged on reconnect` - stops needless `MDNS.end()/begin()` churn during transient WiFi flaps; relies on the responder's RFC 6762 unsolicited re-announces.
4. `fix(server): increase health check timeout and tolerance for transient stalls` - 5s -> 15s timeout, 3 -> 5 max failures. Avoids restart-on-transient-stall.
5. `chore(mqtt): lower MQTT task priority below web server` - priority 3 -> 1 so web requests preempt cloud publishing under load.

## Test plan

- [x] Flashed on test device (PCB v6.1); confirmed `ESP.getHeapSize()` returns to ~320 KB
- [x] Confirmed web/modbus/MQTT no longer freeze under heavy navigation + cloud + HA integration load
- [x] Run for 24 h with cloud + HA active to confirm sustained stability before merging to `main`

## Follow-up

Three secondary refactors filed but not in this PR (cleanup for v2.1):
- #136 - decouple MQTT JSON serialization from TCP send
- #137 - evaluate replacing PubSubClient with an async MQTT client
- #138 - move NVS/LittleFS writes out of AsyncTCP handlers via write queue