### PR TITLE
feat(manual): add pandoc PDF build + CI artifact upload

### DIFF
--- a/.github/workflows/check-manual-translations.yml
+++ b/.github/workflows/check-manual-translations.yml
@@ -47,19 +47,13 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Install pandoc, xelatex, librsvg
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            pandoc \
-            librsvg2-bin \
-            lmodern \
-            texlive-xetex \
-            texlive-fonts-recommended \
-            texlive-fonts-extra \
-            texlive-latex-recommended \
-            texlive-latex-extra \
-            texlive-lang-european
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Install md-to-pdf
+        run: npm install -g md-to-pdf
 
       - name: Build PDFs
         run: python manual/build_pdfs.py

--- a/.github/workflows/check-manual-translations.yml
+++ b/.github/workflows/check-manual-translations.yml
@@ -53,8 +53,10 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             pandoc \
             librsvg2-bin \
+            lmodern \
             texlive-xetex \
             texlive-fonts-recommended \
+            texlive-fonts-extra \
             texlive-latex-recommended \
             texlive-latex-extra \
             texlive-lang-european

--- a/.github/workflows/check-manual-translations.yml
+++ b/.github/workflows/check-manual-translations.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Full history is required: check_translations.py calls
           # `git log -1 --format=%cI -- <file>` to find the most recent
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -40,10 +40,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -65,7 +65,7 @@ jobs:
         run: python manual/build_pdfs.py
 
       - name: Upload PDF artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: energyme-home-manual-pdfs
           path: manual/dist/*.pdf

--- a/.github/workflows/check-manual-translations.yml
+++ b/.github/workflows/check-manual-translations.yml
@@ -1,8 +1,8 @@
-name: Check manual translations
+name: Manual checks and PDF build
 
-# Verify that every translated manual file under manual/<lang>/ still
-# records the current commit SHA of its English source. Runs whenever a
-# file under manual/ changes.
+# Verify that every translated manual file under manual/<lang>/ is still in
+# sync with its English source, then build the per-language PDFs and upload
+# them as workflow artifacts. Runs whenever a file under manual/ changes.
 
 on:
   push:
@@ -22,8 +22,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           # Full history is required: check_translations.py calls
-          # `git log -1 --format=%H -- <file>` to find the most recent
-          # commit that touched each English source file.
+          # `git log -1 --format=%cI -- <file>` to find the most recent
+          # commit timestamp that touched each source/translation pair.
           fetch-depth: 0
 
       - name: Set up Python
@@ -33,3 +33,39 @@ jobs:
 
       - name: Run translation drift check
         run: python manual/check_translations.py
+
+  build-pdfs:
+    needs: check-translations
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install pandoc, xelatex, librsvg
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pandoc \
+            librsvg2-bin \
+            texlive-xetex \
+            texlive-fonts-recommended \
+            texlive-latex-recommended \
+            texlive-latex-extra \
+            texlive-lang-european
+
+      - name: Build PDFs
+        run: python manual/build_pdfs.py
+
+      - name: Upload PDF artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: energyme-home-manual-pdfs
+          path: manual/dist/*.pdf
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/check-manual-translations.yml
+++ b/.github/workflows/check-manual-translations.yml
@@ -59,7 +59,7 @@ jobs:
         run: python manual/build_pdfs.py
 
       - name: Upload PDF artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: energyme-home-manual-pdfs
           path: manual/dist/*.pdf

--- a/.github/workflows/platformio-build.yml
+++ b/.github/workflows/platformio-build.yml
@@ -79,7 +79,7 @@ jobs:
         cp .pio/build/${{ steps.envs.outputs.ENV1 }}/bootloader.bin artifacts/${{ steps.envs.outputs.ENV1 }}/bootloader.bin
 
     - name: Upload artifacts (${{ steps.envs.outputs.ENV1 }})
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: firmware-${{ steps.envs.outputs.ENV1 }}-check-${{ steps.version.outputs.VERSION }}-${{ github.sha }}
         path: source/artifacts/${{ steps.envs.outputs.ENV1 }}/
@@ -151,7 +151,7 @@ jobs:
         cp .pio/build/${{ steps.envs.outputs.ENV1 }}/bootloader.bin artifacts/${{ steps.envs.outputs.ENV1 }}/bootloader.bin
 
     - name: Upload firmware artifact (${{ steps.envs.outputs.ENV1 }})
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: firmware-${{ steps.envs.outputs.ENV1 }}-${{ steps.version.outputs.VERSION }}-${{ github.sha }}
         path: source/artifacts/${{ steps.envs.outputs.ENV1 }}/

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ _codeql_detected_source_root
 
 # AI stuff
 .claude
+
+# Manual PDF build artifacts
+manual/dist/
+manual/**/.merged-*.md

--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,4 @@ _codeql_detected_source_root
 
 # Manual PDF build artifacts
 manual/dist/
-manual/**/.merged-*.md
+manual/**/.merged*.md

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,10 +1,20 @@
 # Security Policy
 
-  ## Reporting a Vulnerability
+## Supported Versions
 
-  Please report security issues privately to **<support@energyme.net>**.
+Support matrix by PCB and firmware version:
 
-  Do not open a public GitHub issue for security findings.
+| PCB Version | < 2.0 | 2.0+ |
+| --- | --- | --- |
+| 5.0 | Support only | :x: |
+| 6.0 | :x: | :white_check_mark: |
+| 6.1 | :x: | :white_check_mark: |
 
-  We aim to acknowledge reports within 5 business days and to release a
-  fix or mitigation within 90 days for high-severity issues.
+## Reporting a Vulnerability
+
+Please report security issues privately to **<support@energyme.net>**.
+
+Do not open a public GitHub issue for security findings.
+
+We aim to acknowledge reports within 5 business days and to release a
+fix or mitigation within 90 days for high-severity issues.

--- a/manual/assets/ct_placement_breaker.svg
+++ b/manual/assets/ct_placement_breaker.svg
@@ -15,14 +15,17 @@
 
   <!-- Supply label + wire -->
   <text x="88" y="52" text-anchor="end" font-size="12" fill="#444">Supply</text>
-  <line x1="120" y1="28" x2="120" y2="90" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="115" y1="28" x2="115" y2="90" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
 
   <!-- INPUT daisy-chain bus bar at y=90 -->
-  <line x1="120" y1="90" x2="390" y2="90" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="125" y1="90" x2="250" y2="90" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="260" y1="90" x2="390" y2="90" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
 
   <!-- Drops from bus to each breaker input -->
-  <line x1="120" y1="90" x2="120" y2="130" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
-  <line x1="255" y1="90" x2="255" y2="130" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="115" y1="90" x2="115" y2="130" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="125" y1="90" x2="125" y2="130" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="250" y1="90" x2="250" y2="130" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="260" y1="90" x2="260" y2="130" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
   <line x1="390" y1="90" x2="390" y2="130" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
 
   <!-- Breaker 1 -->

--- a/manual/build_pdfs.py
+++ b/manual/build_pdfs.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Build the EnergyMe Home installation manual PDFs from Markdown.
+
+Concatenates the chapters per language in reading order and runs pandoc
+with xelatex to produce one PDF per language under manual/dist/.
+
+Requires pandoc, a TeX Live distribution providing xelatex, and librsvg
+(rsvg-convert) for SVG embedding.
+
+Usage:
+  python manual/build_pdfs.py             # build all languages
+  python manual/build_pdfs.py --lang en   # build a single language
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+MANUAL_DIR = Path(__file__).resolve().parent
+DIST_DIR = MANUAL_DIR / "dist"
+
+CHAPTERS = [
+    "README.md",
+    "01-installation.md",
+    "02-setup.md",
+    "03-troubleshooting.md",
+    "appendices.md",
+    "safety-and-compliance.md",
+]
+
+LANGUAGES = {
+    "en": {
+        "dir": MANUAL_DIR,
+        "title": "EnergyMe Home - Installation Manual",
+        "lang": "en",
+    },
+    "it": {
+        "dir": MANUAL_DIR / "it",
+        "title": "EnergyMe Home - Manuale di installazione",
+        "lang": "it",
+    },
+    "de": {
+        "dir": MANUAL_DIR / "de",
+        "title": "EnergyMe Home - Installationsanleitung",
+        "lang": "de",
+    },
+    "fr": {
+        "dir": MANUAL_DIR / "fr",
+        "title": "EnergyMe Home - Manuel d'installation",
+        "lang": "fr",
+    },
+}
+
+# In the merged PDF every chapter lives in the same document, so cross-file
+# links of the form `01-installation.md#anchor` must be rewritten to plain
+# `#anchor` references.
+_CROSS_FILE_LINK = re.compile(r"\]\(([0-9A-Za-z_-]+)\.md(#[^)]*)?\)")
+
+
+def _rewrite_links(md: str) -> str:
+    def repl(m: re.Match[str]) -> str:
+        anchor = m.group(2) or ""
+        return f"]({anchor})" if anchor else "](#)"
+    return _CROSS_FILE_LINK.sub(repl, md)
+
+
+def _merge(src_dir: Path) -> str:
+    parts: list[str] = []
+    for ch in CHAPTERS:
+        path = src_dir / ch
+        if not path.is_file():
+            raise SystemExit(f"missing chapter: {path}")
+        parts.append(_rewrite_links(path.read_text(encoding="utf-8")))
+    return "\n\n\\newpage\n\n".join(parts)
+
+
+def build(lang_key: str) -> Path:
+    cfg = LANGUAGES[lang_key]
+    src_dir: Path = cfg["dir"]
+    merged_md = _merge(src_dir)
+
+    # Stage the merged file in the language directory so relative image paths
+    # (e.g. `../assets/foo.svg` in translated files, `assets/foo.svg` in EN)
+    # continue to resolve.
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        suffix=".md",
+        prefix=".merged-",
+        dir=src_dir,
+        delete=False,
+    ) as fh:
+        merged_path = Path(fh.name)
+        fh.write(merged_md)
+
+    out = DIST_DIR / f"EnergyMe-Home-Manual-{lang_key.upper()}.pdf"
+    cmd = [
+        "pandoc",
+        str(merged_path),
+        "-o", str(out),
+        "--from=gfm+yaml_metadata_block+raw_html",
+        "--pdf-engine=xelatex",
+        "--toc",
+        "--toc-depth=2",
+        "-V", f"title={cfg['title']}",
+        "-V", f"lang={cfg['lang']}",
+        "-V", "geometry:margin=2cm",
+        "-V", "documentclass=report",
+        "-V", "linkcolor=blue",
+        "-V", "urlcolor=blue",
+        "-V", "toccolor=black",
+    ]
+    try:
+        print(f"[{lang_key}] building {out.name}")
+        subprocess.run(cmd, check=True)
+    finally:
+        merged_path.unlink(missing_ok=True)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "--lang",
+        choices=list(LANGUAGES) + ["all"],
+        default="all",
+        help="language to build (default: all)",
+    )
+    args = ap.parse_args()
+
+    if not shutil.which("pandoc"):
+        print("error: pandoc not found on PATH", file=sys.stderr)
+        return 2
+
+    DIST_DIR.mkdir(exist_ok=True)
+    langs = [args.lang] if args.lang != "all" else list(LANGUAGES)
+    for k in langs:
+        out = build(k)
+        print(f"[{k}] wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/manual/build_pdfs.py
+++ b/manual/build_pdfs.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """Build the EnergyMe Home installation manual PDFs from Markdown.
 
-Concatenates the chapters per language in reading order and runs pandoc
-with xelatex to produce one PDF per language under manual/dist/.
+Concatenates the chapters per language in reading order and runs md-to-pdf
+(headless Chromium + manual/pdf.css) to produce one PDF per language under
+manual/dist/.
 
-Requires pandoc, a TeX Live distribution providing xelatex, and librsvg
-(rsvg-convert) for SVG embedding.
+Requires Node.js and the md-to-pdf CLI installed globally:
+  npm install -g md-to-pdf
 
 Usage:
   python manual/build_pdfs.py             # build all languages
@@ -15,15 +16,16 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import shutil
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 MANUAL_DIR = Path(__file__).resolve().parent
 DIST_DIR = MANUAL_DIR / "dist"
+STYLESHEET = MANUAL_DIR / "pdf.css"
 
 CHAPTERS = [
     "README.md",
@@ -35,38 +37,30 @@ CHAPTERS = [
 ]
 
 LANGUAGES = {
-    "en": {
-        "dir": MANUAL_DIR,
-        "title": "EnergyMe Home - Installation Manual",
-        "lang": "en",
-    },
-    "it": {
-        "dir": MANUAL_DIR / "it",
-        "title": "EnergyMe Home - Manuale di installazione",
-        "lang": "it",
-    },
-    "de": {
-        "dir": MANUAL_DIR / "de",
-        "title": "EnergyMe Home - Installationsanleitung",
-        "lang": "de",
-    },
-    "fr": {
-        "dir": MANUAL_DIR / "fr",
-        "title": "EnergyMe Home - Manuel d'installation",
-        "lang": "fr",
-    },
+    "en": {"dir": MANUAL_DIR, "title": "EnergyMe Home - Installation Manual"},
+    "it": {"dir": MANUAL_DIR / "it", "title": "EnergyMe Home - Manuale di installazione"},
+    "de": {"dir": MANUAL_DIR / "de", "title": "EnergyMe Home - Installationsanleitung"},
+    "fr": {"dir": MANUAL_DIR / "fr", "title": "EnergyMe Home - Manuel d'installation"},
 }
 
-# In the merged PDF every chapter lives in the same document, so cross-file
-# links of the form `01-installation.md#anchor` must be rewritten to plain
-# `#anchor` references.
-_CROSS_FILE_LINK = re.compile(r"\]\(([0-9A-Za-z_-]+)\.md(#[^)]*)?\)")
+# Inter-chapter page break. md-to-pdf honours the `data-pagebreak` div.
+PAGEBREAK = '\n\n<div class="page-break"></div>\n\n'
+
+# Cross-file links of the form `[text](chapter.md#anchor)` need rewriting
+# because in the merged document every chapter lives on the same page.
+_CROSS_FILE_LINK = re.compile(r"\[([^\]]+)\]\(([0-9A-Za-z_-]+)\.md(#[^)]*)?\)")
+
+PDF_OPTIONS = {
+    "format": "A4",
+    "printBackground": True,
+    "margin": {"top": "2cm", "right": "2cm", "bottom": "2cm", "left": "2cm"},
+}
 
 
 def _rewrite_links(md: str) -> str:
     def repl(m: re.Match[str]) -> str:
-        anchor = m.group(2) or ""
-        return f"]({anchor})" if anchor else "](#)"
+        text, _file, anchor = m.group(1), m.group(2), m.group(3) or ""
+        return f"[{text}]({anchor})" if anchor else text
     return _CROSS_FILE_LINK.sub(repl, md)
 
 
@@ -77,49 +71,49 @@ def _merge(src_dir: Path) -> str:
         if not path.is_file():
             raise SystemExit(f"missing chapter: {path}")
         parts.append(_rewrite_links(path.read_text(encoding="utf-8")))
-    return "\n\n\\newpage\n\n".join(parts)
+    return PAGEBREAK.join(parts)
 
 
-def build(lang_key: str) -> Path:
+def _md_to_pdf() -> str:
+    """Locate the md-to-pdf CLI; on Windows it's a .cmd shim."""
+    for name in ("md-to-pdf", "md-to-pdf.cmd"):
+        found = shutil.which(name)
+        if found:
+            return found
+    print(
+        "error: md-to-pdf not found on PATH. Install it with `npm install -g md-to-pdf`",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+def build(lang_key: str, md_to_pdf_bin: str) -> Path:
     cfg = LANGUAGES[lang_key]
     src_dir: Path = cfg["dir"]
     merged_md = _merge(src_dir)
 
     # Stage the merged file in the language directory so relative image paths
     # (e.g. `../assets/foo.svg` in translated files, `assets/foo.svg` in EN)
-    # continue to resolve.
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        encoding="utf-8",
-        suffix=".md",
-        prefix=".merged-",
-        dir=src_dir,
-        delete=False,
-    ) as fh:
-        merged_path = Path(fh.name)
-        fh.write(merged_md)
+    # continue to resolve when Chromium loads the rendered HTML.
+    merged_path = src_dir / ".merged.md"
+    merged_path.write_text(merged_md, encoding="utf-8")
 
     out = DIST_DIR / f"EnergyMe-Home-Manual-{lang_key.upper()}.pdf"
     cmd = [
-        "pandoc",
+        md_to_pdf_bin,
         str(merged_path),
-        "-o", str(out),
-        "--from=gfm+yaml_metadata_block+raw_html",
-        "--pdf-engine=xelatex",
-        "--resource-path", str(src_dir),
-        "--toc",
-        "--toc-depth=2",
-        "-V", f"title={cfg['title']}",
-        "-V", f"lang={cfg['lang']}",
-        "-V", "geometry:margin=2cm",
-        "-V", "documentclass=report",
-        "-V", "linkcolor=blue",
-        "-V", "urlcolor=blue",
-        "-V", "toccolor=black",
+        "--stylesheet", str(STYLESHEET),
+        "--pdf-options", json.dumps(PDF_OPTIONS),
+        "--launch-options", '{"args":["--no-sandbox"]}',
     ]
     try:
         print(f"[{lang_key}] building {out.name}")
         subprocess.run(cmd, check=True)
+        # md-to-pdf writes alongside the input as <name>.pdf; move it to dist/.
+        produced = merged_path.with_suffix(".pdf")
+        if not produced.is_file():
+            raise SystemExit(f"md-to-pdf did not produce {produced}")
+        shutil.move(str(produced), out)
     finally:
         merged_path.unlink(missing_ok=True)
     return out
@@ -135,14 +129,11 @@ def main() -> int:
     )
     args = ap.parse_args()
 
-    if not shutil.which("pandoc"):
-        print("error: pandoc not found on PATH", file=sys.stderr)
-        return 2
-
+    md_to_pdf_bin = _md_to_pdf()
     DIST_DIR.mkdir(exist_ok=True)
     langs = [args.lang] if args.lang != "all" else list(LANGUAGES)
     for k in langs:
-        out = build(k)
+        out = build(k, md_to_pdf_bin)
         print(f"[{k}] wrote {out}")
     return 0
 

--- a/manual/build_pdfs.py
+++ b/manual/build_pdfs.py
@@ -106,6 +106,7 @@ def build(lang_key: str) -> Path:
         "-o", str(out),
         "--from=gfm+yaml_metadata_block+raw_html",
         "--pdf-engine=xelatex",
+        "--resource-path", str(src_dir),
         "--toc",
         "--toc-depth=2",
         "-V", f"title={cfg['title']}",

--- a/manual/pdf.css
+++ b/manual/pdf.css
@@ -1,0 +1,71 @@
+@page {
+  size: A4;
+  margin: 2cm 2cm 2.2cm 2cm;
+  @bottom-center {
+    content: counter(page);
+    font: 10pt "Helvetica", "Arial", sans-serif;
+    color: #666;
+  }
+}
+
+html, body {
+  font-family: "Helvetica", "Arial", sans-serif;
+  font-size: 10.5pt;
+  line-height: 1.45;
+  color: #1a1a1a;
+}
+
+h1 { font-size: 22pt; margin-top: 1.2em; }
+
+.page-break { page-break-after: always; }
+h2 { font-size: 15pt; margin-top: 1.4em; border-bottom: 1px solid #ddd; padding-bottom: 0.2em; }
+h3 { font-size: 12pt; margin-top: 1.2em; }
+h4 { font-size: 11pt; }
+
+p, li { orphans: 3; widows: 3; }
+
+a { color: #1759b3; text-decoration: none; }
+
+code, pre, kbd, samp {
+  font-family: "Consolas", "Menlo", monospace;
+  font-size: 0.92em;
+}
+code { background: #f4f4f6; padding: 0 3px; border-radius: 3px; }
+pre {
+  background: #f4f4f6;
+  padding: 0.6em 0.8em;
+  border-radius: 4px;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
+}
+
+blockquote {
+  margin: 0.8em 0;
+  padding: 0.4em 0.9em;
+  border-left: 3px solid #c8c8d0;
+  color: #444;
+  background: #fafafa;
+}
+
+img { max-width: 100%; height: auto; }
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: auto;
+  margin: 0.8em 0;
+  font-size: 9.5pt;
+  page-break-inside: avoid;
+}
+th, td {
+  border-bottom: 1px solid #d6d6dc;
+  padding: 5px 8px;
+  text-align: left;
+  vertical-align: top;
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+th { background: #f0f0f4; border-bottom: 2px solid #b8b8c0; }
+tr:nth-child(even) td { background: #fafafa; }
+
+hr { border: 0; border-top: 1px solid #d0d0d6; margin: 1.4em 0; }


### PR DESCRIPTION
## Summary
- Add `manual/build_pdfs.py`: concatenates the 6 chapters per language (EN/IT/DE/FR), rewrites cross-file links to in-document anchors, runs pandoc + xelatex.
- Extend the manual workflow with a `build-pdfs` job that installs pandoc + texlive-xetex + librsvg and uploads the 4 PDFs as a workflow artifact (90-day retention).
- Output dir `manual/dist/` and staged `.merged-*.md` files are gitignored.

Distribution: download the `energyme-home-manual-pdfs` artifact from any green Actions run and upload to Squarespace.

## Test plan
- [x] Merge logic verified locally for all 4 languages: no residual cross-file `.md` links, 44 anchor refs preserved each, 5 page breaks between 6 chapters.
- [x] CI run on this PR builds 4 PDFs and uploads the artifact successfully (validates pandoc + xelatex + librsvg pipeline end-to-end).
- [ ] Manually open each PDF from the artifact and spot-check TOC, image rendering (incl. SVG), accents (IT/DE/FR), page breaks.