### PR TITLE
feat(ade7953): host-testable meter logic + conduction-gated CT-reversal & grid/battery priority

### DIFF
--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -79,6 +79,7 @@
 #define VARIABILITY_EMA_ALPHA 0.3f   // Exponential moving average smoothing for variability (0-1, lower = smoother)
 #define CHANNEL_MAX_GAP_MS 15000ULL  // Watchdog: max time between successful reads before forcing a pick
 #define MAX_CHANNEL_DEFICIT_BOUND 5.0f // Symmetric clamp on per-channel deficit (safety net against arithmetic edge cases)
+#define WEIGHT_ARMED_BOOST 1.5f      // Extra weight for a channel actively running CT-reversal detection, so it is sampled rapidly and resolves in ~1-2 s
 
 // Default values for ADE7953 registers
 #define UNLOCK_OPTIMUM_REGISTER_VALUE 0xAD // Register to write to unlock the optimum register
@@ -228,7 +229,7 @@
 #define MINIMUM_CURRENT_THREE_PHASE_APPROXIMATION_NO_LOAD 0.01f // The minimum current value for the three-phase approximation to be used as the no-load feature cannot be used
 #define MINIMUM_CURRENT_FOR_VALIDATION 0.02f // Below this current threshold, skip invalidating the reading as measurements are unreliable (noise dominates)
 #define MINIMUM_POWER_FACTOR 0.10f // Measuring such low power factors is virtually impossible with such CTs
-#define AUTO_POLARITY_MIN_POWER_W 5.0f // Below this absolute active power, the auto-polarity check stays armed (avoids flipping on noise / idle circuits)
+#define POLARITY_DETECT_VOTE_THRESHOLD 5 // Net consistent-sign votes (over conducting samples) needed to decide CT orientation. Magnitude-independent, so a steady -4 W reversed CT is caught like a -4 kW one
 #define ADE7953_MIN_LINECYC 10UL // Below this the readings are unstable (200 ms)
 #define ADE7953_MAX_LINECYC 1000UL // Above this too much time passes (20 seconds)
 #define INVALID_SPI_READ_WRITE 0xDEADDEAD // Custom, used to indicate an invalid SPI read/write operation

--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -26,6 +26,9 @@
 #include "utils.h"
 #include "hardware_profile.h"
 
+#include "channel_types.h"   // ChannelRole (shared, Arduino-free - see lib/meter_logic)
+#include "meter_logic.h"     // pure CT-polarity / clamp / WDRR decisions (host-testable)
+
 // SPI
 #define ADE7953_SPI_FREQUENCY 2000000 // The maximum SPI frequency for the ADE7953 is 2MHz
 #define ADE7953_SPI_MUTEX_TIMEOUT_MS 100
@@ -79,7 +82,8 @@
 #define VARIABILITY_EMA_ALPHA 0.3f   // Exponential moving average smoothing for variability (0-1, lower = smoother)
 #define CHANNEL_MAX_GAP_MS 15000ULL  // Watchdog: max time between successful reads before forcing a pick
 #define MAX_CHANNEL_DEFICIT_BOUND 5.0f // Symmetric clamp on per-channel deficit (safety net against arithmetic edge cases)
-#define WEIGHT_ARMED_BOOST 1.5f      // Extra weight for a channel actively running CT-reversal detection, so it is sampled rapidly and resolves in ~1-2 s
+#define WEIGHT_ARMED_BOOST 1.5f      // Extra weight for a channel running CT-reversal detection WHILE CONDUCTING, so it is sampled rapidly and resolves in ~1-2 s
+#define WEIGHT_ROLE_PRIORITY_MULT 2.0f // Weight multiplier for grid / battery roles - mains and storage flow are sampled more often (matters most on 3-phase)
 
 // Default values for ADE7953 registers
 #define UNLOCK_OPTIMUM_REGISTER_VALUE 0xAD // Register to write to unlock the optimum register
@@ -230,6 +234,7 @@
 #define MINIMUM_CURRENT_FOR_VALIDATION 0.02f // Below this current threshold, skip invalidating the reading as measurements are unreliable (noise dominates)
 #define MINIMUM_POWER_FACTOR 0.10f // Measuring such low power factors is virtually impossible with such CTs
 #define POLARITY_DETECT_VOTE_THRESHOLD 5 // Net consistent-sign votes (over conducting samples) needed to decide CT orientation. Magnitude-independent, so a steady -4 W reversed CT is caught like a -4 kW one
+#define POLARITY_DETECT_MAX_CONDUCTING_READS 40 // Give up CT-reversal detection after this many CONDUCTING reads without a decision (only trips on a sign-oscillating channel; a no-load channel waits indefinitely)
 #define ADE7953_MIN_LINECYC 10UL // Below this the readings are unstable (200 ms)
 #define ADE7953_MAX_LINECYC 1000UL // Above this too much time passes (20 seconds)
 #define INVALID_SPI_READ_WRITE 0xDEADDEAD // Custom, used to indicate an invalid SPI read/write operation
@@ -419,18 +424,9 @@ struct CtSpecification
       whLsb(1.0f), varhLsb(1.0f), vahLsb(1.0f) {}
 };
 
-// Channel role enum
-enum ChannelRole : uint8_t {
-    CHANNEL_ROLE_LOAD     = 0, // Default - regular load/consumption (negatives discarded)
-    CHANNEL_ROLE_GRID     = 1, // Grid meter (+ import, - export)
-    CHANNEL_ROLE_PV       = 2, // PV/Solar production (+ generation, negatives discarded)
-    CHANNEL_ROLE_BATTERY  = 3, // Battery (+ discharge, - charge)
-    CHANNEL_ROLE_INVERTER = 4, // Hybrid inverter: PV + battery DC-coupled, AC output (negatives allowed)
-    CHANNEL_ROLE_COUNT    = 5  // Total number of roles
-};
-
-#define DEFAULT_CHANNEL_ROLE CHANNEL_ROLE_LOAD
-#define DEFAULT_CHANNEL_0_ROLE CHANNEL_ROLE_GRID // Channel 0 is typically the grid meter
+// ChannelRole and its DEFAULT_CHANNEL_*_ROLE defaults live in channel_types.h
+// (included above) so the host-testable meter_logic library can use them without
+// pulling in Arduino.
 
 struct ChannelData
 {

--- a/source/lib/meter_logic/channel_types.h
+++ b/source/lib/meter_logic/channel_types.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#pragma once
+
+#include <cstdint>
+
+// Shared channel-configuration types, deliberately free of any Arduino / FreeRTOS
+// dependency so that the pure measurement and scheduling logic in meter_logic can
+// be compiled and unit-tested on the host (see lib/meter_logic + test/).
+//
+// ChannelRole lives here (not in ade7953.h) so the host build never has to pull in
+// Arduino.h just to know what "GRID" or "LOAD" means.
+
+// Plain enum (not enum class) so it serializes directly to/from JSON as an integer.
+enum ChannelRole : uint8_t {
+    CHANNEL_ROLE_LOAD     = 0, // Default - regular load/consumption (negatives clamped to 0)
+    CHANNEL_ROLE_GRID     = 1, // Grid meter (+ import, - export)
+    CHANNEL_ROLE_PV       = 2, // PV/Solar production (+ generation, negatives clamped to 0)
+    CHANNEL_ROLE_BATTERY  = 3, // Battery (+ discharge, - charge)
+    CHANNEL_ROLE_INVERTER = 4, // Hybrid inverter: PV + battery DC-coupled, AC output (negatives allowed)
+    CHANNEL_ROLE_COUNT    = 5  // Total number of roles
+};
+
+#define DEFAULT_CHANNEL_ROLE CHANNEL_ROLE_LOAD
+#define DEFAULT_CHANNEL_0_ROLE CHANNEL_ROLE_GRID // Channel 0 is typically the grid meter

--- a/source/lib/meter_logic/meter_logic.cpp
+++ b/source/lib/meter_logic/meter_logic.cpp
@@ -87,12 +87,13 @@ float computeChannelWeight(const ChannelWeightInput& in, float powerShare,
     // the boost stays a fixed, role-independent priority.
     if (roleHasSchedulingPriority(in.role)) weight *= cfg.rolePriorityMult;
 
-    // Polarity-detection boost, gated on conduction. An armed channel only earns
-    // the boost while it is actually drawing power - so a CT clipped on an idle
-    // circuit waits at normal cadence (no starvation) yet is sampled rapidly the
-    // moment load appears, resolving the orientation in ~1 s.
-    bool conducting = (in.activePower != 0.0f && !std::isnan(in.activePower));
-    if (in.armed && conducting) weight += cfg.armedBoost;
+    // Polarity-detection boost, gated on conduction (in.conducting, the caller's
+    // pre-clamp "drawing power right now" signal). An armed channel only earns the
+    // boost while actually conducting - so a CT clipped on an idle circuit waits at
+    // normal cadence (no starvation) yet is sampled rapidly the moment load appears,
+    // resolving in ~1 s. Using the pre-clamp signal (not activePower, which is 0 for
+    // a clamped reversed load/PV) means reversed loads get the boost too.
+    if (in.armed && in.conducting) weight += cfg.armedBoost;
 
     return weight;
 }

--- a/source/lib/meter_logic/meter_logic.cpp
+++ b/source/lib/meter_logic/meter_logic.cpp
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#include "meter_logic.h"
+
+#include <cmath>
+
+namespace MeterLogic {
+
+// ----------------------------------------------------------------------------
+// CT polarity detector
+// ----------------------------------------------------------------------------
+PolarityResult updatePolarity(PolarityState state, float activePower, PolarityConfig cfg) {
+    PolarityResult result{state, PolarityAction::Continue};
+
+    // Not armed: nothing to do. Defensive - callers should only invoke while armed.
+    if (!state.armed) return result;
+
+    // A non-positive threshold is a misconfiguration; treat it as a safe no-op
+    // rather than letting the sign comparisons below decide on the very first read.
+    if (cfg.voteThreshold <= 0) return result;
+
+    // Only conducting samples carry sign information. A non-conducting reading
+    // (no load, or a reading the validation pipeline zeroed) is a pure no-op: the
+    // channel stays armed and waits, without ever counting toward the bound. This
+    // is what lets a CT clipped on a circuit that is off at install time still be
+    // checked once load eventually flows.
+    bool conducting = (activePower != 0.0f && !std::isnan(activePower));
+    if (!conducting) return result;
+
+    result.state.conductingReads++;
+    result.state.voteCount += (activePower < 0.0f) ? -1 : 1;
+
+    if (result.state.voteCount <= -cfg.voteThreshold) {
+        result.action = PolarityAction::Flip;
+        result.state.armed = false;
+        result.state.voteCount = 0;
+        result.state.conductingReads = 0;
+        return result;
+    }
+    if (result.state.voteCount >= cfg.voteThreshold) {
+        result.action = PolarityAction::Disarm;
+        result.state.armed = false;
+        result.state.voteCount = 0;
+        result.state.conductingReads = 0;
+        return result;
+    }
+
+    // Bound only the pathological case: a channel that keeps conducting but whose
+    // sign oscillates without ever reaching the threshold. Give up with no flip -
+    // an ambiguous signal cannot be oriented automatically.
+    if (cfg.maxConductingReads > 0 && result.state.conductingReads >= cfg.maxConductingReads) {
+        result.action = PolarityAction::Disarm;
+        result.state.armed = false;
+        result.state.voteCount = 0;
+        result.state.conductingReads = 0;
+    }
+
+    return result;
+}
+
+// ----------------------------------------------------------------------------
+// Negative-reading handling
+// ----------------------------------------------------------------------------
+bool shouldClampNegative(float activePower, ChannelRole role) {
+    return activePower < 0.0f &&
+           (role == CHANNEL_ROLE_LOAD || role == CHANNEL_ROLE_PV);
+}
+
+// ----------------------------------------------------------------------------
+// WDRR weighting
+// ----------------------------------------------------------------------------
+bool roleHasSchedulingPriority(ChannelRole role) {
+    return role == CHANNEL_ROLE_GRID || role == CHANNEL_ROLE_BATTERY;
+}
+
+float computeChannelWeight(const ChannelWeightInput& in, float powerShare,
+                           float variabilityShare, const WeightConfig& cfg) {
+    if (!in.active) return 0.0f;
+
+    float weight = cfg.powerShare * powerShare +
+                   cfg.variability * variabilityShare +
+                   cfg.minBase;
+
+    // Grid / battery are sampled more often (mains + storage flow matter most,
+    // especially on 3-phase). Applied to the base share before the armed boost so
+    // the boost stays a fixed, role-independent priority.
+    if (roleHasSchedulingPriority(in.role)) weight *= cfg.rolePriorityMult;
+
+    // Polarity-detection boost, gated on conduction. An armed channel only earns
+    // the boost while it is actually drawing power - so a CT clipped on an idle
+    // circuit waits at normal cadence (no starvation) yet is sampled rapidly the
+    // moment load appears, resolving the orientation in ~1 s.
+    bool conducting = (in.activePower != 0.0f && !std::isnan(in.activePower));
+    if (in.armed && conducting) weight += cfg.armedBoost;
+
+    return weight;
+}
+
+void computeWeights(const ChannelWeightInput* in, uint8_t count, uint8_t startIndex,
+                    const WeightConfig& cfg, float* outWeights) {
+    // Indices outside the scheduled range are not part of the rotation.
+    for (uint8_t i = 0; i < startIndex && i < count; i++) outWeights[i] = 0.0f;
+
+    // First pass: totals across active channels. NaN guard keeps a single bad
+    // reading from poisoning every share (and thus every weight).
+    float totalAbsPower = 0.0f;
+    float totalVariability = 0.0f;
+    for (uint8_t i = startIndex; i < count; i++) {
+        if (!in[i].active) continue;
+        if (!std::isnan(in[i].activePower)) totalAbsPower += std::fabs(in[i].activePower);
+        if (!std::isnan(in[i].variability)) totalVariability += in[i].variability;
+    }
+
+    // Second pass: per-channel weights.
+    for (uint8_t i = startIndex; i < count; i++) {
+        if (!in[i].active) {
+            outWeights[i] = 0.0f;
+            continue;
+        }
+
+        float powerShare = 0.0f;
+        if (totalAbsPower > 0.0f && !std::isnan(in[i].activePower)) {
+            powerShare = std::fabs(in[i].activePower) / totalAbsPower;
+        }
+
+        float variabilityShare = 0.0f;
+        if (totalVariability > 0.0f && !std::isnan(in[i].variability)) {
+            variabilityShare = in[i].variability / totalVariability;
+        }
+
+        outWeights[i] = computeChannelWeight(in[i], powerShare, variabilityShare, cfg);
+    }
+}
+
+// ----------------------------------------------------------------------------
+// WDRR scheduler core
+// ----------------------------------------------------------------------------
+uint8_t findStarvedChannel(const uint64_t* lastMillis, const bool* active,
+                           uint8_t count, uint8_t startIndex, uint64_t now,
+                           uint64_t maxGap) {
+    for (uint8_t i = startIndex; i < count; i++) {
+        if (!active[i]) continue;
+        if (lastMillis[i] == 0) continue; // never baselined - priority slot handles it
+        if (now - lastMillis[i] > maxGap) return i;
+    }
+    return NO_CHANNEL;
+}
+
+void wdrrAccumulate(const float* weights, float* deficits, const bool* active,
+                    uint8_t count, uint8_t startIndex, float deficitBound) {
+    for (uint8_t i = startIndex; i < count; i++) {
+        if (active[i]) deficits[i] += weights[i];
+        else deficits[i] = 0.0f;
+
+        if (std::isnan(deficits[i])) deficits[i] = 0.0f;
+        if (deficits[i] > deficitBound) deficits[i] = deficitBound;
+        else if (deficits[i] < -deficitBound) deficits[i] = -deficitBound;
+    }
+}
+
+uint8_t wdrrPick(float* deficits, const bool* active, uint8_t count,
+                 uint8_t startIndex, uint8_t* cursor) {
+    if (count <= startIndex) return NO_CHANNEL;
+    const uint8_t range = count - startIndex;
+
+    uint8_t bestChannel = NO_CHANNEL;
+    float bestDeficit = 0.0f; // only meaningful once bestChannel is set
+
+    // Iterate all schedulable channels starting one past the cursor, so that when
+    // deficits are tied (e.g. a fleet of idle channels) service rotates instead of
+    // the lowest index winning every time. The first active channel seeds the max
+    // (no sentinel, so the result is independent of the deficit scale); strict '>'
+    // thereafter makes the first-seen max win, preserving the rotation on ties.
+    for (uint8_t offset = 0; offset < range; offset++) {
+        uint8_t i = startIndex + ((*cursor - startIndex + 1 + offset) % range);
+        if (!active[i]) continue;
+        if (bestChannel == NO_CHANNEL || deficits[i] > bestDeficit) {
+            bestDeficit = deficits[i];
+            bestChannel = i;
+        }
+    }
+
+    if (bestChannel != NO_CHANNEL) {
+        deficits[bestChannel] -= 1.0f;
+        *cursor = bestChannel;
+    }
+
+    return bestChannel;
+}
+
+} // namespace MeterLogic

--- a/source/lib/meter_logic/meter_logic.cpp
+++ b/source/lib/meter_logic/meter_logic.cpp
@@ -8,9 +8,17 @@
 namespace MeterLogic {
 
 // ----------------------------------------------------------------------------
+// Reading classification
+// ----------------------------------------------------------------------------
+bool isConductingReading(float activePower, float current, float minCurrent) {
+    return !std::isnan(activePower) && activePower != 0.0f &&
+           !std::isnan(current) && current >= minCurrent;
+}
+
+// ----------------------------------------------------------------------------
 // CT polarity detector
 // ----------------------------------------------------------------------------
-PolarityResult updatePolarity(PolarityState state, float activePower, PolarityConfig cfg) {
+PolarityResult updatePolarity(PolarityState state, float activePower, float current, PolarityConfig cfg) {
     PolarityResult result{state, PolarityAction::Continue};
 
     // Not armed: nothing to do. Defensive - callers should only invoke while armed.
@@ -21,12 +29,13 @@ PolarityResult updatePolarity(PolarityState state, float activePower, PolarityCo
     if (cfg.voteThreshold <= 0) return result;
 
     // Only conducting samples carry sign information. A non-conducting reading
-    // (no load, or a reading the validation pipeline zeroed) is a pure no-op: the
-    // channel stays armed and waits, without ever counting toward the bound. This
-    // is what lets a CT clipped on a circuit that is off at install time still be
-    // checked once load eventually flows.
-    bool conducting = (activePower != 0.0f && !std::isnan(activePower));
-    if (!conducting) return result;
+    // (no load, a reading the validation pipeline zeroed, or a small offset power at
+    // near-zero current) is a pure no-op: the channel stays armed and waits, without
+    // ever counting toward the bound. The current gate (cfg.minCurrent) is what stops
+    // ADE7953 offset noise on an unclamped role from voting a false reversal, and it
+    // is also what lets a CT clipped on a circuit that is off at install time still be
+    // checked once real load eventually flows.
+    if (!isConductingReading(activePower, current, cfg.minCurrent)) return result;
 
     result.state.conductingReads++;
     result.state.voteCount += (activePower < 0.0f) ? -1 : 1;

--- a/source/lib/meter_logic/meter_logic.h
+++ b/source/lib/meter_logic/meter_logic.h
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#pragma once
+
+#include <cstdint>
+#include "channel_types.h"
+
+// Pure measurement and scheduling decisions for the ADE7953 channel pipeline.
+//
+// Everything here is free-standing: no Arduino, no FreeRTOS, no SPI, no logging,
+// no global state. Inputs come in as plain values, decisions go out as plain
+// values, and the caller (src/ade7953.cpp) is responsible for all I/O, mutexes
+// and for acting on the decisions. That boundary is what lets this logic be
+// unit-tested on the host (see test/test_meter_logic) without any hardware.
+namespace MeterLogic {
+
+// ============================================================================
+// CT polarity (reversed-CT) detector
+// ============================================================================
+// A net consistent-sign vote accumulator. Each CONDUCTING reading votes +1
+// (power flows in the expected direction) or -1 (reversed). The orientation is
+// decided once the running net reaches +/- voteThreshold, which makes the
+// detector magnitude-independent (a steady -4 W reversed CT is caught like a
+// -4 kW one) and immune to transient sign flips (they cancel out).
+//
+// A non-conducting reading (no load) carries no sign information: it does NOT
+// vote and does NOT count toward any bound, so an armed channel with no load
+// simply waits - indefinitely if need be. This is deliberate: a CT clipped on a
+// circuit that happens to be off at install time must still be checked the moment
+// real load first flows. (Starvation is prevented separately, by gating the
+// scheduler boost on conduction - see computeChannelWeight - not by disarming.)
+//
+// maxConductingReads only bounds the pathological case of a channel that DOES
+// conduct but whose sign keeps oscillating (never reaching the threshold): after
+// that many conducting reads it gives up with no flip.
+
+enum class PolarityAction : uint8_t {
+    Continue, // still accumulating - caller does nothing
+    Flip,     // threshold of reversed votes reached - caller flips the reverse flag
+    Disarm,   // confirmed correct, or gave up on an ambiguous signal - caller stops, no flip
+};
+
+struct PolarityState {
+    bool armed;               // detection in progress for this channel
+    int8_t voteCount;         // running net vote (+ expected, - reversed)
+    uint16_t conductingReads; // conducting reads seen since arming (for the bound)
+};
+
+struct PolarityConfig {
+    int8_t voteThreshold;       // net votes needed to decide (e.g. 5)
+    uint16_t maxConductingReads; // give up after this many conducting reads w/o a decision (0 = no bound)
+};
+
+struct PolarityResult {
+    PolarityState state; // updated state to store back
+    PolarityAction action;
+};
+
+// One detector step for a single channel reading. Safe to call on every read of
+// an armed channel: a non-conducting reading is a no-op. activePower is the
+// post-validation reading; 0 or NaN means non-conducting (no vote, no count).
+//
+// PRECONDITION: feed the RAW signed reading. Do NOT pre-clamp negatives to zero
+// before calling - a reversed LOAD/PV reads negative, and clamping it to 0 first
+// would make every reading look non-conducting, so the reversal would never be
+// detected. (The firmware runs this detector before shouldClampNegative.)
+PolarityResult updatePolarity(PolarityState state, float activePower, PolarityConfig cfg);
+
+// ============================================================================
+// Negative-reading handling
+// ============================================================================
+
+// True if a negative active-power reading on this role is physically impossible
+// and must be clamped to zero. Load and PV can only consume / generate one way;
+// grid, battery and hybrid inverters legitimately go negative (export / charge).
+bool shouldClampNegative(float activePower, ChannelRole role);
+
+// ============================================================================
+// WDRR weighting
+// ============================================================================
+// Weighted Deficit Round-Robin sampling weights. Higher weight -> sampled more
+// often. Weight = power-share + variability-share + a minimum base (so every
+// active channel is eventually serviced), with two priority bumps on top:
+//   - grid / battery roles get a multiplier (we want the mains and storage flow
+//     sampled more often, especially on 3-phase systems);
+//   - a channel actively running polarity detection AND currently conducting gets
+//     a flat boost so it resolves quickly. The boost is gated on conduction: an
+//     armed channel with no load gets no boost, so it cannot hog the scheduler
+//     while it waits for load (this is what prevents the no-load starvation).
+
+struct WeightConfig {
+    float powerShare;       // contribution from |power| share
+    float variability;      // contribution from variability share
+    float minBase;          // floor for every active channel (anti-starvation)
+    float armedBoost;       // flat add-on while polarity detection is armed AND conducting
+    float rolePriorityMult; // multiplier for grid / battery roles (e.g. 2.0)
+};
+
+struct ChannelWeightInput {
+    bool active;
+    float activePower; // signed; only magnitude is used
+    float variability; // EMA of |delta power|
+    bool armed;        // polarity detection in progress
+    ChannelRole role;
+};
+
+// True if this role is sampled more often (grid + battery).
+bool roleHasSchedulingPriority(ChannelRole role);
+
+// Weight for a single channel given its precomputed shares (each 0..1).
+float computeChannelWeight(const ChannelWeightInput& in, float powerShare,
+                           float variabilityShare, const WeightConfig& cfg);
+
+// Compute weights for channels [startIndex, count). Indices below startIndex are
+// set to 0 (the firmware reads channel 0 separately, outside the rotation).
+// NaN power / variability values are excluded from the totals and treated as 0,
+// so one bad reading cannot poison every other channel's weight.
+void computeWeights(const ChannelWeightInput* in, uint8_t count, uint8_t startIndex,
+                    const WeightConfig& cfg, float* outWeights);
+
+// ============================================================================
+// WDRR scheduler core
+// ============================================================================
+
+// Sentinel for "no channel". Deliberately NOT named INVALID_CHANNEL: the firmware
+// defines that as an object-like macro (#define INVALID_CHANNEL 255), which would
+// textually rewrite any `MeterLogic::INVALID_CHANNEL` into `MeterLogic::255`. The
+// firmware asserts NO_CHANNEL == its own INVALID_CHANNEL so the values stay in sync.
+constexpr uint8_t NO_CHANNEL = 255;
+
+// Lowest-index active channel whose gap (now - lastMillis) exceeds maxGap, over
+// [startIndex, count). Channels with lastMillis == 0 (never baselined) are
+// skipped. Returns NO_CHANNEL if none are starved. Pure lookup - the caller
+// updates lastMillis after forcing the read.
+uint8_t findStarvedChannel(const uint64_t* lastMillis, const bool* active,
+                           uint8_t count, uint8_t startIndex, uint64_t now,
+                           uint64_t maxGap);
+
+// Gain phase: add each active channel's weight to its deficit; zero inactive
+// channels; guard NaN; clamp symmetrically to +/- deficitBound. Operates on
+// [startIndex, count).
+void wdrrAccumulate(const float* weights, float* deficits, const bool* active,
+                    uint8_t count, uint8_t startIndex, float deficitBound);
+
+// Pick phase: select the highest-deficit active channel over [startIndex, count)
+// with a round-robin tie-break starting one past *cursor (so equal-deficit
+// channels rotate instead of letting the lowest index monopolise). Decrements
+// the winner's deficit by 1 and moves *cursor to it. Returns the winner, or
+// NO_CHANNEL if no active channel exists.
+uint8_t wdrrPick(float* deficits, const bool* active, uint8_t count,
+                 uint8_t startIndex, uint8_t* cursor);
+
+} // namespace MeterLogic

--- a/source/lib/meter_logic/meter_logic.h
+++ b/source/lib/meter_logic/meter_logic.h
@@ -84,10 +84,12 @@ bool shouldClampNegative(float activePower, ChannelRole role);
 // active channel is eventually serviced), with two priority bumps on top:
 //   - grid / battery roles get a multiplier (we want the mains and storage flow
 //     sampled more often, especially on 3-phase systems);
-//   - a channel actively running polarity detection AND currently conducting gets
-//     a flat boost so it resolves quickly. The boost is gated on conduction: an
-//     armed channel with no load gets no boost, so it cannot hog the scheduler
-//     while it waits for load (this is what prevents the no-load starvation).
+//   - a channel actively running polarity detection AND currently conducting (the
+//     `conducting` input) gets a flat boost so it resolves quickly. Gating on
+//     conduction means an armed channel with no load gets no boost and cannot hog
+//     the scheduler while it waits for load (this prevents the no-load starvation),
+//     while a reversed load/PV - whose stored power is clamped to 0 but which is
+//     genuinely conducting - still earns the boost and resolves in ~1 s.
 
 struct WeightConfig {
     float powerShare;       // contribution from |power| share
@@ -99,10 +101,15 @@ struct WeightConfig {
 
 struct ChannelWeightInput {
     bool active;
-    float activePower; // signed; only magnitude is used
-    float variability; // EMA of |delta power|
-    bool armed;        // polarity detection in progress
+    float activePower;       // signed; only the magnitude is used (for the power share)
+    float variability;       // EMA of |delta power|
+    bool armed;              // polarity detection in progress
     ChannelRole role;
+    bool conducting = false; // is the channel drawing power *right now*? Drives the
+                             // armed boost. Deliberately separate from activePower!=0:
+                             // a reversed load/PV is stored clamped to 0 yet is really
+                             // conducting, so the caller passes the pre-clamp signal -
+                             // otherwise reversed loads would never earn the boost.
 };
 
 // True if this role is sampled more often (grid + battery).

--- a/source/lib/meter_logic/meter_logic.h
+++ b/source/lib/meter_logic/meter_logic.h
@@ -50,6 +50,7 @@ struct PolarityState {
 struct PolarityConfig {
     int8_t voteThreshold;       // net votes needed to decide (e.g. 5)
     uint16_t maxConductingReads; // give up after this many conducting reads w/o a decision (0 = no bound)
+    float minCurrent;            // a reading below this current is offset noise: no vote, no count
 };
 
 struct PolarityResult {
@@ -57,15 +58,33 @@ struct PolarityResult {
     PolarityAction action;
 };
 
-// One detector step for a single channel reading. Safe to call on every read of
-// an armed channel: a non-conducting reading is a no-op. activePower is the
-// post-validation reading; 0 or NaN means non-conducting (no vote, no count).
+// True if a reading carries usable directional information: a real, non-zero
+// power backed by enough current (current >= minCurrent) that the ADE7953's
+// offset noise - which shows up as a small, consistent-sign power at essentially
+// zero current - cannot masquerade as a genuine (possibly reversed) load. This is
+// the one definition of "conducting" used across the pipeline: updatePolarity gates
+// the vote on it, and the firmware gates the scheduler's armed boost (_lastConducting,
+// feeding computeChannelWeight) on the same call, so the two can never disagree about
+// whether a channel is drawing power. NaN power or NaN current -> false.
 //
-// PRECONDITION: feed the RAW signed reading. Do NOT pre-clamp negatives to zero
-// before calling - a reversed LOAD/PV reads negative, and clamping it to 0 first
-// would make every reading look non-conducting, so the reversal would never be
-// detected. (The firmware runs this detector before shouldClampNegative.)
-PolarityResult updatePolarity(PolarityState state, float activePower, PolarityConfig cfg);
+// A reversed load/PV reads NEGATIVE power but with REAL current, so it stays
+// conducting - that is what lets a reversed CT both vote (to flip) and earn the boost.
+bool isConductingReading(float activePower, float current, float minCurrent);
+
+// One detector step for a single channel reading. Safe to call on every read of
+// an armed channel: a non-conducting reading is a no-op. The reading votes only if
+// isConductingReading(activePower, current, cfg.minCurrent) - so 0/NaN power, or a
+// small offset power at near-zero current, never votes and never counts toward the
+// bound. activePower's sign gives the vote direction.
+//
+// PRECONDITION: feed the RAW signed reading (both power and current). Do NOT
+// pre-clamp negative power to zero before calling - a reversed LOAD/PV reads
+// negative with real current, and clamping power to 0 first would make the reading
+// look non-conducting, so the reversal would never be detected. (The firmware runs
+// this detector before shouldClampNegative.) current is the post-validation current
+// (an invalid low-current reading is already zeroed upstream, which correctly reads
+// as non-conducting here).
+PolarityResult updatePolarity(PolarityState state, float activePower, float current, PolarityConfig cfg);
 
 // ============================================================================
 // Negative-reading handling

--- a/source/platformio.ini
+++ b/source/platformio.ini
@@ -1,4 +1,13 @@
 ; ============================================================================
+; Project Configuration
+; ============================================================================
+; default_envs limits `pio run` to the firmware targets. The `native` env builds
+; host unit tests only (pio test -e native) and must never be a default build.
+; ============================================================================
+[platformio]
+default_envs = esp32s3-dev, esp32s3-prod
+
+; ============================================================================
 ; Common Configuration (shared by all environments)
 ; ============================================================================
 ; In general, it is required to always pin all the libraries and packages to the exact
@@ -267,3 +276,16 @@ lib_deps = ${common.lib_deps}
 
 ; Embedded Files
 board_build.embed_txtfiles = ${common.board_build.embed_txtfiles}
+
+; ============================================================================
+; Native host environment - unit tests only:  pio test -e native
+; Compiles the pure libraries (e.g. lib/meter_logic) + test/ with the host
+; compiler (no Arduino, no board). Never built by `pio run` (see default_envs).
+; ============================================================================
+[env:native]
+platform = native
+test_framework = unity
+build_flags =
+    -std=c++17
+    -Wall
+    -Wextra

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -32,7 +32,14 @@ namespace Ade7953
     static float _powerVariability[MAX_CHANNEL_COUNT] = {};  // EMA of |delta power| for variability scoring
     static uint8_t _wdrrCursor = 0;                          // Round-robin tie-break cursor for argmax
     static int8_t _polarityVoteCount[MAX_CHANNEL_COUNT] = {}; // Net consistent-sign vote accumulator for CT-reversal detection (runtime only; reset on arm/decision)
+    static uint16_t _polarityConductingReads[MAX_CHANNEL_COUNT] = {}; // Conducting reads since arming - bounds a sign-oscillating channel (runtime only; reset on arm/decision)
     static float _gridFrequency = 50.0f;
+
+    // The library returns MeterLogic::NO_CHANNEL for "no channel"; the firmware
+    // compares scheduler results against its own INVALID_CHANNEL macro. They must
+    // hold the same value. (The library cannot reuse the name INVALID_CHANNEL: it
+    // is an object-like macro here and would rewrite MeterLogic::INVALID_CHANNEL.)
+    static_assert(INVALID_CHANNEL == MeterLogic::NO_CHANNEL, "INVALID_CHANNEL / MeterLogic::NO_CHANNEL value mismatch");
 
     // Set by the meter task when the CT-reversal detector flips the persisted reverse flag.
     // Drained by the energy save task (internal-RAM stack, flash-capable) since the meter
@@ -802,6 +809,7 @@ namespace Ade7953
                 // instead of up to 15 s away on a heavily loaded scheduler.
                 _channelData[channelIndex]._pendingPolarityCheck = false;
                 _polarityVoteCount[channelIndex] = 0;
+                _polarityConductingReads[channelIndex] = 0;
                 if (channelIndex > 0) _channelData[channelIndex]._pendingPriorityRead = true;
             } else if (activated || roleChangedActive) {
                 // Fresh activation / role change with no explicit polarity choice: arm
@@ -809,6 +817,7 @@ namespace Ade7953
                 // legitimately differ between roles, so a role change re-validates.
                 _channelData[channelIndex]._pendingPolarityCheck = true;
                 _polarityVoteCount[channelIndex] = 0;
+                _polarityConductingReads[channelIndex] = 0;
                 if (channelIndex > 0) _channelData[channelIndex]._pendingPriorityRead = true;
             }
         }
@@ -3803,37 +3812,45 @@ namespace Ade7953
 
         }
 
-        // CT-reversal detection (replaces the old one-shot auto-polarity flip).
-        // While a channel is armed (set on activation / role change without a manual
-        // reverse - see setChannelData), accumulate a NET sign vote over conducting
-        // samples. Only readings that survived the no-load / low-pf / validation
-        // filters above (activePower != 0) vote, so idle circuits and noise never
-        // flip the flag. Magnitude is irrelevant - only sign consistency matters - so
-        // a steady -4 W reversed CT is caught just like a -4 kW one, and a single
-        // transient of the wrong sign is just one vote that net-counting absorbs.
-        //
-        // A decisive run of negatives past the threshold flips the persisted reverse
-        // flag once (and we negate this reading so it is stored with the corrected
-        // sign); a decisive run of positives simply confirms the CT is correct. Either
-        // way the channel disarms. Hold _channelDataMutex for the test-and-update so a
-        // concurrent setChannelData arm/disarm is neither lost nor double-fired.
-        if (activePower != 0.0f) {
+        // CT-reversal detection. While a channel is armed (set on activation / role
+        // change without a manual reverse - see setChannelData) AND conducting, feed
+        // each reading to the net sign-vote detector (MeterLogic::updatePolarity).
+        // Only conducting samples carry sign information, so a no-load armed channel
+        // simply waits: it is never disarmed and (the boost being conduction-gated in
+        // _recalculateWeights) never starves its peers, so a CT clipped on a circuit
+        // that is off at install time is still checked the moment load first flows.
+        // Magnitude is irrelevant - only sign consistency matters - so a steady -4 W
+        // reversed CT is caught like a -4 kW one. A decisive run of reversed votes
+        // flips the persisted reverse flag once (and we negate this reading so it is
+        // stored with the corrected sign); a decisive run of forward votes confirms
+        // the CT. Hold _channelDataMutex for the test-and-update so a concurrent
+        // setChannelData arm/disarm is neither lost nor double-fired. (The unsynced
+        // _pendingPolarityCheck pre-check is an atomic-bool fast path; it is re-tested
+        // under the mutex before any state change.)
+        if (_channelData[channelIndex]._pendingPolarityCheck && activePower != 0.0f) {
             bool flipped = false;
             bool newReverse = false;
             if (acquireMutex(&_channelDataMutex)) {
                 if (_channelData[channelIndex]._pendingPolarityCheck) {
-                    _polarityVoteCount[channelIndex] += (activePower < 0.0f) ? -1 : 1;
-                    if (_polarityVoteCount[channelIndex] <= -POLARITY_DETECT_VOTE_THRESHOLD) {
+                    MeterLogic::PolarityState state{
+                        true, // armed (guarded above and re-checked here)
+                        _polarityVoteCount[channelIndex],
+                        _polarityConductingReads[channelIndex]
+                    };
+                    MeterLogic::PolarityConfig cfg{
+                        POLARITY_DETECT_VOTE_THRESHOLD,
+                        POLARITY_DETECT_MAX_CONDUCTING_READS
+                    };
+                    MeterLogic::PolarityResult res = MeterLogic::updatePolarity(state, activePower, cfg);
+                    _polarityVoteCount[channelIndex] = res.state.voteCount;
+                    _polarityConductingReads[channelIndex] = res.state.conductingReads;
+                    _channelData[channelIndex]._pendingPolarityCheck = res.state.armed;
+                    if (res.action == MeterLogic::PolarityAction::Flip) {
                         _channelData[channelIndex].reverse = !_channelData[channelIndex].reverse;
                         _pendingPolaritySave[channelIndex] = true;
-                        _channelData[channelIndex]._pendingPolarityCheck = false;
-                        _polarityVoteCount[channelIndex] = 0;
                         if (channelIndex > 0) _channelData[channelIndex]._pendingPriorityRead = true;
                         flipped = true;
                         newReverse = _channelData[channelIndex].reverse;
-                    } else if (_polarityVoteCount[channelIndex] >= POLARITY_DETECT_VOTE_THRESHOLD) {
-                        _channelData[channelIndex]._pendingPolarityCheck = false;
-                        _polarityVoteCount[channelIndex] = 0;
                     }
                 }
                 releaseMutex(&_channelDataMutex);
@@ -3860,7 +3877,7 @@ namespace Ade7953
         // is PV inverter standby or sub-detection noise. Clamp (do NOT discard) so the
         // data cadence is preserved - a genuinely reversed CT is corrected by the
         // reversal detector above, not by dropping readings (which created silent gaps).
-        if (activePower < 0.0f && (channelData.role == CHANNEL_ROLE_LOAD || channelData.role == CHANNEL_ROLE_PV)) {
+        if (MeterLogic::shouldClampNegative(activePower, channelData.role)) {
             LOG_DEBUG(
                 "%s (%d): clamping negative reading (%.1fW) to 0 (role=%s)",
                 channelData.label,
@@ -4459,53 +4476,30 @@ namespace Ade7953
      * - Minimum base: every active channel gets a minimum weight to prevent starvation
      */
     static void _recalculateWeights() {
-        float totalAbsPower = 0.0f;
-        float totalVariability = 0.0f;
+        const uint8_t count = globalHwProfile->totalChannelCount;
 
-        // Sum totals across active multiplexed channels (skip channel 0).
-        // NaN guards: a NaN reading must not poison the totals - it would
-        // make every powerScore NaN, propagating into _channelWeight[] and
-        // breaking argmax in _findNextActiveChannel.
-        for (uint8_t i = 1; i < globalHwProfile->totalChannelCount; i++) {
-            if (_channelData[i].active) {
-                float ap = _meterValues[i].activePower;
-                float pv = _powerVariability[i];
-                if (!isnan(ap)) totalAbsPower += fabsf(ap);
-                if (!isnan(pv)) totalVariability += pv;
-            }
+        // Gather the per-channel inputs for the pure WDRR weight computation
+        // (MeterLogic::computeWeights handles the power/variability shares, the
+        // grid/battery multiplier, the conduction-gated polarity boost, and the
+        // NaN guards). Reads of _meterValues / _powerVariability here are unlocked,
+        // matching the original meter-task access pattern.
+        MeterLogic::ChannelWeightInput inputs[MAX_CHANNEL_COUNT] = {};
+        for (uint8_t i = 0; i < count; i++) {
+            inputs[i].active = _channelData[i].active;
+            inputs[i].activePower = _meterValues[i].activePower;
+            inputs[i].variability = _powerVariability[i];
+            inputs[i].armed = _channelData[i]._pendingPolarityCheck;
+            inputs[i].role = _channelData[i].role;
         }
 
-        // Compute per-channel weights
-        for (uint8_t i = 1; i < globalHwProfile->totalChannelCount; i++) {
-            if (!_channelData[i].active) {
-                _channelWeight[i] = 0.0f;
-                continue;
-            }
+        const MeterLogic::WeightConfig cfg{
+            WEIGHT_POWER_SHARE, WEIGHT_VARIABILITY, WEIGHT_MIN_BASE,
+            WEIGHT_ARMED_BOOST, WEIGHT_ROLE_PRIORITY_MULT
+        };
 
-            float powerScore = 0.0f;
-            if (totalAbsPower > 0.0f) {
-                float ap = _meterValues[i].activePower;
-                if (!isnan(ap)) powerScore = fabsf(ap) / totalAbsPower;
-            }
-
-            float variabilityScore = 0.0f;
-            if (totalVariability > 0.0f) {
-                float pv = _powerVariability[i];
-                if (!isnan(pv)) variabilityScore = pv / totalVariability;
-            }
-
-            _channelWeight[i] = WEIGHT_POWER_SHARE * powerScore
-                              + WEIGHT_VARIABILITY * variabilityScore
-                              + WEIGHT_MIN_BASE;
-
-            // Boost channels currently running CT-reversal detection so they are
-            // sampled rapidly and resolve in ~1-2 s. The boost clears automatically
-            // once the detector disarms, since weights are recomputed every read.
-            if (_channelData[i]._pendingPolarityCheck) _channelWeight[i] += WEIGHT_ARMED_BOOST;
-        }
-
-        // Channel 0 is not scheduled (always read separately)
-        _channelWeight[0] = 0.0f;
+        // startIndex = 1: channel 0 is read separately, outside the rotation
+        // (computeWeights zeroes its weight for us).
+        MeterLogic::computeWeights(inputs, count, 1, cfg, _channelWeight);
     }
 
     /**
@@ -4521,43 +4515,38 @@ namespace Ade7953
     uint8_t _findNextActiveChannel(uint8_t currentChannel) {
         (void)currentChannel; // No longer needed for state tracking
 
+        const uint8_t count = globalHwProfile->totalChannelCount;
+
+        // Snapshot the active flags once (atomic bool reads, unlocked - matches the
+        // original access pattern) and reuse them for every WDRR step below.
+        bool active[MAX_CHANNEL_COUNT] = {};
+        for (uint8_t i = 0; i < count; i++) active[i] = _channelData[i].active;
+
         // Starvation watchdog (fix for issue #149): hard upper bound on the time
-        // between successful reads for any active mux channel. If a channel goes
-        // CHANNEL_MAX_GAP_MS without lastMillis advancing - whether because the
-        // WDRR weights are skewed, the channel is in a discard loop, or the meter
-        // task missed cycles during OTA - force-pick it now.
-        //
-        // After firing, we set lastMillis = now and reset the deficit. The
-        // lastMillis reset throttles the watchdog to one fire per
-        // CHANNEL_MAX_GAP_MS even when the read continues to fail (e.g., a
-        // permanently misclamped CT): user gets one warning per interval, not a
-        // torrent. The deficit reset prevents the channel from immediately
-        // re-winning the argmax on the next call.
-        //
-        // Hold _meterValuesMutex around the read and the write: a 32-bit ESP32
-        // cannot atomically store a uint64_t, so a concurrent setChannelData
-        // baseline write from the web task could be torn-read here.
+        // between successful reads for any active mux channel. MeterLogic::
+        // findStarvedChannel returns the lowest-index channel past CHANNEL_MAX_GAP_MS
+        // (skipping never-baselined ones); we then stamp lastMillis = now - which
+        // throttles the watchdog to one fire per interval even if the read keeps
+        // failing - and reset its deficit so it does not immediately re-win the
+        // argmax. Hold _meterValuesMutex around the 64-bit read + write: a 32-bit
+        // ESP32 cannot atomically store a uint64_t, so a concurrent setChannelData
+        // baseline write could otherwise be torn-read here.
         uint64_t nowMillis = millis64();
         uint8_t starvedChannel = INVALID_CHANNEL;
         uint64_t starvedGap = 0;
         if (acquireMutex(&_meterValuesMutex)) {
-            for (uint8_t i = 1; i < globalHwProfile->totalChannelCount; i++) {
-                if (!_channelData[i].active) continue;
-                uint64_t lastMs = _meterValues[i].lastMillis;
-                if (lastMs == 0) continue; // never baselined - priority slot handles it
-                uint64_t gap = nowMillis - lastMs;
-                if (gap > CHANNEL_MAX_GAP_MS) {
-                    starvedChannel = i;
-                    starvedGap = gap;
-                    _meterValues[i].lastMillis = nowMillis;
-                    break;
-                }
+            uint64_t lastMs[MAX_CHANNEL_COUNT] = {};
+            for (uint8_t i = 0; i < count; i++) lastMs[i] = _meterValues[i].lastMillis;
+            starvedChannel = MeterLogic::findStarvedChannel(lastMs, active, count, 1, nowMillis, CHANNEL_MAX_GAP_MS);
+            if (starvedChannel != INVALID_CHANNEL) {
+                starvedGap = nowMillis - lastMs[starvedChannel];
+                _meterValues[starvedChannel].lastMillis = nowMillis;
             }
             releaseMutex(&_meterValuesMutex);
         }
         if (starvedChannel != INVALID_CHANNEL) {
-            // This might happen in cases of high-value loads in some channels
-            // with static 0W channels, so it is not an error per se (thus DEBUG level)
+            // Can happen with high-power channels alongside static 0 W ones, so it is
+            // not an error per se (hence DEBUG level).
             LOG_DEBUG(
                 "%s (%u): scheduler starvation, %llu ms since last read; force-picking",
                 _channelData[starvedChannel].label, starvedChannel, starvedGap
@@ -4566,34 +4555,20 @@ namespace Ade7953
             return starvedChannel;
         }
 
-        // Add each channel's weight to its deficit. Done BEFORE the priority-claim
-        // loop so that a channel taking the priority slot still has its deficit
-        // updated in this round (fix for issue #149 - previously the priority
-        // branch returned early and skipped the gain phase entirely, leaving the
-        // claiming channel one round behind in the WDRR accounting).
-        // NaN guard + symmetric clamp keeps the deficit array in a sane range even
-        // in pathological cases (NaN injection from a broken read, weight-table
-        // shock from a sudden role change, OTA-induced timing jumps).
-        for (uint8_t i = 1; i < globalHwProfile->totalChannelCount; i++) {
-            if (_channelData[i].active) {
-                _channelDeficit[i] += _channelWeight[i];
-            } else {
-                _channelDeficit[i] = 0.0f;
-            }
-            if (isnan(_channelDeficit[i])) _channelDeficit[i] = 0.0f;
-            if (_channelDeficit[i] > MAX_CHANNEL_DEFICIT_BOUND) _channelDeficit[i] = MAX_CHANNEL_DEFICIT_BOUND;
-            else if (_channelDeficit[i] < -MAX_CHANNEL_DEFICIT_BOUND) _channelDeficit[i] = -MAX_CHANNEL_DEFICIT_BOUND;
-        }
+        // Gain phase: add each active channel's weight to its deficit (NaN-guarded
+        // and symmetrically clamped). Done BEFORE the priority-claim loop so a
+        // channel taking the priority slot still has its deficit advanced this round
+        // (fix for issue #149 - the priority branch used to return early and skip the
+        // gain phase, leaving the claiming channel one round behind).
+        MeterLogic::wdrrAccumulate(_channelWeight, _channelDeficit, active, count, 1, MAX_CHANNEL_DEFICIT_BOUND);
 
         // One-shot priority override: a freshly activated channel jumps the WDRR queue
-        // for exactly one read so the user gets immediate data (and so the auto-polarity
-        // check runs without waiting for the channel to win a normal slot). Take
-        // _channelDataMutex for the test-and-clear so a concurrent re-arm from
-        // setChannelData / the polarity check cannot be lost between read and write.
-        // Priority pick is a freebie: no deficit decrement, since the channel has
-        // not "consumed" a normal scheduling slot.
-        for (uint8_t i = 1; i < globalHwProfile->totalChannelCount; i++) {
-            if (!_channelData[i].active) continue;
+        // for exactly one read so the user gets immediate data (and so the polarity
+        // check runs without waiting for a normal slot). Take _channelDataMutex for
+        // the test-and-clear so a concurrent re-arm cannot be lost. Priority pick is a
+        // freebie: no deficit decrement, since the channel has not consumed a slot.
+        for (uint8_t i = 1; i < count; i++) {
+            if (!_channelData[i].active) continue; // live read (a channel may have just activated)
             bool claim = false;
             if (acquireMutex(&_channelDataMutex)) {
                 if (_channelData[i]._pendingPriorityRead) {
@@ -4605,32 +4580,11 @@ namespace Ade7953
             if (claim) return i;
         }
 
-        // Select the channel with the highest deficit, with a round-robin
-        // tie-break (iteration starts at _wdrrCursor + 1 wrapping back to 1).
-        // Without the rotation, when every active channel sits at the same
-        // deficit (e.g., a multi-channel discard storm or post-watchdog reset),
-        // the lowest-index active channel monopolises the scheduler. The cursor
-        // moves to the winning channel so the next call starts iteration one
-        // past it.
-        uint8_t bestChannel = INVALID_CHANNEL;
-        float bestDeficit = -1e9f; // Use a very large negative value to ensure any active channel is selectable
-
-        uint8_t n = globalHwProfile->totalChannelCount;
-        for (uint8_t offset = 1; offset < n; offset++) {
-            uint8_t i = ((_wdrrCursor + offset - 1) % (n - 1)) + 1;
-            if (_channelData[i].active && _channelDeficit[i] > bestDeficit) {
-                bestDeficit = _channelDeficit[i];
-                bestChannel = i;
-            }
-        }
-
-        // Decrement the selected channel's deficit and advance the cursor.
-        if (bestChannel != INVALID_CHANNEL) {
-            _channelDeficit[bestChannel] -= 1.0f;
-            _wdrrCursor = bestChannel;
-        }
-
-        return bestChannel;
+        // Pick the highest-deficit active channel, with a round-robin tie-break so
+        // that equal deficits (e.g. a fleet of idle channels) rotate instead of the
+        // lowest index monopolising the scheduler. Decrements the winner and advances
+        // _wdrrCursor.
+        return MeterLogic::wdrrPick(_channelDeficit, active, count, 1, &_wdrrCursor);
     }
 
     // Poor man's phase shift (doing with modulus didn't work properly,

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -3828,7 +3828,14 @@ namespace Ade7953
         // setChannelData arm/disarm is neither lost nor double-fired. (The unsynced
         // _pendingPolarityCheck pre-check is an atomic-bool fast path; it is re-tested
         // under the mutex before any state change.)
-        if (_channelData[channelIndex]._pendingPolarityCheck && activePower != 0.0f) {
+        // Current-gate "conducting" so ADE7953 offset noise at ~0 A (a small, steady,
+        // signed power) cannot vote a false reversal on an unclamped role (grid/battery)
+        // or earn the armed boost. The same signal drives _lastConducting below, so the
+        // vote and the boost always agree on whether the channel is drawing power.
+        bool conducting = MeterLogic::isConductingReading(
+            activePower, current, MINIMUM_CURRENT_FOR_VALIDATION);
+
+        if (_channelData[channelIndex]._pendingPolarityCheck && conducting) {
             bool flipped = false;
             bool newReverse = false;
             if (acquireMutex(&_channelDataMutex)) {
@@ -3840,9 +3847,10 @@ namespace Ade7953
                     };
                     MeterLogic::PolarityConfig cfg{
                         POLARITY_DETECT_VOTE_THRESHOLD,
-                        POLARITY_DETECT_MAX_CONDUCTING_READS
+                        POLARITY_DETECT_MAX_CONDUCTING_READS,
+                        MINIMUM_CURRENT_FOR_VALIDATION
                     };
-                    MeterLogic::PolarityResult res = MeterLogic::updatePolarity(state, activePower, cfg);
+                    MeterLogic::PolarityResult res = MeterLogic::updatePolarity(state, activePower, current, cfg);
                     _polarityVoteCount[channelIndex] = res.state.voteCount;
                     _polarityConductingReads[channelIndex] = res.state.conductingReads;
                     _channelData[channelIndex]._pendingPolarityCheck = res.state.armed;
@@ -3873,11 +3881,12 @@ namespace Ade7953
             }
         }
 
-        // Record whether this reading is conducting BEFORE the clamp below zeroes a
-        // reversed load/PV. The WDRR boost for an armed channel keys off this (not the
-        // stored power), so a reversed load/PV - stored as 0 but really drawing power -
-        // still gets sampled rapidly and resolves its orientation in ~1 s.
-        _lastConducting[channelIndex] = (activePower != 0.0f);
+        // Record whether this reading is conducting (computed above, current-gated)
+        // BEFORE the clamp below zeroes a reversed load/PV. The WDRR boost for an armed
+        // channel keys off this (not the stored power), so a reversed load/PV - stored
+        // as 0 but really drawing power - still gets sampled rapidly and resolves its
+        // orientation in ~1 s, while a near-zero-current offset reading earns no boost.
+        _lastConducting[channelIndex] = conducting;
 
         // Clamp negative active power to zero for load and PV channels. With the phase
         // configured correctly a load/PV should not be net-negative; a residual negative

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -31,9 +31,10 @@ namespace Ade7953
     static float _prevActivePower[MAX_CHANNEL_COUNT] = {};   // Previous power reading for variability tracking
     static float _powerVariability[MAX_CHANNEL_COUNT] = {};  // EMA of |delta power| for variability scoring
     static uint8_t _wdrrCursor = 0;                          // Round-robin tie-break cursor for argmax
+    static int8_t _polarityVoteCount[MAX_CHANNEL_COUNT] = {}; // Net consistent-sign vote accumulator for CT-reversal detection (runtime only; reset on arm/decision)
     static float _gridFrequency = 50.0f;
 
-    // Set by the meter task when an auto-polarity flip flips the persisted reverse flag.
+    // Set by the meter task when the CT-reversal detector flips the persisted reverse flag.
     // Drained by the energy save task (internal-RAM stack, flash-capable) since the meter
     // task runs on a PSRAM stack and cannot perform NVS writes.
     static volatile bool _pendingPolaritySave[MAX_CHANNEL_COUNT] = {};
@@ -790,21 +791,25 @@ namespace Ade7953
         // re-runs the auto-polarity detection and can oscillate the persisted reverse
         // flag on channels that genuinely read negative at idle.
         if (armTransients) {
-            if (wasInactive && _channelData[channelIndex].active) {
-                _channelData[channelIndex]._pendingPolarityCheck = true;
+            bool reverseChanged = (oldReverse != _channelData[channelIndex].reverse);
+            bool activated = (wasInactive && _channelData[channelIndex].active);
+            bool roleChangedActive = (!wasInactive && _channelData[channelIndex].active && oldRole != _channelData[channelIndex].role);
+
+            if (reverseChanged) {
+                // A manual reverse change is the trusted value: disarm CT-reversal
+                // detection so it can never override the user's explicit choice, and
+                // (issue #149) read once now so the corrected sign lands immediately
+                // instead of up to 15 s away on a heavily loaded scheduler.
+                _channelData[channelIndex]._pendingPolarityCheck = false;
+                _polarityVoteCount[channelIndex] = 0;
                 if (channelIndex > 0) _channelData[channelIndex]._pendingPriorityRead = true;
-            }
-            // Re-arm polarity check on role change while channel is active (sign convention
-            // can legitimately differ between roles; let the next reading re-validate).
-            if (!wasInactive && _channelData[channelIndex].active && oldRole != _channelData[channelIndex].role) {
+            } else if (activated || roleChangedActive) {
+                // Fresh activation / role change with no explicit polarity choice: arm
+                // auto-detection from a clean vote count. The sign convention can
+                // legitimately differ between roles, so a role change re-validates.
                 _channelData[channelIndex]._pendingPolarityCheck = true;
-            }
-            // Fix for issue #149: arm priority read when the user flips the reverse
-            // flag via API. Intent is "read me now with the corrected sign" - without
-            // this, the corrected reading lands on the next normal rotation slot,
-            // which can be up to 15 s away on a heavily loaded scheduler.
-            if (channelIndex > 0 && oldReverse != _channelData[channelIndex].reverse) {
-                _channelData[channelIndex]._pendingPriorityRead = true;
+                _polarityVoteCount[channelIndex] = 0;
+                if (channelIndex > 0) _channelData[channelIndex]._pendingPriorityRead = true;
             }
         }
 
@@ -3798,61 +3803,70 @@ namespace Ade7953
 
         }
 
-        // Auto-detect a reversed CT clamp on the first meaningful reading after activation
-        // (or after a role change). If the active power is negative, toggle the persisted
-        // reverse flag, queue the NVS write for the energy save task, re-arm the priority
-        // slot so the corrected reading lands on the very next linecyc, and discard this
-        // reading. The threshold avoids flipping on noise when the circuit is essentially idle.
+        // CT-reversal detection (replaces the old one-shot auto-polarity flip).
+        // While a channel is armed (set on activation / role change without a manual
+        // reverse - see setChannelData), accumulate a NET sign vote over conducting
+        // samples. Only readings that survived the no-load / low-pf / validation
+        // filters above (activePower != 0) vote, so idle circuits and noise never
+        // flip the flag. Magnitude is irrelevant - only sign consistency matters - so
+        // a steady -4 W reversed CT is caught just like a -4 kW one, and a single
+        // transient of the wrong sign is just one vote that net-counting absorbs.
         //
-        // Hold _channelDataMutex for the test-and-clear so a concurrent setChannelData arm
-        // is neither lost nor double-fired. The block only fires once per channel after
-        // activation / role change so the contention is negligible.
-        if (abs(activePower) >= AUTO_POLARITY_MIN_POWER_W) {
+        // A decisive run of negatives past the threshold flips the persisted reverse
+        // flag once (and we negate this reading so it is stored with the corrected
+        // sign); a decisive run of positives simply confirms the CT is correct. Either
+        // way the channel disarms. Hold _channelDataMutex for the test-and-update so a
+        // concurrent setChannelData arm/disarm is neither lost nor double-fired.
+        if (activePower != 0.0f) {
             bool flipped = false;
             bool newReverse = false;
             if (acquireMutex(&_channelDataMutex)) {
                 if (_channelData[channelIndex]._pendingPolarityCheck) {
-                    _channelData[channelIndex]._pendingPolarityCheck = false;
-                    if (activePower < 0.0f) {
+                    _polarityVoteCount[channelIndex] += (activePower < 0.0f) ? -1 : 1;
+                    if (_polarityVoteCount[channelIndex] <= -POLARITY_DETECT_VOTE_THRESHOLD) {
                         _channelData[channelIndex].reverse = !_channelData[channelIndex].reverse;
                         _pendingPolaritySave[channelIndex] = true;
+                        _channelData[channelIndex]._pendingPolarityCheck = false;
+                        _polarityVoteCount[channelIndex] = 0;
                         if (channelIndex > 0) _channelData[channelIndex]._pendingPriorityRead = true;
                         flipped = true;
                         newReverse = _channelData[channelIndex].reverse;
+                    } else if (_polarityVoteCount[channelIndex] >= POLARITY_DETECT_VOTE_THRESHOLD) {
+                        _channelData[channelIndex]._pendingPolarityCheck = false;
+                        _polarityVoteCount[channelIndex] = 0;
                     }
                 }
                 releaseMutex(&_channelDataMutex);
             }
             if (flipped) {
+                // This reading was computed with the pre-flip sign; negate the signed
+                // quantities so it stores consistently with the new reverse flag
+                // (apparent power and current stay positive).
+                activePower = -activePower;
+                reactivePower = -reactivePower;
+                activeEnergy = -activeEnergy;
+                reactiveEnergy = -reactiveEnergy;
+                powerFactor = -powerFactor;
                 LOG_INFO(
-                    "%s (%u): auto-detected reversed CT (raw P=%.1fW, role=%s); reverse flag now %d, discarding this reading",
+                    "%s (%u): CT reversal detected (P now %.1fW, role=%s); reverse flag now %d",
                     channelData.label, channelIndex, activePower,
                     channelRoleToString(channelData.role), newReverse
                 );
-                _recordFailure();
-                return false;
             }
         }
 
-        // Discard negative readings for Load channels (likely CT installed backwards)
-        if (activePower < 0.0f && channelData.role == CHANNEL_ROLE_LOAD) {
+        // Clamp negative active power to zero for load and PV channels. With the phase
+        // configured correctly a load/PV should not be net-negative; a residual negative
+        // is PV inverter standby or sub-detection noise. Clamp (do NOT discard) so the
+        // data cadence is preserved - a genuinely reversed CT is corrected by the
+        // reversal detector above, not by dropping readings (which created silent gaps).
+        if (activePower < 0.0f && (channelData.role == CHANNEL_ROLE_LOAD || channelData.role == CHANNEL_ROLE_PV)) {
             LOG_DEBUG(
-                "%s (%d): Discarding negative reading (%.1fW) (Load channel, likely CT installed backwards)",
+                "%s (%d): clamping negative reading (%.1fW) to 0 (role=%s)",
                 channelData.label,
                 channelIndex,
-                activePower
-            );
-            _recordFailure();
-            return false;
-        }
-
-        // Clamp negative readings to zero for PV channels (expected inverter standby consumption, so no record failure)
-        if (activePower < 0.0f && channelData.role == CHANNEL_ROLE_PV) {
-            LOG_DEBUG(
-                "%s (%d): Clamping negative reading (%.1fW) to 0 (PV channel, likely inverter standby consumption)",
-                channelData.label,
-                channelIndex,
-                activePower
+                activePower,
+                channelRoleToString(channelData.role)
             );
             activePower = 0.0f;
             reactivePower = 0.0f;
@@ -4483,6 +4497,11 @@ namespace Ade7953
             _channelWeight[i] = WEIGHT_POWER_SHARE * powerScore
                               + WEIGHT_VARIABILITY * variabilityScore
                               + WEIGHT_MIN_BASE;
+
+            // Boost channels currently running CT-reversal detection so they are
+            // sampled rapidly and resolve in ~1-2 s. The boost clears automatically
+            // once the detector disarms, since weights are recomputed every read.
+            if (_channelData[i]._pendingPolarityCheck) _channelWeight[i] += WEIGHT_ARMED_BOOST;
         }
 
         // Channel 0 is not scheduled (always read separately)

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -33,6 +33,7 @@ namespace Ade7953
     static uint8_t _wdrrCursor = 0;                          // Round-robin tie-break cursor for argmax
     static int8_t _polarityVoteCount[MAX_CHANNEL_COUNT] = {}; // Net consistent-sign vote accumulator for CT-reversal detection (runtime only; reset on arm/decision)
     static uint16_t _polarityConductingReads[MAX_CHANNEL_COUNT] = {}; // Conducting reads since arming - bounds a sign-oscillating channel (runtime only; reset on arm/decision)
+    static bool _lastConducting[MAX_CHANNEL_COUNT] = {}; // Was the channel's most recent reading conducting (pre-clamp)? Drives the CT-detection boost so a clamped reversed load/PV still gets it (meter-task only)
     static float _gridFrequency = 50.0f;
 
     // The library returns MeterLogic::NO_CHANNEL for "no channel"; the firmware
@@ -3872,6 +3873,12 @@ namespace Ade7953
             }
         }
 
+        // Record whether this reading is conducting BEFORE the clamp below zeroes a
+        // reversed load/PV. The WDRR boost for an armed channel keys off this (not the
+        // stored power), so a reversed load/PV - stored as 0 but really drawing power -
+        // still gets sampled rapidly and resolves its orientation in ~1 s.
+        _lastConducting[channelIndex] = (activePower != 0.0f);
+
         // Clamp negative active power to zero for load and PV channels. With the phase
         // configured correctly a load/PV should not be net-negative; a residual negative
         // is PV inverter standby or sub-detection noise. Clamp (do NOT discard) so the
@@ -4490,6 +4497,7 @@ namespace Ade7953
             inputs[i].variability = _powerVariability[i];
             inputs[i].armed = _channelData[i]._pendingPolarityCheck;
             inputs[i].role = _channelData[i].role;
+            inputs[i].conducting = _lastConducting[i];
         }
 
         const MeterLogic::WeightConfig cfg{

--- a/source/test/test_meter_logic/test_meter_logic.cpp
+++ b/source/test/test_meter_logic/test_meter_logic.cpp
@@ -202,17 +202,30 @@ void test_weight_grid_gets_multiplier(void) {
 }
 
 void test_weight_armed_boost_only_when_conducting(void) {
-    // Armed but idle (no load): NO boost - this is what stops a no-load armed
-    // channel from hogging the scheduler.
-    ChannelWeightInput idleArmed{true, 0.0f, 0.0f, true, CHANNEL_ROLE_LOAD};
+    // Armed but NOT conducting (no current): NO boost - this is what stops a no-load
+    // armed channel from hogging the scheduler.
+    ChannelWeightInput idleArmed{true, 0.0f, 0.0f, true, CHANNEL_ROLE_LOAD, false};
     TEST_ASSERT_EQUAL_FLOAT(WCFG.minBase, computeChannelWeight(idleArmed, 0.0f, 0.0f, WCFG));
 
     // Armed AND conducting: boost added on top of the normal weight.
-    ChannelWeightInput condArmed{true, 500.0f, 0.0f, true, CHANNEL_ROLE_LOAD};
-    ChannelWeightInput condUnarmed{true, 500.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    ChannelWeightInput condArmed{true, 500.0f, 0.0f, true, CHANNEL_ROLE_LOAD, true};
+    ChannelWeightInput condUnarmed{true, 500.0f, 0.0f, false, CHANNEL_ROLE_LOAD, true};
     float wArmed = computeChannelWeight(condArmed, 1.0f, 0.0f, WCFG);
     float wUnarmed = computeChannelWeight(condUnarmed, 1.0f, 0.0f, WCFG);
     TEST_ASSERT_EQUAL_FLOAT(wUnarmed + WCFG.armedBoost, wArmed);
+}
+
+void test_weight_clamped_reversed_load_still_boosted(void) {
+    // The load/PV priority fix: a reversed LOAD is stored clamped to 0, but it IS
+    // conducting - so it must still earn the armed boost (driven by `conducting`,
+    // not the clamped stored power). Without this, reversed loads resolved slowly.
+    ChannelWeightInput in{true, 0.0f /*clamped*/, 0.0f, true, CHANNEL_ROLE_LOAD, true /*conducting*/};
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, WCFG.minBase + WCFG.armedBoost,
+                             computeChannelWeight(in, 0.0f, 0.0f, WCFG));
+    // And a clamped reversed PV likewise.
+    ChannelWeightInput pv{true, 0.0f, 0.0f, true, CHANNEL_ROLE_PV, true};
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, WCFG.minBase + WCFG.armedBoost,
+                             computeChannelWeight(pv, 0.0f, 0.0f, WCFG));
 }
 
 void test_weight_shares_contribute(void) {
@@ -356,7 +369,10 @@ void test_armed_no_load_channel_does_not_starve_peers(void) {
     const int ROUNDS = 600;
 
     for (int r = 0; r < ROUNDS; r++) {
-        for (uint8_t i = START; i < N; i++) in[i].armed = pol[i].armed;
+        for (uint8_t i = START; i < N; i++) {
+            in[i].armed = pol[i].armed;
+            in[i].conducting = (in[i].activePower != 0.0f); // pre-clamp conduction signal
+        }
         computeWeights(in, N, START, WCFG, weights);
         wdrrAccumulate(weights, deficits, active, N, START, 5.0f);
         uint8_t pick = wdrrPick(deficits, active, N, START, &cursor);
@@ -406,7 +422,10 @@ void test_armed_conducting_channel_resolves_quickly(void) {
     uint8_t cursor = 0;
     int flipRound = -1;
     for (int r = 0; r < 200; r++) {
-        for (uint8_t i = START; i < N; i++) in[i].armed = pol[i].armed;
+        for (uint8_t i = START; i < N; i++) {
+            in[i].armed = pol[i].armed;
+            in[i].conducting = (in[i].activePower != 0.0f); // pre-clamp conduction signal
+        }
         computeWeights(in, N, START, WCFG, weights);
         wdrrAccumulate(weights, deficits, active, N, START, 5.0f);
         uint8_t pick = wdrrPick(deficits, active, N, START, &cursor);
@@ -554,11 +573,11 @@ void test_polarity_disarmed_mid_sequence_is_noop(void) {
 void test_weight_grid_armed_conducting_all_bumps_stack(void) {
     // grid (x2) + armed + conducting + full power share: pins the arithmetic order
     // (role multiply on the base, THEN add the flat armed boost).
-    ChannelWeightInput in{true, -500.0f, 0.0f, true, CHANNEL_ROLE_GRID};
+    ChannelWeightInput in{true, -500.0f, 0.0f, true, CHANNEL_ROLE_GRID, true};
     // base = 0.4*1 + 0.4*0 + 0.1 = 0.5; *2.0 = 1.0; + 1.5 = 2.5
     TEST_ASSERT_FLOAT_WITHIN(1e-5, 2.5f, computeChannelWeight(in, 1.0f, 0.0f, WCFG));
-    // same but idle (no conduction) -> no boost: 0.5*2.0 = 1.0
-    ChannelWeightInput idle{true, 0.0f, 0.0f, true, CHANNEL_ROLE_GRID};
+    // same but not conducting -> no boost: 0.5*2.0 = 1.0
+    ChannelWeightInput idle{true, 0.0f, 0.0f, true, CHANNEL_ROLE_GRID, false};
     TEST_ASSERT_FLOAT_WITHIN(1e-5, 1.0f, computeChannelWeight(idle, 1.0f, 0.0f, WCFG));
 }
 
@@ -717,7 +736,10 @@ void test_multiple_armed_channels_both_resolve(void) {
     uint8_t cursor = 0;
     bool flipped1 = false, flipped2 = false;
     for (int r = 0; r < 200; r++) {
-        for (uint8_t i = START; i < N; i++) in[i].armed = pol[i].armed;
+        for (uint8_t i = START; i < N; i++) {
+            in[i].armed = pol[i].armed;
+            in[i].conducting = (in[i].activePower != 0.0f); // pre-clamp conduction signal
+        }
         computeWeights(in, N, START, WCFG, weights);
         wdrrAccumulate(weights, deficits, active, N, START, 5.0f);
         uint8_t pick = wdrrPick(deficits, active, N, START, &cursor);
@@ -847,6 +869,7 @@ int main(int, char **) {
     RUN_TEST(test_polarity_disarmed_mid_sequence_is_noop);
 
     RUN_TEST(test_weight_grid_armed_conducting_all_bumps_stack);
+    RUN_TEST(test_weight_clamped_reversed_load_still_boosted);
     RUN_TEST(test_computeWeights_battery_gets_multiplier);
     RUN_TEST(test_computeWeights_tiny_channel_gets_min_base);
     RUN_TEST(test_computeWeights_all_inactive_all_zeros);

--- a/source/test/test_meter_logic/test_meter_logic.cpp
+++ b/source/test/test_meter_logic/test_meter_logic.cpp
@@ -20,7 +20,9 @@ void tearDown(void) {}
 
 // Config values mirror the firmware defaults so the tests track real behaviour.
 static const WeightConfig WCFG = {0.4f, 0.4f, 0.1f, 1.5f, 2.0f};
-static const PolarityConfig PCFG = {5, 50};
+static const float MIN_A = 0.02f;              // MINIMUM_CURRENT_FOR_VALIDATION
+static const PolarityConfig PCFG = {5, 50, MIN_A};
+static const float COND_A = 1.0f;              // a nominal "real load" current (>= MIN_A)
 
 // ============================================================================
 // updatePolarity
@@ -28,7 +30,7 @@ static const PolarityConfig PCFG = {5, 50};
 
 void test_polarity_not_armed_is_noop(void) {
     PolarityState s{false, 0, 0};
-    PolarityResult r = updatePolarity(s, -100.0f, PCFG);
+    PolarityResult r = updatePolarity(s, -100.0f, COND_A, PCFG);
     TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
     TEST_ASSERT_FALSE(r.state.armed);
     TEST_ASSERT_EQUAL_INT8(0, r.state.voteCount);
@@ -40,7 +42,7 @@ void test_polarity_steady_reverse_flips_at_threshold(void) {
     PolarityAction action = PolarityAction::Continue;
     int reads = 0;
     for (int i = 0; i < 10; i++) {
-        PolarityResult r = updatePolarity(s, -230.0f, PCFG);
+        PolarityResult r = updatePolarity(s, -230.0f, COND_A, PCFG);
         s = r.state;
         action = r.action;
         reads++;
@@ -55,7 +57,7 @@ void test_polarity_steady_forward_confirms_without_flip(void) {
     PolarityState s{true, 0, 0};
     PolarityAction action = PolarityAction::Continue;
     for (int i = 0; i < 10; i++) {
-        PolarityResult r = updatePolarity(s, 1500.0f, PCFG);
+        PolarityResult r = updatePolarity(s, 1500.0f, COND_A, PCFG);
         s = r.state;
         action = r.action;
         if (action != PolarityAction::Continue) break;
@@ -69,7 +71,7 @@ void test_polarity_is_magnitude_independent(void) {
     PolarityState s{true, 0, 0};
     PolarityAction action = PolarityAction::Continue;
     for (int i = 0; i < 10; i++) {
-        PolarityResult r = updatePolarity(s, -0.3f, PCFG);
+        PolarityResult r = updatePolarity(s, -0.3f, COND_A, PCFG);
         s = r.state;
         action = r.action;
         if (action != PolarityAction::Continue) break;
@@ -82,7 +84,7 @@ void test_polarity_idle_is_noop_and_stays_armed(void) {
     // bound, and must leave the channel armed (waiting for load).
     PolarityState s{true, 0, 0};
     for (int i = 0; i < 500; i++) {
-        PolarityResult r = updatePolarity(s, 0.0f, PCFG);
+        PolarityResult r = updatePolarity(s, 0.0f, 0.0f, PCFG);
         s = r.state;
         TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
     }
@@ -93,7 +95,7 @@ void test_polarity_idle_is_noop_and_stays_armed(void) {
 
 void test_polarity_nan_is_noop(void) {
     PolarityState s{true, 0, 0};
-    PolarityResult r = updatePolarity(s, NAN, PCFG);
+    PolarityResult r = updatePolarity(s, NAN, COND_A, PCFG);
     TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
     TEST_ASSERT_TRUE(r.state.armed);
     TEST_ASSERT_EQUAL_INT8(0, r.state.voteCount);
@@ -106,13 +108,13 @@ void test_polarity_delayed_load_still_detects(void) {
     // load finally appears - and it must still be detected and flipped.
     PolarityState s{true, 0, 0};
     for (int i = 0; i < 200; i++) {
-        s = updatePolarity(s, 0.0f, PCFG).state; // idle: no load yet
+        s = updatePolarity(s, 0.0f, 0.0f, PCFG).state; // idle: no load yet
     }
     TEST_ASSERT_TRUE(s.armed); // still armed after a long wait
 
     PolarityAction action = PolarityAction::Continue;
     for (int i = 0; i < 10; i++) {
-        PolarityResult r = updatePolarity(s, -230.0f, PCFG); // load finally flows, reversed
+        PolarityResult r = updatePolarity(s, -230.0f, COND_A, PCFG); // load finally flows, reversed
         s = r.state;
         action = r.action;
         if (action != PolarityAction::Continue) break;
@@ -128,7 +130,7 @@ void test_polarity_oscillating_conducting_disarms_via_bound(void) {
     PolarityAction action = PolarityAction::Continue;
     for (int i = 0; i < 200; i++) {
         float p = (i % 2 == 0) ? -50.0f : 50.0f;
-        PolarityResult r = updatePolarity(s, p, PCFG);
+        PolarityResult r = updatePolarity(s, p, COND_A, PCFG);
         s = r.state;
         action = r.action;
         if (!s.armed) break;
@@ -141,12 +143,49 @@ void test_polarity_unbounded_oscillation_never_disarms(void) {
     // Documents why the bound exists: with maxConductingReads == 0 an oscillating
     // conducting channel never decides and never disarms.
     PolarityState s{true, 0, 0};
-    PolarityConfig unbounded{5, 0};
+    PolarityConfig unbounded{5, 0, MIN_A};
     for (int i = 0; i < 1000; i++) {
         float p = (i % 2 == 0) ? -50.0f : 50.0f;
-        s = updatePolarity(s, p, unbounded).state;
+        s = updatePolarity(s, p, COND_A, unbounded).state;
     }
     TEST_ASSERT_TRUE(s.armed);
+}
+
+// ============================================================================
+// isConductingReading  (the current gate that stops offset-noise false flips)
+// ============================================================================
+
+void test_conducting_true_for_real_load(void) {
+    TEST_ASSERT_TRUE(isConductingReading(100.0f, 5.0f, MIN_A)); // forward load
+    TEST_ASSERT_TRUE(isConductingReading(1.0f, MIN_A, MIN_A));  // exactly at the threshold
+}
+
+void test_conducting_true_for_reversed_load_with_current(void) {
+    // CRITICAL for the load/PV priority work: a reversed load reads NEGATIVE power
+    // but with REAL current, so it must still count as conducting - that is what lets
+    // a reversed CT both vote (to flip) and earn the armed boost (to resolve fast).
+    TEST_ASSERT_TRUE(isConductingReading(-100.0f, 5.0f, MIN_A));
+    TEST_ASSERT_TRUE(isConductingReading(-0.3f, 5.0f, MIN_A)); // tiny reversed power, real current
+}
+
+void test_conducting_false_for_offset_noise(void) {
+    // THE BUG: ADE7953 offset noise is a small, steady, signed power at ~0 current.
+    // On an unclamped role it must NOT conduct, or it votes a false reversal and hogs.
+    TEST_ASSERT_FALSE(isConductingReading(1.2f, 0.004f, MIN_A));  // the observed bench value
+    TEST_ASSERT_FALSE(isConductingReading(-3.5f, 0.0f, MIN_A));
+    TEST_ASSERT_FALSE(isConductingReading(1.0f, 0.0199f, MIN_A)); // just below the threshold
+}
+
+void test_conducting_false_for_zero_power_or_nan(void) {
+    TEST_ASSERT_FALSE(isConductingReading(0.0f, 5.0f, MIN_A));  // no power, current irrelevant
+    TEST_ASSERT_FALSE(isConductingReading(NAN, 5.0f, MIN_A));   // bad power read
+    TEST_ASSERT_FALSE(isConductingReading(100.0f, NAN, MIN_A)); // bad current read
+}
+
+void test_conducting_zero_threshold_degrades_to_power_only(void) {
+    // minCurrent == 0 disables the gate: any non-zero power conducts (old behaviour).
+    TEST_ASSERT_TRUE(isConductingReading(1.0f, 0.0f, 0.0f));
+    TEST_ASSERT_FALSE(isConductingReading(0.0f, 0.0f, 0.0f));
 }
 
 // ============================================================================
@@ -378,7 +417,7 @@ void test_armed_no_load_channel_does_not_starve_peers(void) {
         uint8_t pick = wdrrPick(deficits, active, N, START, &cursor);
         TEST_ASSERT_NOT_EQUAL(NO_CHANNEL, pick);
 
-        PolarityResult pr = updatePolarity(pol[pick], in[pick].activePower, PCFG);
+        PolarityResult pr = updatePolarity(pol[pick], in[pick].activePower, COND_A, PCFG);
         pol[pick] = pr.state;
 
         for (uint8_t i = START; i < N; i++) {
@@ -430,7 +469,7 @@ void test_armed_conducting_channel_resolves_quickly(void) {
         wdrrAccumulate(weights, deficits, active, N, START, 5.0f);
         uint8_t pick = wdrrPick(deficits, active, N, START, &cursor);
 
-        PolarityResult pr = updatePolarity(pol[pick], in[pick].activePower, PCFG);
+        PolarityResult pr = updatePolarity(pol[pick], in[pick].activePower, COND_A, PCFG);
         if (pr.action == PolarityAction::Flip && flipRound < 0) flipRound = r;
         pol[pick] = pr.state;
     }
@@ -475,8 +514,8 @@ void test_grid_sampled_more_often_than_load(void) {
 void test_polarity_nonpositive_threshold_is_noop(void) {
     // Misconfigured threshold must be a safe no-op, not decide on the first read.
     PolarityState s{true, 0, 0};
-    PolarityConfig zero{0, 50};
-    PolarityResult r = updatePolarity(s, -230.0f, zero);
+    PolarityConfig zero{0, 50, MIN_A};
+    PolarityResult r = updatePolarity(s, -230.0f, COND_A, zero);
     TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
     TEST_ASSERT_TRUE(r.state.armed);
     TEST_ASSERT_EQUAL_INT8(0, r.state.voteCount);
@@ -484,16 +523,16 @@ void test_polarity_nonpositive_threshold_is_noop(void) {
 
 void test_polarity_threshold_one_decides_immediately(void) {
     PolarityState s{true, 0, 0};
-    PolarityConfig one{1, 50};
-    TEST_ASSERT_EQUAL(PolarityAction::Flip, updatePolarity(s, -100.0f, one).action);
-    TEST_ASSERT_EQUAL(PolarityAction::Disarm, updatePolarity(s, 100.0f, one).action);
+    PolarityConfig one{1, 50, MIN_A};
+    TEST_ASSERT_EQUAL(PolarityAction::Flip, updatePolarity(s, -100.0f, COND_A, one).action);
+    TEST_ASSERT_EQUAL(PolarityAction::Disarm, updatePolarity(s, 100.0f, COND_A, one).action);
 }
 
 void test_polarity_one_below_threshold_stays_armed(void) {
     PolarityState s{true, 0, 0};
     PolarityAction action = PolarityAction::Continue;
     for (int i = 0; i < 4; i++) { // threshold is 5
-        PolarityResult r = updatePolarity(s, -230.0f, PCFG);
+        PolarityResult r = updatePolarity(s, -230.0f, COND_A, PCFG);
         s = r.state;
         action = r.action;
     }
@@ -507,10 +546,10 @@ void test_polarity_flip_takes_precedence_over_bound(void) {
     // bound == threshold: a genuinely reversed CT must Flip, not Disarm, on the
     // read where both conditions are first satisfiable.
     PolarityState s{true, 0, 0};
-    PolarityConfig cfg{5, 5};
+    PolarityConfig cfg{5, 5, MIN_A};
     PolarityAction action = PolarityAction::Continue;
     for (int i = 0; i < 5; i++) {
-        PolarityResult r = updatePolarity(s, -230.0f, cfg);
+        PolarityResult r = updatePolarity(s, -230.0f, COND_A, cfg);
         s = r.state;
         action = r.action;
     }
@@ -520,11 +559,11 @@ void test_polarity_flip_takes_precedence_over_bound(void) {
 
 void test_polarity_bound_disarms_without_flip(void) {
     PolarityState s{true, 0, 0};
-    PolarityConfig cfg{5, 4};
+    PolarityConfig cfg{5, 4, MIN_A};
     PolarityAction action = PolarityAction::Continue;
     for (int i = 0; i < 4; i++) {
         float p = (i % 2 == 0) ? -50.0f : 50.0f; // net stays near 0, never reaches 5
-        PolarityResult r = updatePolarity(s, p, cfg);
+        PolarityResult r = updatePolarity(s, p, COND_A, cfg);
         s = r.state;
         action = r.action;
     }
@@ -536,10 +575,10 @@ void test_polarity_vote_recovers_and_confirms(void) {
     // Goes to -4, then a run of forward votes recovers it to +5 -> confirm (no flip).
     PolarityState s{true, 0, 0};
     PolarityAction action = PolarityAction::Continue;
-    for (int i = 0; i < 4; i++) s = updatePolarity(s, -100.0f, PCFG).state; // vote -4
+    for (int i = 0; i < 4; i++) s = updatePolarity(s, -100.0f, COND_A, PCFG).state; // vote -4
     TEST_ASSERT_EQUAL_INT8(-4, s.voteCount);
     for (int i = 0; i < 9; i++) {
-        PolarityResult r = updatePolarity(s, 100.0f, PCFG); // -3,-2,-1,0,1,2,3,4,5
+        PolarityResult r = updatePolarity(s, 100.0f, COND_A, PCFG); // -3,-2,-1,0,1,2,3,4,5
         s = r.state;
         action = r.action;
         if (action != PolarityAction::Continue) break;
@@ -551,9 +590,9 @@ void test_polarity_vote_recovers_and_flips(void) {
     // Mirror: +4 then a run of reversed votes -> reaches -5 -> flip.
     PolarityState s{true, 0, 0};
     PolarityAction action = PolarityAction::Continue;
-    for (int i = 0; i < 4; i++) s = updatePolarity(s, 100.0f, PCFG).state; // vote +4
+    for (int i = 0; i < 4; i++) s = updatePolarity(s, 100.0f, COND_A, PCFG).state; // vote +4
     for (int i = 0; i < 9; i++) {
-        PolarityResult r = updatePolarity(s, -100.0f, PCFG);
+        PolarityResult r = updatePolarity(s, -100.0f, COND_A, PCFG);
         s = r.state;
         action = r.action;
         if (action != PolarityAction::Continue) break;
@@ -563,7 +602,7 @@ void test_polarity_vote_recovers_and_flips(void) {
 
 void test_polarity_disarmed_mid_sequence_is_noop(void) {
     PolarityState s{false, -3, 3}; // disarmed but with residual counters
-    PolarityResult r = updatePolarity(s, -230.0f, PCFG);
+    PolarityResult r = updatePolarity(s, -230.0f, COND_A, PCFG);
     TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
     TEST_ASSERT_FALSE(r.state.armed);
     TEST_ASSERT_EQUAL_INT8(-3, r.state.voteCount);     // unchanged
@@ -743,7 +782,7 @@ void test_multiple_armed_channels_both_resolve(void) {
         computeWeights(in, N, START, WCFG, weights);
         wdrrAccumulate(weights, deficits, active, N, START, 5.0f);
         uint8_t pick = wdrrPick(deficits, active, N, START, &cursor);
-        PolarityResult pr = updatePolarity(pol[pick], in[pick].activePower, PCFG);
+        PolarityResult pr = updatePolarity(pol[pick], in[pick].activePower, COND_A, PCFG);
         if (pr.action == PolarityAction::Flip && pick == 1) flipped1 = true;
         if (pr.action == PolarityAction::Flip && pick == 2) flipped2 = true;
         pol[pick] = pr.state;
@@ -818,6 +857,62 @@ void test_mixed_fleet_grid_battery_sampled_more(void) {
 }
 
 // ============================================================================
+// Current-gate integration (reproduces the bench false-flip and proves the fix)
+// ============================================================================
+
+void test_offset_noise_never_false_flips_unclamped_role(void) {
+    // THE HARDWARE REGRESSION, end to end: a grid channel (unclamped role) armed with
+    // no real load. The ADE7953 reports a small steady offset (+1.2 W) at ~0.004 A.
+    // Current-gated, every such read is non-conducting: updatePolarity no-ops, the
+    // channel never votes and stays armed - no false "CT reversal detected".
+    PolarityState s{true, 0, 0};
+    for (int i = 0; i < 1000; i++) {
+        PolarityResult r = updatePolarity(s, 1.2f, 0.004f, PCFG);
+        s = r.state;
+        TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
+    }
+    TEST_ASSERT_TRUE(s.armed);
+    TEST_ASSERT_EQUAL_INT8(0, s.voteCount);
+    TEST_ASSERT_EQUAL_UINT16(0, s.conductingReads);
+
+    // A genuine reversed load finally flows (-2000 W at 8.7 A): now it must flip.
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 10; i++) {
+        PolarityResult r = updatePolarity(s, -2000.0f, 8.7f, PCFG);
+        s = r.state;
+        action = r.action;
+        if (action != PolarityAction::Continue) break;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Flip, action);
+}
+
+void test_offset_noise_earns_no_boost(void) {
+    // The other half of the regression: offset noise must not earn the armed boost,
+    // or the noisy channel hogs the scheduler. The caller derives `conducting` from
+    // isConductingReading, so an armed grid channel on offset noise gets only its
+    // normal (role-multiplied) weight - no boost.
+    bool conducting = isConductingReading(1.2f, 0.004f, MIN_A);
+    TEST_ASSERT_FALSE(conducting);
+    ChannelWeightInput in{true, 1.2f, 0.0f, true /*armed*/, CHANNEL_ROLE_GRID, conducting};
+    // base 0.1 * rolePriorityMult 2.0 = 0.2; NO armed boost.
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, WCFG.minBase * WCFG.rolePriorityMult,
+                             computeChannelWeight(in, 0.0f, 0.0f, WCFG));
+}
+
+void test_low_current_noise_does_not_burn_the_bound(void) {
+    // A noisy unclamped channel that oscillates sign at ~0 current must NOT burn its
+    // conducting-read bound: it stays armed indefinitely (waiting for real load),
+    // exactly like an idle channel, rather than disarming on noise.
+    PolarityState s{true, 0, 0};
+    for (int i = 0; i < 500; i++) {
+        float p = (i % 2 == 0) ? -2.0f : 2.0f; // offset noise, both signs
+        s = updatePolarity(s, p, 0.004f, PCFG).state;
+    }
+    TEST_ASSERT_TRUE(s.armed);
+    TEST_ASSERT_EQUAL_UINT16(0, s.conductingReads);
+}
+
+// ============================================================================
 // runner
 // ============================================================================
 
@@ -833,6 +928,12 @@ int main(int, char **) {
     RUN_TEST(test_polarity_delayed_load_still_detects);
     RUN_TEST(test_polarity_oscillating_conducting_disarms_via_bound);
     RUN_TEST(test_polarity_unbounded_oscillation_never_disarms);
+
+    RUN_TEST(test_conducting_true_for_real_load);
+    RUN_TEST(test_conducting_true_for_reversed_load_with_current);
+    RUN_TEST(test_conducting_false_for_offset_noise);
+    RUN_TEST(test_conducting_false_for_zero_power_or_nan);
+    RUN_TEST(test_conducting_zero_threshold_degrades_to_power_only);
 
     RUN_TEST(test_clamp_load_and_pv_negatives);
     RUN_TEST(test_clamp_allows_grid_battery_inverter_negatives);
@@ -888,6 +989,10 @@ int main(int, char **) {
     RUN_TEST(test_multiple_armed_channels_both_resolve);
     RUN_TEST(test_full_17_channel_no_starvation);
     RUN_TEST(test_mixed_fleet_grid_battery_sampled_more);
+
+    RUN_TEST(test_offset_noise_never_false_flips_unclamped_role);
+    RUN_TEST(test_offset_noise_earns_no_boost);
+    RUN_TEST(test_low_current_noise_does_not_burn_the_bound);
 
     return UNITY_END();
 }

--- a/source/test/test_meter_logic/test_meter_logic.cpp
+++ b/source/test/test_meter_logic/test_meter_logic.cpp
@@ -1,0 +1,870 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+//
+// Host unit tests for the pure meter logic. Run with:  pio test -e native
+// (On Windows the native toolchain is unreliable - run it from WSL.)
+//
+// These need no hardware: they exercise the CT-polarity detector, the negative
+// clamp, the WDRR weighting and the scheduler core entirely in memory. The
+// integration simulations at the bottom reproduce the dev-bench starvation
+// regression and prove the conduction-gated boost fixes it without breaking
+// reversed-CT detection on circuits that are idle at install time.
+
+#include <unity.h>
+#include "meter_logic.h"
+
+using namespace MeterLogic;
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// Config values mirror the firmware defaults so the tests track real behaviour.
+static const WeightConfig WCFG = {0.4f, 0.4f, 0.1f, 1.5f, 2.0f};
+static const PolarityConfig PCFG = {5, 50};
+
+// ============================================================================
+// updatePolarity
+// ============================================================================
+
+void test_polarity_not_armed_is_noop(void) {
+    PolarityState s{false, 0, 0};
+    PolarityResult r = updatePolarity(s, -100.0f, PCFG);
+    TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
+    TEST_ASSERT_FALSE(r.state.armed);
+    TEST_ASSERT_EQUAL_INT8(0, r.state.voteCount);
+    TEST_ASSERT_EQUAL_UINT16(0, r.state.conductingReads);
+}
+
+void test_polarity_steady_reverse_flips_at_threshold(void) {
+    PolarityState s{true, 0, 0};
+    PolarityAction action = PolarityAction::Continue;
+    int reads = 0;
+    for (int i = 0; i < 10; i++) {
+        PolarityResult r = updatePolarity(s, -230.0f, PCFG);
+        s = r.state;
+        action = r.action;
+        reads++;
+        if (action != PolarityAction::Continue) break;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Flip, action);
+    TEST_ASSERT_EQUAL_INT(5, reads);   // flips on exactly the 5th reversed vote
+    TEST_ASSERT_FALSE(s.armed);        // disarms after deciding
+}
+
+void test_polarity_steady_forward_confirms_without_flip(void) {
+    PolarityState s{true, 0, 0};
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 10; i++) {
+        PolarityResult r = updatePolarity(s, 1500.0f, PCFG);
+        s = r.state;
+        action = r.action;
+        if (action != PolarityAction::Continue) break;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Disarm, action); // confirmed correct, no flip
+    TEST_ASSERT_FALSE(s.armed);
+}
+
+void test_polarity_is_magnitude_independent(void) {
+    // A tiny steady reversed load must flip exactly like a huge one.
+    PolarityState s{true, 0, 0};
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 10; i++) {
+        PolarityResult r = updatePolarity(s, -0.3f, PCFG);
+        s = r.state;
+        action = r.action;
+        if (action != PolarityAction::Continue) break;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Flip, action);
+}
+
+void test_polarity_idle_is_noop_and_stays_armed(void) {
+    // No load: a non-conducting reading must not vote, must not count toward the
+    // bound, and must leave the channel armed (waiting for load).
+    PolarityState s{true, 0, 0};
+    for (int i = 0; i < 500; i++) {
+        PolarityResult r = updatePolarity(s, 0.0f, PCFG);
+        s = r.state;
+        TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
+    }
+    TEST_ASSERT_TRUE(s.armed);
+    TEST_ASSERT_EQUAL_INT8(0, s.voteCount);
+    TEST_ASSERT_EQUAL_UINT16(0, s.conductingReads);
+}
+
+void test_polarity_nan_is_noop(void) {
+    PolarityState s{true, 0, 0};
+    PolarityResult r = updatePolarity(s, NAN, PCFG);
+    TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
+    TEST_ASSERT_TRUE(r.state.armed);
+    TEST_ASSERT_EQUAL_INT8(0, r.state.voteCount);
+    TEST_ASSERT_EQUAL_UINT16(0, r.state.conductingReads);
+}
+
+void test_polarity_delayed_load_still_detects(void) {
+    // THE KEY CORRECTNESS CASE: a CT clipped on a circuit that is off at install
+    // time. The channel stays armed through a long idle period, then a reversed
+    // load finally appears - and it must still be detected and flipped.
+    PolarityState s{true, 0, 0};
+    for (int i = 0; i < 200; i++) {
+        s = updatePolarity(s, 0.0f, PCFG).state; // idle: no load yet
+    }
+    TEST_ASSERT_TRUE(s.armed); // still armed after a long wait
+
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 10; i++) {
+        PolarityResult r = updatePolarity(s, -230.0f, PCFG); // load finally flows, reversed
+        s = r.state;
+        action = r.action;
+        if (action != PolarityAction::Continue) break;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Flip, action);
+}
+
+void test_polarity_oscillating_conducting_disarms_via_bound(void) {
+    // A channel that keeps conducting but whose sign oscillates can never decide;
+    // the conducting-read bound makes it give up (no flip) so it cannot stay
+    // armed-and-boosted forever.
+    PolarityState s{true, 0, 0};
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 200; i++) {
+        float p = (i % 2 == 0) ? -50.0f : 50.0f;
+        PolarityResult r = updatePolarity(s, p, PCFG);
+        s = r.state;
+        action = r.action;
+        if (!s.armed) break;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Disarm, action); // gave up, did not flip
+    TEST_ASSERT_FALSE(s.armed);
+}
+
+void test_polarity_unbounded_oscillation_never_disarms(void) {
+    // Documents why the bound exists: with maxConductingReads == 0 an oscillating
+    // conducting channel never decides and never disarms.
+    PolarityState s{true, 0, 0};
+    PolarityConfig unbounded{5, 0};
+    for (int i = 0; i < 1000; i++) {
+        float p = (i % 2 == 0) ? -50.0f : 50.0f;
+        s = updatePolarity(s, p, unbounded).state;
+    }
+    TEST_ASSERT_TRUE(s.armed);
+}
+
+// ============================================================================
+// shouldClampNegative
+// ============================================================================
+
+void test_clamp_load_and_pv_negatives(void) {
+    TEST_ASSERT_TRUE(shouldClampNegative(-5.0f, CHANNEL_ROLE_LOAD));
+    TEST_ASSERT_TRUE(shouldClampNegative(-5.0f, CHANNEL_ROLE_PV));
+}
+
+void test_clamp_allows_grid_battery_inverter_negatives(void) {
+    TEST_ASSERT_FALSE(shouldClampNegative(-5.0f, CHANNEL_ROLE_GRID));
+    TEST_ASSERT_FALSE(shouldClampNegative(-5.0f, CHANNEL_ROLE_BATTERY));
+    TEST_ASSERT_FALSE(shouldClampNegative(-5.0f, CHANNEL_ROLE_INVERTER));
+}
+
+void test_clamp_never_touches_positive(void) {
+    TEST_ASSERT_FALSE(shouldClampNegative(5.0f, CHANNEL_ROLE_LOAD));
+    TEST_ASSERT_FALSE(shouldClampNegative(0.0f, CHANNEL_ROLE_PV));
+    TEST_ASSERT_FALSE(shouldClampNegative(0.0f, CHANNEL_ROLE_LOAD)); // exact zero is not negative
+    TEST_ASSERT_FALSE(shouldClampNegative(NAN, CHANNEL_ROLE_LOAD));  // NaN < 0 is false in IEEE-754
+}
+
+// ============================================================================
+// weighting
+// ============================================================================
+
+void test_role_priority_grid_battery_only(void) {
+    TEST_ASSERT_TRUE(roleHasSchedulingPriority(CHANNEL_ROLE_GRID));
+    TEST_ASSERT_TRUE(roleHasSchedulingPriority(CHANNEL_ROLE_BATTERY));
+    TEST_ASSERT_FALSE(roleHasSchedulingPriority(CHANNEL_ROLE_LOAD));
+    TEST_ASSERT_FALSE(roleHasSchedulingPriority(CHANNEL_ROLE_PV));
+    TEST_ASSERT_FALSE(roleHasSchedulingPriority(CHANNEL_ROLE_INVERTER));
+}
+
+void test_weight_inactive_is_zero(void) {
+    ChannelWeightInput in{false, 100.0f, 1.0f, false, CHANNEL_ROLE_LOAD};
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, computeChannelWeight(in, 0.5f, 0.5f, WCFG));
+}
+
+void test_weight_idle_load_is_min_base(void) {
+    ChannelWeightInput in{true, 0.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    TEST_ASSERT_EQUAL_FLOAT(WCFG.minBase, computeChannelWeight(in, 0.0f, 0.0f, WCFG));
+}
+
+void test_weight_grid_gets_multiplier(void) {
+    ChannelWeightInput load{true, 0.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    ChannelWeightInput grid{true, 0.0f, 0.0f, false, CHANNEL_ROLE_GRID};
+    float wLoad = computeChannelWeight(load, 0.0f, 0.0f, WCFG);
+    float wGrid = computeChannelWeight(grid, 0.0f, 0.0f, WCFG);
+    TEST_ASSERT_EQUAL_FLOAT(wLoad * WCFG.rolePriorityMult, wGrid);
+}
+
+void test_weight_armed_boost_only_when_conducting(void) {
+    // Armed but idle (no load): NO boost - this is what stops a no-load armed
+    // channel from hogging the scheduler.
+    ChannelWeightInput idleArmed{true, 0.0f, 0.0f, true, CHANNEL_ROLE_LOAD};
+    TEST_ASSERT_EQUAL_FLOAT(WCFG.minBase, computeChannelWeight(idleArmed, 0.0f, 0.0f, WCFG));
+
+    // Armed AND conducting: boost added on top of the normal weight.
+    ChannelWeightInput condArmed{true, 500.0f, 0.0f, true, CHANNEL_ROLE_LOAD};
+    ChannelWeightInput condUnarmed{true, 500.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    float wArmed = computeChannelWeight(condArmed, 1.0f, 0.0f, WCFG);
+    float wUnarmed = computeChannelWeight(condUnarmed, 1.0f, 0.0f, WCFG);
+    TEST_ASSERT_EQUAL_FLOAT(wUnarmed + WCFG.armedBoost, wArmed);
+}
+
+void test_weight_shares_contribute(void) {
+    ChannelWeightInput in{true, 500.0f, 2.0f, false, CHANNEL_ROLE_LOAD};
+    // full power share + full variability share + base
+    float expected = WCFG.powerShare * 1.0f + WCFG.variability * 1.0f + WCFG.minBase;
+    TEST_ASSERT_EQUAL_FLOAT(expected, computeChannelWeight(in, 1.0f, 1.0f, WCFG));
+}
+
+void test_computeWeights_zeroes_channel_zero_and_handles_nan(void) {
+    const uint8_t N = 4;
+    ChannelWeightInput in[N];
+    in[0] = {true, 1000.0f, 0.0f, false, CHANNEL_ROLE_GRID}; // ch0 - excluded
+    in[1] = {true, NAN, NAN, false, CHANNEL_ROLE_LOAD};      // bad reading
+    in[2] = {true, 100.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    in[3] = {false, 0.0f, 0.0f, false, CHANNEL_ROLE_LOAD};   // inactive
+    float w[N] = {9, 9, 9, 9};
+
+    computeWeights(in, N, 1, WCFG, w);
+
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, w[0]); // channel 0 not scheduled
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, w[3]); // inactive
+    // NaN channel does not crash and gets a finite (base) weight; ch2 carries the share.
+    TEST_ASSERT_TRUE(w[1] >= WCFG.minBase);
+    TEST_ASSERT_TRUE(w[2] > w[1]);
+}
+
+// ============================================================================
+// scheduler core
+// ============================================================================
+
+void test_find_starved_channel(void) {
+    const uint8_t N = 4;
+    bool active[N] = {true, true, true, false};
+    uint64_t last[N] = {0, 19000, 1000, 0};
+    uint64_t now = 20000;
+    uint8_t s = findStarvedChannel(last, active, N, 1, now, 15000);
+    TEST_ASSERT_EQUAL_UINT8(2, s); // ch2 gap 19000 > 15000 (ch1 gap 1000 is fine)
+}
+
+void test_find_starved_skips_unbaselined_and_inactive(void) {
+    const uint8_t N = 4;
+    bool active[N] = {true, false, true, true};
+    uint64_t last[N] = {0, 1, 0, 1}; // ch1 inactive, ch2 never baselined (0), ch3 baselined
+    uint64_t now = 100000;
+    uint8_t s = findStarvedChannel(last, active, N, 1, now, 15000);
+    TEST_ASSERT_EQUAL_UINT8(3, s); // only ch3 qualifies
+}
+
+void test_find_starved_none(void) {
+    const uint8_t N = 3;
+    bool active[N] = {true, true, true};
+    uint64_t last[N] = {0, 99000, 99500};
+    uint64_t now = 100000;
+    TEST_ASSERT_EQUAL_UINT8(NO_CHANNEL, findStarvedChannel(last, active, N, 1, now, 15000));
+}
+
+void test_wdrr_accumulate_gains_zeroes_and_clamps(void) {
+    const uint8_t N = 4;
+    float weights[N] = {0, 1.0f, 0.1f, 99.0f};
+    bool active[N] = {true, true, true, false};
+    float deficits[N] = {0, 4.9f, 0.0f, 7.0f};
+    wdrrAccumulate(weights, deficits, active, N, 1, 5.0f);
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, 5.0f, deficits[1]); // 4.9 + 1.0 -> clamped to 5.0
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, 0.1f, deficits[2]); // 0 + 0.1
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, deficits[3]);        // inactive -> zeroed
+}
+
+void test_wdrr_pick_highest_deficit(void) {
+    const uint8_t N = 4;
+    float deficits[N] = {0, 0.2f, 0.9f, 0.5f};
+    bool active[N] = {true, true, true, true};
+    uint8_t cursor = 0;
+    uint8_t pick = wdrrPick(deficits, active, N, 1, &cursor);
+    TEST_ASSERT_EQUAL_UINT8(2, pick);
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, -0.1f, deficits[2]); // decremented by 1.0
+    TEST_ASSERT_EQUAL_UINT8(2, cursor);
+}
+
+void test_wdrr_pick_all_inactive_returns_invalid(void) {
+    const uint8_t N = 3;
+    float deficits[N] = {0, 1.0f, 2.0f};
+    bool active[N] = {true, false, false};
+    uint8_t cursor = 0;
+    TEST_ASSERT_EQUAL_UINT8(NO_CHANNEL, wdrrPick(deficits, active, N, 1, &cursor));
+}
+
+void test_wdrr_tie_break_rotates_no_monopoly(void) {
+    // Equal-deficit idle channels must rotate, not let the lowest index win every
+    // time. Run many rounds and assert service counts are balanced.
+    const uint8_t N = 6; // ch0 + 5 schedulable
+    bool active[N] = {true, true, true, true, true, true};
+    float weights[N] = {0, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f};
+    float deficits[N] = {0, 0, 0, 0, 0, 0};
+    uint8_t cursor = 0;
+    int picks[N] = {0};
+    for (int r = 0; r < 500; r++) {
+        wdrrAccumulate(weights, deficits, active, N, 1, 5.0f);
+        uint8_t p = wdrrPick(deficits, active, N, 1, &cursor);
+        TEST_ASSERT_NOT_EQUAL(NO_CHANNEL, p);
+        picks[p]++;
+    }
+    for (uint8_t i = 1; i < N; i++) {
+        TEST_ASSERT_TRUE(picks[i] > 50); // none starved
+    }
+}
+
+// ============================================================================
+// Integration simulations
+// ============================================================================
+//
+// A small driver that runs the full per-round pipeline (weights -> accumulate ->
+// pick -> detector) so the pieces are exercised together exactly as the firmware
+// composes them.
+
+void test_armed_no_load_channel_does_not_starve_peers(void) {
+    // ch0 + 6 active LOAD channels, none carrying any load. ch1 is armed (the
+    // installer just toggled it). The conduction-gated boost means ch1 is NEVER
+    // boosted while idle, so peers are serviced fairly from the very first round,
+    // and ch1 simply stays armed waiting for load.
+    const uint8_t N = 7;
+    const uint8_t START = 1;
+    ChannelWeightInput in[N];
+    bool active[N];
+    float deficits[N];
+    float weights[N];
+    PolarityState pol[N];
+    for (uint8_t i = 0; i < N; i++) {
+        in[i] = {i >= START, 0.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+        active[i] = (i >= START);
+        deficits[i] = 0.0f;
+        weights[i] = 0.0f;
+        pol[i] = {false, 0, 0};
+    }
+    pol[1].armed = true;
+    in[1].armed = true;
+
+    uint8_t cursor = 0;
+    int gap[N] = {0};
+    int maxGap[N] = {0};
+    const int ROUNDS = 600;
+
+    for (int r = 0; r < ROUNDS; r++) {
+        for (uint8_t i = START; i < N; i++) in[i].armed = pol[i].armed;
+        computeWeights(in, N, START, WCFG, weights);
+        wdrrAccumulate(weights, deficits, active, N, START, 5.0f);
+        uint8_t pick = wdrrPick(deficits, active, N, START, &cursor);
+        TEST_ASSERT_NOT_EQUAL(NO_CHANNEL, pick);
+
+        PolarityResult pr = updatePolarity(pol[pick], in[pick].activePower, PCFG);
+        pol[pick] = pr.state;
+
+        for (uint8_t i = START; i < N; i++) {
+            if (i == pick) gap[i] = 0;
+            else {
+                gap[i]++;
+                if (gap[i] > maxGap[i]) maxGap[i] = gap[i];
+            }
+        }
+    }
+
+    // ch1 stays armed (no load ever arrived) - it must keep waiting, not give up.
+    TEST_ASSERT_TRUE(pol[1].armed);
+    // No starvation at any point: with 6 equal channels, fair service is ~6 rounds.
+    for (uint8_t i = START; i < N; i++) {
+        TEST_ASSERT_TRUE(maxGap[i] > 0);
+        TEST_ASSERT_TRUE(maxGap[i] < 12);
+    }
+}
+
+void test_armed_conducting_channel_resolves_quickly(void) {
+    // ch1 armed AND carrying a steady reversed load: the conduction-gated boost
+    // makes it win most slots and resolve (flip) within a handful of rounds.
+    const uint8_t N = 7;
+    const uint8_t START = 1;
+    ChannelWeightInput in[N];
+    bool active[N];
+    float deficits[N];
+    float weights[N];
+    PolarityState pol[N];
+    for (uint8_t i = 0; i < N; i++) {
+        in[i] = {i >= START, 0.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+        active[i] = (i >= START);
+        deficits[i] = 0.0f;
+        weights[i] = 0.0f;
+        pol[i] = {false, 0, 0};
+    }
+    pol[1].armed = true;
+    in[1].activePower = -500.0f; // reversed load conducting
+
+    uint8_t cursor = 0;
+    int flipRound = -1;
+    for (int r = 0; r < 200; r++) {
+        for (uint8_t i = START; i < N; i++) in[i].armed = pol[i].armed;
+        computeWeights(in, N, START, WCFG, weights);
+        wdrrAccumulate(weights, deficits, active, N, START, 5.0f);
+        uint8_t pick = wdrrPick(deficits, active, N, START, &cursor);
+
+        PolarityResult pr = updatePolarity(pol[pick], in[pick].activePower, PCFG);
+        if (pr.action == PolarityAction::Flip && flipRound < 0) flipRound = r;
+        pol[pick] = pr.state;
+    }
+
+    TEST_ASSERT_TRUE(flipRound >= 0);
+    TEST_ASSERT_TRUE(flipRound < 20); // boosted -> resolves fast
+    TEST_ASSERT_FALSE(pol[1].armed);  // disarmed after the flip
+}
+
+void test_grid_sampled_more_often_than_load(void) {
+    // A grid channel and load channels, all idle: grid should be picked clearly
+    // more often thanks to the role multiplier (which is NOT gated on conduction).
+    const uint8_t N = 5; // ch0 + ch1 grid + ch2..4 load
+    ChannelWeightInput in[N];
+    bool active[N];
+    float deficits[N];
+    float weights[N];
+    for (uint8_t i = 0; i < N; i++) {
+        ChannelRole role = (i == 1) ? CHANNEL_ROLE_GRID : CHANNEL_ROLE_LOAD;
+        in[i] = {i >= 1, 0.0f, 0.0f, false, role};
+        active[i] = (i >= 1);
+        deficits[i] = 0.0f;
+        weights[i] = 0.0f;
+    }
+    uint8_t cursor = 0;
+    int picks[N] = {0};
+    for (int r = 0; r < 1000; r++) {
+        computeWeights(in, N, 1, WCFG, weights);
+        wdrrAccumulate(weights, deficits, active, N, 1, 5.0f);
+        uint8_t p = wdrrPick(deficits, active, N, 1, &cursor);
+        picks[p]++;
+    }
+    TEST_ASSERT_TRUE(picks[1] > picks[2]);
+    TEST_ASSERT_TRUE(picks[1] > picks[3]);
+    TEST_ASSERT_TRUE(picks[1] > picks[4]);
+}
+
+// ============================================================================
+// Additional coverage (boundaries, precedence, multi-channel, full-size)
+// ============================================================================
+
+void test_polarity_nonpositive_threshold_is_noop(void) {
+    // Misconfigured threshold must be a safe no-op, not decide on the first read.
+    PolarityState s{true, 0, 0};
+    PolarityConfig zero{0, 50};
+    PolarityResult r = updatePolarity(s, -230.0f, zero);
+    TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
+    TEST_ASSERT_TRUE(r.state.armed);
+    TEST_ASSERT_EQUAL_INT8(0, r.state.voteCount);
+}
+
+void test_polarity_threshold_one_decides_immediately(void) {
+    PolarityState s{true, 0, 0};
+    PolarityConfig one{1, 50};
+    TEST_ASSERT_EQUAL(PolarityAction::Flip, updatePolarity(s, -100.0f, one).action);
+    TEST_ASSERT_EQUAL(PolarityAction::Disarm, updatePolarity(s, 100.0f, one).action);
+}
+
+void test_polarity_one_below_threshold_stays_armed(void) {
+    PolarityState s{true, 0, 0};
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 4; i++) { // threshold is 5
+        PolarityResult r = updatePolarity(s, -230.0f, PCFG);
+        s = r.state;
+        action = r.action;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Continue, action);
+    TEST_ASSERT_TRUE(s.armed);
+    TEST_ASSERT_EQUAL_INT8(-4, s.voteCount);
+    TEST_ASSERT_EQUAL_UINT16(4, s.conductingReads);
+}
+
+void test_polarity_flip_takes_precedence_over_bound(void) {
+    // bound == threshold: a genuinely reversed CT must Flip, not Disarm, on the
+    // read where both conditions are first satisfiable.
+    PolarityState s{true, 0, 0};
+    PolarityConfig cfg{5, 5};
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 5; i++) {
+        PolarityResult r = updatePolarity(s, -230.0f, cfg);
+        s = r.state;
+        action = r.action;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Flip, action);
+    TEST_ASSERT_FALSE(s.armed);
+}
+
+void test_polarity_bound_disarms_without_flip(void) {
+    PolarityState s{true, 0, 0};
+    PolarityConfig cfg{5, 4};
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 4; i++) {
+        float p = (i % 2 == 0) ? -50.0f : 50.0f; // net stays near 0, never reaches 5
+        PolarityResult r = updatePolarity(s, p, cfg);
+        s = r.state;
+        action = r.action;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Disarm, action);
+    TEST_ASSERT_FALSE(s.armed);
+}
+
+void test_polarity_vote_recovers_and_confirms(void) {
+    // Goes to -4, then a run of forward votes recovers it to +5 -> confirm (no flip).
+    PolarityState s{true, 0, 0};
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 4; i++) s = updatePolarity(s, -100.0f, PCFG).state; // vote -4
+    TEST_ASSERT_EQUAL_INT8(-4, s.voteCount);
+    for (int i = 0; i < 9; i++) {
+        PolarityResult r = updatePolarity(s, 100.0f, PCFG); // -3,-2,-1,0,1,2,3,4,5
+        s = r.state;
+        action = r.action;
+        if (action != PolarityAction::Continue) break;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Disarm, action); // confirmed forward, no flip
+}
+
+void test_polarity_vote_recovers_and_flips(void) {
+    // Mirror: +4 then a run of reversed votes -> reaches -5 -> flip.
+    PolarityState s{true, 0, 0};
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 4; i++) s = updatePolarity(s, 100.0f, PCFG).state; // vote +4
+    for (int i = 0; i < 9; i++) {
+        PolarityResult r = updatePolarity(s, -100.0f, PCFG);
+        s = r.state;
+        action = r.action;
+        if (action != PolarityAction::Continue) break;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Flip, action);
+}
+
+void test_polarity_disarmed_mid_sequence_is_noop(void) {
+    PolarityState s{false, -3, 3}; // disarmed but with residual counters
+    PolarityResult r = updatePolarity(s, -230.0f, PCFG);
+    TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
+    TEST_ASSERT_FALSE(r.state.armed);
+    TEST_ASSERT_EQUAL_INT8(-3, r.state.voteCount);     // unchanged
+    TEST_ASSERT_EQUAL_UINT16(3, r.state.conductingReads);
+}
+
+void test_weight_grid_armed_conducting_all_bumps_stack(void) {
+    // grid (x2) + armed + conducting + full power share: pins the arithmetic order
+    // (role multiply on the base, THEN add the flat armed boost).
+    ChannelWeightInput in{true, -500.0f, 0.0f, true, CHANNEL_ROLE_GRID};
+    // base = 0.4*1 + 0.4*0 + 0.1 = 0.5; *2.0 = 1.0; + 1.5 = 2.5
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, 2.5f, computeChannelWeight(in, 1.0f, 0.0f, WCFG));
+    // same but idle (no conduction) -> no boost: 0.5*2.0 = 1.0
+    ChannelWeightInput idle{true, 0.0f, 0.0f, true, CHANNEL_ROLE_GRID};
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, 1.0f, computeChannelWeight(idle, 1.0f, 0.0f, WCFG));
+}
+
+void test_computeWeights_battery_gets_multiplier(void) {
+    const uint8_t N = 3;
+    ChannelWeightInput in[N];
+    in[0] = {false, 0.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    in[1] = {true, 100.0f, 0.0f, false, CHANNEL_ROLE_BATTERY};
+    in[2] = {true, 100.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    float w[N] = {};
+    computeWeights(in, N, 1, WCFG, w);
+    TEST_ASSERT_TRUE(w[1] > w[2]);
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, w[2] * WCFG.rolePriorityMult, w[1]);
+}
+
+void test_computeWeights_tiny_channel_gets_min_base(void) {
+    const uint8_t N = 3;
+    ChannelWeightInput in[N];
+    in[0] = {false, 0.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    in[1] = {true, 10000.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    in[2] = {true, 1.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    float w[N] = {};
+    computeWeights(in, N, 1, WCFG, w);
+    TEST_ASSERT_TRUE(w[2] >= WCFG.minBase); // anti-starvation floor holds under skew
+    TEST_ASSERT_TRUE(w[1] > w[2]);
+}
+
+void test_computeWeights_all_inactive_all_zeros(void) {
+    const uint8_t N = 4;
+    ChannelWeightInput in[N];
+    for (uint8_t i = 0; i < N; i++) in[i] = {false, 0.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    float w[N] = {9, 9, 9, 9};
+    computeWeights(in, N, 1, WCFG, w);
+    for (uint8_t i = 0; i < N; i++) TEST_ASSERT_EQUAL_FLOAT(0.0f, w[i]);
+}
+
+void test_computeWeights_variability_differentiates_equal_power(void) {
+    const uint8_t N = 3;
+    ChannelWeightInput in[N];
+    in[0] = {false, 0.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    in[1] = {true, 100.0f, 0.1f, false, CHANNEL_ROLE_LOAD};
+    in[2] = {true, 100.0f, 0.9f, false, CHANNEL_ROLE_LOAD};
+    float w[N] = {};
+    computeWeights(in, N, 1, WCFG, w);
+    TEST_ASSERT_TRUE(w[2] > w[1]); // higher variability -> more weight
+}
+
+void test_find_starved_returns_lowest_index_when_multiple(void) {
+    const uint8_t N = 5;
+    bool active[N] = {true, true, true, true, true};
+    uint64_t last[N] = {0, 1000, 2000, 1000, 2000}; // all past gap at now=30000
+    TEST_ASSERT_EQUAL_UINT8(1, findStarvedChannel(last, active, N, 1, 30000, 5000));
+}
+
+void test_find_starved_exactly_at_gap_is_not_starved(void) {
+    const uint8_t N = 3;
+    bool active[N] = {true, true, true};
+    uint64_t last[N] = {0, 5000, 4999}; // ch1 gap=15000 (==), ch2 gap=15001 (>)
+    TEST_ASSERT_EQUAL_UINT8(2, findStarvedChannel(last, active, N, 1, 20000, 15000));
+    uint64_t last2[N] = {0, 4999, 5000}; // ch1 gap=15001 (>), ch2 gap=15000 (==)
+    TEST_ASSERT_EQUAL_UINT8(1, findStarvedChannel(last2, active, N, 1, 20000, 15000));
+}
+
+void test_find_starved_now_before_lastMillis_returns_channel(void) {
+    // Defensive: if lastMillis > now (clock skew / torn read), the unsigned gap
+    // underflows to a huge value and the channel is force-picked. This matches the
+    // original firmware and is the intended (force-read rather than defer) behavior.
+    const uint8_t N = 3;
+    bool active[N] = {true, true, true};
+    uint64_t last[N] = {0, 5000, 5000};
+    TEST_ASSERT_EQUAL_UINT8(1, findStarvedChannel(last, active, N, 1, 1000, 5000));
+}
+
+void test_wdrr_accumulate_nan_weight_is_zeroed(void) {
+    const uint8_t N = 3;
+    float weights[N] = {0, NAN, 0.5f};
+    bool active[N] = {false, true, true};
+    float deficits[N] = {0, 2.0f, 2.0f};
+    wdrrAccumulate(weights, deficits, active, N, 1, 5.0f);
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, deficits[1]); // NaN poisoned then reset
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, 2.5f, deficits[2]);
+}
+
+void test_wdrr_accumulate_clamps_negative(void) {
+    const uint8_t N = 2;
+    float weights[N] = {0, 0.0f};
+    bool active[N] = {false, true};
+    float deficits[N] = {0, -5.5f};
+    wdrrAccumulate(weights, deficits, active, N, 1, 5.0f);
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, -5.0f, deficits[1]); // clamped to -bound
+}
+
+void test_wdrr_pick_single_channel_always_wins(void) {
+    const uint8_t N = 4;
+    float deficits[N] = {0, 0.0f, 0.0f, 0.5f};
+    bool active[N] = {true, false, false, true}; // only ch3 schedulable
+    uint8_t cursor = 3;
+    TEST_ASSERT_EQUAL_UINT8(3, wdrrPick(deficits, active, N, 1, &cursor));
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, -0.5f, deficits[3]);
+    cursor = 1; // even starting elsewhere, the wrap finds ch3
+    deficits[3] = 0.5f;
+    TEST_ASSERT_EQUAL_UINT8(3, wdrrPick(deficits, active, N, 1, &cursor));
+}
+
+void test_wdrr_pick_cursor_wraps_at_end(void) {
+    // cursor at the last index must wrap to startIndex on the next pick.
+    const uint8_t N = 4;
+    float deficits[N] = {0, 0.1f, 0.1f, 0.1f};
+    bool active[N] = {true, true, true, true};
+    uint8_t cursor = 3; // last index -> next starts at ch1
+    TEST_ASSERT_EQUAL_UINT8(1, wdrrPick(deficits, active, N, 1, &cursor));
+    TEST_ASSERT_EQUAL_UINT8(1, cursor);
+    // next pick starts one past ch1 -> ch2 (deficits ch2,ch3 still 0.1, ch1 now -0.9)
+    TEST_ASSERT_EQUAL_UINT8(2, wdrrPick(deficits, active, N, 1, &cursor));
+}
+
+void test_wdrr_pick_tie_goes_to_channel_after_cursor(void) {
+    const uint8_t N = 4;
+    float deficits[N] = {0, 1.0f, 1.0f, 0.0f};
+    bool active[N] = {true, true, true, false};
+    uint8_t cursor = 1; // iteration starts at ch2
+    TEST_ASSERT_EQUAL_UINT8(2, wdrrPick(deficits, active, N, 1, &cursor));
+}
+
+void test_wdrr_pick_all_negative_deficits_picks_max(void) {
+    // Validates the no-sentinel picker: all deficits negative, highest still wins.
+    const uint8_t N = 4;
+    float deficits[N] = {0, -3.0f, -1.0f, -2.0f};
+    bool active[N] = {true, true, true, true};
+    uint8_t cursor = 0;
+    TEST_ASSERT_EQUAL_UINT8(2, wdrrPick(deficits, active, N, 1, &cursor));
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, -2.0f, deficits[2]);
+}
+
+void test_multiple_armed_channels_both_resolve(void) {
+    // Two reversed CTs armed at once (panel with several reversed clips): both must
+    // flip, neither starving the other.
+    const uint8_t N = 5;
+    const uint8_t START = 1;
+    ChannelWeightInput in[N];
+    bool active[N];
+    float deficits[N];
+    float weights[N];
+    PolarityState pol[N];
+    float power[N] = {0, -500.0f, -300.0f, 200.0f, 100.0f};
+    for (uint8_t i = 0; i < N; i++) {
+        in[i] = {i >= START, power[i], 0.0f, false, CHANNEL_ROLE_LOAD};
+        active[i] = (i >= START);
+        deficits[i] = 0.0f;
+        weights[i] = 0.0f;
+        pol[i] = {false, 0, 0};
+    }
+    pol[1].armed = true;
+    pol[2].armed = true;
+
+    uint8_t cursor = 0;
+    bool flipped1 = false, flipped2 = false;
+    for (int r = 0; r < 200; r++) {
+        for (uint8_t i = START; i < N; i++) in[i].armed = pol[i].armed;
+        computeWeights(in, N, START, WCFG, weights);
+        wdrrAccumulate(weights, deficits, active, N, START, 5.0f);
+        uint8_t pick = wdrrPick(deficits, active, N, START, &cursor);
+        PolarityResult pr = updatePolarity(pol[pick], in[pick].activePower, PCFG);
+        if (pr.action == PolarityAction::Flip && pick == 1) flipped1 = true;
+        if (pr.action == PolarityAction::Flip && pick == 2) flipped2 = true;
+        pol[pick] = pr.state;
+    }
+    TEST_ASSERT_TRUE(flipped1);
+    TEST_ASSERT_TRUE(flipped2);
+    TEST_ASSERT_FALSE(pol[1].armed);
+    TEST_ASSERT_FALSE(pol[2].armed);
+}
+
+void test_full_17_channel_no_starvation(void) {
+    // Production array size: 17 channels (ch0 + 16 mux), all active LOAD, equal load.
+    // Every schedulable channel must be serviced and none may monopolise.
+    const uint8_t N = 17;
+    const uint8_t START = 1;
+    ChannelWeightInput in[N];
+    bool active[N];
+    float deficits[N];
+    float weights[N];
+    for (uint8_t i = 0; i < N; i++) {
+        in[i] = {i >= START, 100.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+        active[i] = (i >= START);
+        deficits[i] = 0.0f;
+        weights[i] = 0.0f;
+    }
+    uint8_t cursor = 0;
+    int picks[N] = {0};
+    for (int r = 0; r < 1600; r++) {
+        computeWeights(in, N, START, WCFG, weights);
+        wdrrAccumulate(weights, deficits, active, N, START, 5.0f);
+        uint8_t p = wdrrPick(deficits, active, N, START, &cursor);
+        TEST_ASSERT_NOT_EQUAL(NO_CHANNEL, p);
+        picks[p]++;
+    }
+    // 16 equal channels over 1600 rounds -> ~100 each. Assert balanced, none starved.
+    for (uint8_t i = START; i < N; i++) {
+        TEST_ASSERT_TRUE(picks[i] > 50);
+        TEST_ASSERT_TRUE(picks[i] < 200);
+    }
+}
+
+void test_mixed_fleet_grid_battery_sampled_more(void) {
+    // grid + battery (priority roles) vs load + PV: priority roles sampled clearly
+    // more often, and nothing is starved.
+    const uint8_t N = 6;
+    const uint8_t START = 1;
+    ChannelWeightInput in[N];
+    bool active[N];
+    float deficits[N];
+    float weights[N];
+    ChannelRole roles[N] = {CHANNEL_ROLE_LOAD, CHANNEL_ROLE_GRID, CHANNEL_ROLE_BATTERY,
+                            CHANNEL_ROLE_LOAD, CHANNEL_ROLE_LOAD, CHANNEL_ROLE_PV};
+    float power[N] = {0, 1000.0f, 500.0f, 300.0f, 200.0f, 400.0f};
+    for (uint8_t i = 0; i < N; i++) {
+        in[i] = {i >= START, power[i], 0.0f, false, roles[i]};
+        active[i] = (i >= START);
+        deficits[i] = 0.0f;
+        weights[i] = 0.0f;
+    }
+    uint8_t cursor = 0;
+    int picks[N] = {0};
+    for (int r = 0; r < 2000; r++) {
+        computeWeights(in, N, START, WCFG, weights);
+        wdrrAccumulate(weights, deficits, active, N, START, 5.0f);
+        uint8_t p = wdrrPick(deficits, active, N, START, &cursor);
+        picks[p]++;
+    }
+    TEST_ASSERT_TRUE(picks[1] > picks[3]); // grid > load
+    TEST_ASSERT_TRUE(picks[2] > picks[3]); // battery > load
+    TEST_ASSERT_TRUE(picks[1] > picks[5]); // grid > PV
+    for (uint8_t i = START; i < N; i++) TEST_ASSERT_TRUE(picks[i] > 50); // none starved
+}
+
+// ============================================================================
+// runner
+// ============================================================================
+
+int main(int, char **) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_polarity_not_armed_is_noop);
+    RUN_TEST(test_polarity_steady_reverse_flips_at_threshold);
+    RUN_TEST(test_polarity_steady_forward_confirms_without_flip);
+    RUN_TEST(test_polarity_is_magnitude_independent);
+    RUN_TEST(test_polarity_idle_is_noop_and_stays_armed);
+    RUN_TEST(test_polarity_nan_is_noop);
+    RUN_TEST(test_polarity_delayed_load_still_detects);
+    RUN_TEST(test_polarity_oscillating_conducting_disarms_via_bound);
+    RUN_TEST(test_polarity_unbounded_oscillation_never_disarms);
+
+    RUN_TEST(test_clamp_load_and_pv_negatives);
+    RUN_TEST(test_clamp_allows_grid_battery_inverter_negatives);
+    RUN_TEST(test_clamp_never_touches_positive);
+
+    RUN_TEST(test_role_priority_grid_battery_only);
+    RUN_TEST(test_weight_inactive_is_zero);
+    RUN_TEST(test_weight_idle_load_is_min_base);
+    RUN_TEST(test_weight_grid_gets_multiplier);
+    RUN_TEST(test_weight_armed_boost_only_when_conducting);
+    RUN_TEST(test_weight_shares_contribute);
+    RUN_TEST(test_computeWeights_zeroes_channel_zero_and_handles_nan);
+
+    RUN_TEST(test_find_starved_channel);
+    RUN_TEST(test_find_starved_skips_unbaselined_and_inactive);
+    RUN_TEST(test_find_starved_none);
+    RUN_TEST(test_wdrr_accumulate_gains_zeroes_and_clamps);
+    RUN_TEST(test_wdrr_pick_highest_deficit);
+    RUN_TEST(test_wdrr_pick_all_inactive_returns_invalid);
+    RUN_TEST(test_wdrr_tie_break_rotates_no_monopoly);
+
+    RUN_TEST(test_armed_no_load_channel_does_not_starve_peers);
+    RUN_TEST(test_armed_conducting_channel_resolves_quickly);
+    RUN_TEST(test_grid_sampled_more_often_than_load);
+
+    // Additional coverage
+    RUN_TEST(test_polarity_nonpositive_threshold_is_noop);
+    RUN_TEST(test_polarity_threshold_one_decides_immediately);
+    RUN_TEST(test_polarity_one_below_threshold_stays_armed);
+    RUN_TEST(test_polarity_flip_takes_precedence_over_bound);
+    RUN_TEST(test_polarity_bound_disarms_without_flip);
+    RUN_TEST(test_polarity_vote_recovers_and_confirms);
+    RUN_TEST(test_polarity_vote_recovers_and_flips);
+    RUN_TEST(test_polarity_disarmed_mid_sequence_is_noop);
+
+    RUN_TEST(test_weight_grid_armed_conducting_all_bumps_stack);
+    RUN_TEST(test_computeWeights_battery_gets_multiplier);
+    RUN_TEST(test_computeWeights_tiny_channel_gets_min_base);
+    RUN_TEST(test_computeWeights_all_inactive_all_zeros);
+    RUN_TEST(test_computeWeights_variability_differentiates_equal_power);
+
+    RUN_TEST(test_find_starved_returns_lowest_index_when_multiple);
+    RUN_TEST(test_find_starved_exactly_at_gap_is_not_starved);
+    RUN_TEST(test_find_starved_now_before_lastMillis_returns_channel);
+    RUN_TEST(test_wdrr_accumulate_nan_weight_is_zeroed);
+    RUN_TEST(test_wdrr_accumulate_clamps_negative);
+    RUN_TEST(test_wdrr_pick_single_channel_always_wins);
+    RUN_TEST(test_wdrr_pick_cursor_wraps_at_end);
+    RUN_TEST(test_wdrr_pick_tie_goes_to_channel_after_cursor);
+    RUN_TEST(test_wdrr_pick_all_negative_deficits_picks_max);
+
+    RUN_TEST(test_multiple_armed_channels_both_resolve);
+    RUN_TEST(test_full_17_channel_no_starvation);
+    RUN_TEST(test_mixed_fleet_grid_battery_sampled_more);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## What

Extracts the ADE7953 measurement and scheduling decisions into a pure, Arduino-free library (`lib/meter_logic`) and wires the firmware to it. This makes the logic behind the recent measurement gaps unit-testable on the host, and fixes the dev-bench starvation regression introduced by the first version of this branch.

### Library (`lib/meter_logic`, host-testable)
- **CT-reversal detector** (`updatePolarity`): net consistent-sign vote over conducting samples; flips the reverse flag at the threshold, confirms on the opposite run. Magnitude-independent and transient-immune. A non-conducting reading is a no-op, so a CT clipped on a circuit that is **off** at install time stays armed and is still checked the moment load first flows.
- **Negative clamp** (`shouldClampNegative`): load/PV clamp to 0; grid/battery/inverter may legitimately go negative.
- **WDRR weighting + scheduler core** (`computeWeights`, `findStarvedChannel`, `wdrrAccumulate`, `wdrrPick`).

### Behaviour changes
- **Conduction-gated boost (fixes the regression):** the CT-detection scheduler boost applies only while the armed channel is conducting. An armed channel with no load no longer hogs the scheduler and starves its peers - this was causing the repeated 15 s `scheduler starvation` gaps seen on the dev device after toggling a channel. The conduction signal is captured **before** the negative clamp, so a reversed load/PV (stored clamped to 0) still earns the boost and resolves in ~1 s, the same as grid/battery.
- **Grid/battery 2x sampling priority:** grid and battery channels get a 2x weight multiplier so mains and storage flow are sampled more often (matters most on three-phase).

## Testing

- **55 host unit tests** (`pio test -e native`) cover every function plus boundary/precedence cases, multi-channel interactions, the full 17-channel array, the no-load-armed-channel scenario, and the clamped-reversed-load-still-boosted case. All green.
- Native compilation is unreliable on Windows; **run the tests from WSL**.
- **Scope of what is verified:** the unit tests verify the *library logic* only. The firmware integration (`ade7953.cpp`) is compiled by CI (the first real build), not locally. On-device CT-reversal **detection** is NOT exercised by an idle bench - it needs a channel with real load and a deliberately reversed CT to see a vote -> flip.

## Manual test steps (dev device, via CI artifact)
1. Flash the dev firmware built by CI.
2. **No-starvation check (no load needed):** activate then deactivate a channel. Confirm no channel logs `scheduler starvation` repeatedly and meter data has no >15 s gaps. Previously an armed idle channel starved its peers to the 15 s watchdog floor.
3. **Reversal detection (needs real load):** on a channel carrying load, clip the CT reversed (or toggle its `reverse` in config off then on to re-arm). Within ~1 s of load flowing, expect a `CT reversal detected` INFO log and the reading to turn positive. This now resolves fast for plain loads/PV too, not just grid/battery.
4. **Grid/battery cadence:** confirm grid/battery channels sample ~2x more often than equivalent loads (Grafana sampling panel).
