### PR TITLE
fix(server): stream embedded static assets without heap copy

### DIFF
--- a/source/include/binaries.h
+++ b/source/include/binaries.h
@@ -5,38 +5,74 @@
 
 #include <Arduino.h>
 
-// Web server files
+// Web server files embedded via board_build.embed_txtfiles.
+// Each file exposes _start / _end symbols from the linker; _end - _start
+// includes the trailing '\0' that embed_txtfiles appends, hence the -1 in
+// EMBEDDED_SIZE() to recover the original file size for HTTP responses.
 // --------------------------------------------------
+
 // Styles
-extern const char button_css[] asm("_binary_css_button_css_start");
-extern const char forms_css[] asm("_binary_css_forms_css_start");
-extern const char index_css[] asm("_binary_css_index_css_start");
-extern const char styles_css[] asm("_binary_css_styles_css_start");
-extern const char section_css[] asm("_binary_css_section_css_start");
-extern const char tooltip_css[] asm("_binary_css_tooltip_css_start");
-extern const char typography_css[] asm("_binary_css_typography_css_start");
+extern const char button_css[]         asm("_binary_css_button_css_start");
+extern const char button_css_end[]     asm("_binary_css_button_css_end");
+extern const char forms_css[]          asm("_binary_css_forms_css_start");
+extern const char forms_css_end[]      asm("_binary_css_forms_css_end");
+extern const char index_css[]          asm("_binary_css_index_css_start");
+extern const char index_css_end[]      asm("_binary_css_index_css_end");
+extern const char styles_css[]         asm("_binary_css_styles_css_start");
+extern const char styles_css_end[]     asm("_binary_css_styles_css_end");
+extern const char section_css[]        asm("_binary_css_section_css_start");
+extern const char section_css_end[]    asm("_binary_css_section_css_end");
+extern const char tooltip_css[]        asm("_binary_css_tooltip_css_start");
+extern const char tooltip_css_end[]    asm("_binary_css_tooltip_css_end");
+extern const char typography_css[]     asm("_binary_css_typography_css_start");
+extern const char typography_css_end[] asm("_binary_css_typography_css_end");
 
 // JavaScript
-extern const char api_client_js[] asm("_binary_js_api_client_js_start");
-extern const char chart_helpers_js[] asm("_binary_js_chart_helpers_js_start");
-extern const char data_helpers_js[] asm("_binary_js_data_helpers_js_start");
-extern const char power_flow_js[] asm("_binary_js_power_flow_js_start");
-extern const char tooltip_js[] asm("_binary_js_tooltip_js_start");
+extern const char api_client_js[]       asm("_binary_js_api_client_js_start");
+extern const char api_client_js_end[]   asm("_binary_js_api_client_js_end");
+extern const char chart_helpers_js[]    asm("_binary_js_chart_helpers_js_start");
+extern const char chart_helpers_js_end[]asm("_binary_js_chart_helpers_js_end");
+extern const char data_helpers_js[]     asm("_binary_js_data_helpers_js_start");
+extern const char data_helpers_js_end[] asm("_binary_js_data_helpers_js_end");
+extern const char power_flow_js[]       asm("_binary_js_power_flow_js_start");
+extern const char power_flow_js_end[]   asm("_binary_js_power_flow_js_end");
+extern const char tooltip_js[]          asm("_binary_js_tooltip_js_start");
+extern const char tooltip_js_end[]      asm("_binary_js_tooltip_js_end");
 
 // HTML
-extern const char ade7953_tester_html[] asm("_binary_html_ade7953_tester_html_start");
-extern const char calibration_html[] asm("_binary_html_calibration_html_start");
-extern const char channel_html[] asm("_binary_html_channel_html_start");
-extern const char configuration_html[] asm("_binary_html_configuration_html_start");
-extern const char index_html[] asm("_binary_html_index_html_start");
-extern const char info_html[] asm("_binary_html_info_html_start");
-extern const char integrations_html[] asm("_binary_html_integrations_html_start");
-extern const char log_html[] asm("_binary_html_log_html_start");
-extern const char swagger_ui_html[] asm("_binary_html_swagger_html_start");
-extern const char update_html[] asm("_binary_html_update_html_start");
-extern const char waveform_html[] asm("_binary_html_waveform_html_start");
+extern const char ade7953_tester_html[]    asm("_binary_html_ade7953_tester_html_start");
+extern const char ade7953_tester_html_end[]asm("_binary_html_ade7953_tester_html_end");
+extern const char calibration_html[]       asm("_binary_html_calibration_html_start");
+extern const char calibration_html_end[]   asm("_binary_html_calibration_html_end");
+extern const char channel_html[]           asm("_binary_html_channel_html_start");
+extern const char channel_html_end[]       asm("_binary_html_channel_html_end");
+extern const char configuration_html[]     asm("_binary_html_configuration_html_start");
+extern const char configuration_html_end[] asm("_binary_html_configuration_html_end");
+extern const char index_html[]             asm("_binary_html_index_html_start");
+extern const char index_html_end[]         asm("_binary_html_index_html_end");
+extern const char info_html[]              asm("_binary_html_info_html_start");
+extern const char info_html_end[]          asm("_binary_html_info_html_end");
+extern const char integrations_html[]      asm("_binary_html_integrations_html_start");
+extern const char integrations_html_end[]  asm("_binary_html_integrations_html_end");
+extern const char log_html[]               asm("_binary_html_log_html_start");
+extern const char log_html_end[]           asm("_binary_html_log_html_end");
+extern const char swagger_ui_html[]        asm("_binary_html_swagger_html_start");
+extern const char swagger_ui_html_end[]    asm("_binary_html_swagger_html_end");
+extern const char update_html[]            asm("_binary_html_update_html_start");
+extern const char update_html_end[]        asm("_binary_html_update_html_end");
+extern const char waveform_html[]          asm("_binary_html_waveform_html_start");
+extern const char waveform_html_end[]      asm("_binary_html_waveform_html_end");
 
-// Swagger UI
-extern const char swagger_yaml[] asm("_binary_resources_swagger_yaml_start");
-extern const char favicon_svg[] asm("_binary_resources_favicon_svg_start");
+// Swagger / favicon
+extern const char swagger_yaml[]     asm("_binary_resources_swagger_yaml_start");
+extern const char swagger_yaml_end[] asm("_binary_resources_swagger_yaml_end");
+extern const char favicon_svg[]      asm("_binary_resources_favicon_svg_start");
+extern const char favicon_svg_end[]  asm("_binary_resources_favicon_svg_end");
 
+// Expands to (const uint8_t* content, size_t len) - the two args expected by
+// AsyncWebServerRequest::beginResponse(int, const char*, const uint8_t*, size_t).
+// Streams from flash without copying into heap (vs the const char* overload,
+// which copies into a String).
+#define EMBEDDED(name) \
+    reinterpret_cast<const uint8_t*>(name), \
+    static_cast<size_t>(name##_end - name) - 1

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -4537,7 +4537,9 @@ namespace Ade7953
             releaseMutex(&_meterValuesMutex);
         }
         if (starvedChannel != INVALID_CHANNEL) {
-            LOG_WARNING(
+            // This might happen in cases of high-value loads in some channels
+            // with static 0W channels, so it is not an error per se (thus DEBUG level)
+            LOG_DEBUG(
                 "%s (%u): scheduler starvation, %llu ms since last read; force-picking",
                 _channelData[starvedChannel].label, starvedChannel, starvedGap
             );

--- a/source/src/customserver.cpp
+++ b/source/src/customserver.cpp
@@ -693,13 +693,17 @@ namespace CustomServer
      * If client sends matching If-None-Match header, responds with 304 Not Modified (no body)
      * Otherwise sends full content with ETag and Cache-Control headers
      */
-    static void _sendStaticWithEtag(AsyncWebServerRequest *request, const char* contentType, const char* content, const char* etag)
+    static void _sendStaticWithEtag(AsyncWebServerRequest *request, const char* contentType, const uint8_t* content, size_t len, const char* etag)
     {
         // Check if client sent matching ETag
         if (_checkEtagAndSend304(request, etag)) return;
-        
-        // ETag doesn't match or not provided - send full content
-        AsyncWebServerResponse *response = request->beginResponse(HTTP_CODE_OK, contentType, content);
+
+        // ETag doesn't match or not provided - stream full content from flash
+        // (uint8_t* + size_t overload constructs AsyncProgmemResponse, which reads
+        // chunks directly from flash via memcpy_P; no heap copy of the body, vs
+        // the const char* overload that copies the entire file into a String and
+        // can corrupt under concurrent parallel requests on a fragmented heap)
+        AsyncWebServerResponse *response = request->beginResponse(HTTP_CODE_OK, contentType, content, len);
         _sendResponseWithEtag(request, response, etag);
     }
 
@@ -735,7 +739,6 @@ namespace CustomServer
     // === STATIC CONTENT SERVING ===
     static void _serveStaticContent()
     {
-        // === STATIC CONTENT (no auth required) ===
         // Cache strategy: "no-cache" with ETag validation
         // - Browser always asks server before using cache
         // - Server responds 304 Not Modified (no body) if ETag matches → fast
@@ -748,89 +751,89 @@ namespace CustomServer
 
         // CSS files
         server.on("/css/button.css", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "text/css", button_css, etag);
+            _sendStaticWithEtag(request, "text/css", EMBEDDED(button_css), etag);
         });
         server.on("/css/forms.css", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "text/css", forms_css, etag);
+            _sendStaticWithEtag(request, "text/css", EMBEDDED(forms_css), etag);
         });
         server.on("/css/index.css", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "text/css", index_css, etag);
+            _sendStaticWithEtag(request, "text/css", EMBEDDED(index_css), etag);
         });
         server.on("/css/styles.css", HTTP_GET, [etag](AsyncWebServerRequest *request) { 
-            _sendStaticWithEtag(request, "text/css", styles_css, etag);
+            _sendStaticWithEtag(request, "text/css", EMBEDDED(styles_css), etag);
         });
         server.on("/css/section.css", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "text/css", section_css, etag);
+            _sendStaticWithEtag(request, "text/css", EMBEDDED(section_css), etag);
         });
         server.on("/css/tooltip.css", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "text/css", tooltip_css, etag);
+            _sendStaticWithEtag(request, "text/css", EMBEDDED(tooltip_css), etag);
         });
         server.on("/css/typography.css", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "text/css", typography_css, etag);
+            _sendStaticWithEtag(request, "text/css", EMBEDDED(typography_css), etag);
         });
 
         // JavaScript files
         server.on("/js/api-client.js", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "application/javascript", api_client_js, etag);
+            _sendStaticWithEtag(request, "application/javascript", EMBEDDED(api_client_js), etag);
         });
         server.on("/js/chart-helpers.js", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "application/javascript", chart_helpers_js, etag);
+            _sendStaticWithEtag(request, "application/javascript", EMBEDDED(chart_helpers_js), etag);
         });
         server.on("/js/data-helpers.js", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "application/javascript", data_helpers_js, etag);
+            _sendStaticWithEtag(request, "application/javascript", EMBEDDED(data_helpers_js), etag);
         });
         server.on("/js/power-flow.js", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "application/javascript", power_flow_js, etag);
+            _sendStaticWithEtag(request, "application/javascript", EMBEDDED(power_flow_js), etag);
         });
         server.on("/js/tooltip.js", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "application/javascript", tooltip_js, etag);
+            _sendStaticWithEtag(request, "application/javascript", EMBEDDED(tooltip_js), etag);
         });
 
         // Resources
         server.on("/favicon.svg", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "image/svg+xml", favicon_svg, etag);
+            _sendStaticWithEtag(request, "image/svg+xml", EMBEDDED(favicon_svg), etag);
         });
 
         // Main dashboard
         server.on("/", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "text/html", index_html, etag);
+            _sendStaticWithEtag(request, "text/html", EMBEDDED(index_html), etag);
         });
 
         // Configuration pages
         server.on("/ade7953-tester", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "text/html", ade7953_tester_html, etag);
+            _sendStaticWithEtag(request, "text/html", EMBEDDED(ade7953_tester_html), etag);
         });
         server.on("/configuration", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "text/html", configuration_html, etag);
+            _sendStaticWithEtag(request, "text/html", EMBEDDED(configuration_html), etag);
         });
         server.on("/calibration", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "text/html", calibration_html, etag);
+            _sendStaticWithEtag(request, "text/html", EMBEDDED(calibration_html), etag);
         });
         server.on("/channel", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "text/html", channel_html, etag);
+            _sendStaticWithEtag(request, "text/html", EMBEDDED(channel_html), etag);
         });
         server.on("/info", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "text/html", info_html, etag);
+            _sendStaticWithEtag(request, "text/html", EMBEDDED(info_html), etag);
         });
         server.on("/integrations", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "text/html", integrations_html, etag);
+            _sendStaticWithEtag(request, "text/html", EMBEDDED(integrations_html), etag);
         });
         server.on("/log", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "text/html", log_html, etag);
+            _sendStaticWithEtag(request, "text/html", EMBEDDED(log_html), etag);
         });
         server.on("/update", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "text/html", update_html, etag);
+            _sendStaticWithEtag(request, "text/html", EMBEDDED(update_html), etag);
         });
         server.on("/waveform", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "text/html", waveform_html, etag);
+            _sendStaticWithEtag(request, "text/html", EMBEDDED(waveform_html), etag);
         });
 
         // Swagger UI
         server.on("/swagger-ui", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "text/html", swagger_ui_html, etag);
+            _sendStaticWithEtag(request, "text/html", EMBEDDED(swagger_ui_html), etag);
         });
         server.on("/swagger.yaml", HTTP_GET, [etag](AsyncWebServerRequest *request) {
-            _sendStaticWithEtag(request, "text/yaml", swagger_yaml, etag);
+            _sendStaticWithEtag(request, "text/yaml", EMBEDDED(swagger_yaml), etag);
         });
     }
 


### PR DESCRIPTION
## Summary

- Static asset routes were calling the `beginResponse(int, const char*, const char*)` overload, which constructs an `AsyncBasicResponse` and copies the entire embedded file into a heap-allocated `String` per request. Under post-OTA heap fragmentation with the browser firing ~15 parallel asset requests, concurrent `String` allocations could corrupt each other's backing buffers - producing valid-looking but spliced JS/CSS that the browser then cached against the sketch-MD5 ETag and served via 304s indefinitely.
- Switched to the `(const uint8_t*, size_t)` overload, which constructs `AsyncProgmemResponse` and streams chunks directly from flash via `memcpy_P` with no heap copy of the body.
- Added `_end` linker symbols and an `EMBEDDED(name)` helper in `binaries.h` to derive content length from the `_start`/`_end` pair (`-1` strips the trailing NUL appended by `embed_txtfiles`).
- Drive-bys: removed misleading "no auth required" comment on the static routes (they go through global digest auth), and demoted `Ade7953::` scheduler-starvation log from WARNING to DEBUG (expected condition when high-power channels coexist with static 0W channels).

## Test plan

- [x] Reproduced the corruption pre-fix: `Uncaught SyntaxError: Invalid or unexpected token` at `api-client.js:351` and `data-helpers.js:346:64` after OTA, with valid-looking but spliced JS payload.
- [x] Confirmed bytes were correct under sequential `curl` (matched source MD5), ruling out file-on-disk corruption and pointing at a concurrent-allocation failure mode.
- [x] Disabled caching entirely as a discriminator (`no-store`, no ETag): corruption still reproduced under parallel browser fetch -> server-side bug confirmed, not a browser cache issue.
- [x] Flashed fix branch, cleared site data, navigated `/`, `/configuration`, `/log`, hard- and soft-reloaded several times: console clean, no syntax errors.
- [x] Reviewer: spot-check that ETag/304 path still works (request a static asset twice in DevTools, second one should be `304 Not Modified`).
- [x] Reviewer: confirm no regression in cached-load times vs. `development` baseline (this PR doesn't touch the cache strategy, only the response construction).