### PR TITLE
feat: live per-phase preview and PF readout for installer phase assignment

### DIFF
--- a/source/html/channel.html
+++ b/source/html/channel.html
@@ -377,12 +377,15 @@
                     // Only show power if channel is active
                     if (powerElement && channelData[index] && channelData[index].active &&
                         channelMeterData.data && channelMeterData.data.activePower !== undefined) {
-                        // Absolute PF: in this firmware the PF sign carries inductive/capacitive,
-                        // not flow direction (that is the sign of active power)
-                        const pfText = channelMeterData.data.apparentPower > 0
-                            ? ` &middot; PF ${Math.abs(channelMeterData.data.powerFactor).toFixed(2)}`
+                        // Current and absolute PF only on a genuine reading: zeroed readings
+                        // (no-load / noise / clamp) have PF 0 by design, which carries no
+                        // information. PF sign carries inductive/capacitive in this firmware,
+                        // not flow direction (that is the sign of active power).
+                        const d = channelMeterData.data;
+                        const extraText = d.apparentPower > 0
+                            ? ` &middot; ${d.current.toFixed(3)} A &middot; PF ${Math.abs(d.powerFactor).toFixed(2)}`
                             : '';
-                        powerElement.innerHTML = `${channelMeterData.data.activePower.toFixed(1)} W${pfText}`;
+                        powerElement.innerHTML = `${d.activePower.toFixed(1)} W${extraText}`;
                         updatePhasePreview(index, channelMeterData.data);
                     } else if (powerElement && channelData[index] && !channelData[index].active) {
                         // Clear power display for inactive channels

--- a/source/html/channel.html
+++ b/source/html/channel.html
@@ -201,7 +201,10 @@
                     <span class="info-tooltip">
                         <button class="info-tooltip-icon" onclick="toggleTooltip(this, event)" aria-label="More info about Phase">ⓘ</button>
                         <div class="info-tooltip-popover" role="tooltip">
-                            The AC phase this CT is measuring. For single-phase or standard split-phase loads use Phase 1. For 3-phase installations, assign each CT to its matching phase so voltage and current are in sync. While the load is drawing power, the live preview below shows what each phase choice would read &ndash; the right one typically shows positive power with PF close to 1. Channel 0 carries the voltage reference, so its phase is correct by definition. <strong>240V (Split Phase)</strong> is for North American 240V circuits spanning both L1 and L2 legs; the firmware automatically applies a ×2 voltage multiplier because the reference voltage is measured line-to-neutral (about 120&nbsp;V) while the circuit operates at 240&nbsp;V line-to-line.
+                            The AC phase this CT is measuring.<br><br>
+                            <strong>Single-phase</strong>: leave everything on Phase 1.<br><br>
+                            <strong>3-phase</strong>: assign each CT to its physical phase. While the load is drawing power, the live preview below shows what each choice would read &ndash; the right one shows positive power with PF close to 1. Channel 0 carries the voltage reference, so its phase is correct by definition.<br><br>
+                            <strong>240V (Split Phase)</strong>: North American 240V circuits spanning both legs. A ×2 voltage multiplier is applied automatically, since the reference voltage is measured line-to-neutral (about 120&nbsp;V).
                         </div>
                     </span>
                     <select id="phase${index}" onchange="queueChannelUpdate(${index})">
@@ -216,7 +219,8 @@
                     <span class="info-tooltip">
                         <button class="info-tooltip-icon" onclick="toggleTooltip(this, event)" aria-label="More info about Reverse">ⓘ</button>
                         <div class="info-tooltip-popover" role="tooltip">
-                            Inverted CT readings? Do not worry: software comes to the rescue! Check "Reverse" to flip the sign of all readings from this channel.
+                            Flips the sign of all readings from this channel. You should rarely need it: when current first flows, the firmware detects a reversed CT and sets this flag by itself.<br><br>
+                            Note that loads never display negative power (negative readings are clamped to 0&nbsp;W), so a reversed CT reads 0&nbsp;W until the auto-detection corrects it &ndash; usually within seconds of real load. Changing it manually disables auto-detection for this channel.
                         </div>
                     </span>
                 </label>

--- a/source/html/channel.html
+++ b/source/html/channel.html
@@ -201,16 +201,14 @@
                     <span class="info-tooltip">
                         <button class="info-tooltip-icon" onclick="toggleTooltip(this, event)" aria-label="More info about Phase">ⓘ</button>
                         <div class="info-tooltip-popover" role="tooltip">
-                            The AC phase this CT is measuring. For single-phase or standard split-phase loads use Phase 1. For 3-phase installations, assign each CT to its matching phase so voltage and current are in sync. While the load is drawing power, the live preview below shows what each phase choice would read &ndash; the right one typically shows positive power with PF close to 1. Channel 0 carries the voltage reference, so it has no preview: every other channel's phase is measured relative to it. <strong>240V (Split Phase)</strong> is for North American 240V circuits spanning both L1 and L2 legs; the firmware automatically applies a ×2 voltage multiplier because the reference voltage is measured line-to-neutral (about 120&nbsp;V) while the circuit operates at 240&nbsp;V line-to-line.
+                            The AC phase this CT is measuring. For single-phase or standard split-phase loads use Phase 1. For 3-phase installations, assign each CT to its matching phase so voltage and current are in sync. While the load is drawing power, the live preview below shows what each phase choice would read &ndash; the right one typically shows positive power with PF close to 1. Channel 0 carries the voltage reference, so its phase is correct by definition. <strong>240V (Split Phase)</strong> is for North American 240V circuits spanning both L1 and L2 legs; the firmware automatically applies a ×2 voltage multiplier because the reference voltage is measured line-to-neutral (about 120&nbsp;V) while the circuit operates at 240&nbsp;V line-to-line.
                         </div>
                     </span>
                     <select id="phase${index}" onchange="queueChannelUpdate(${index})">
                         ${phaseOptions}
                     </select>
                 </label>
-                ${isChannel0
-                    ? '<div class="phase-preview">Voltage reference &ndash; the phases of all other channels are measured relative to this one, so its own assignment is correct by definition</div>'
-                    : `<div id="phasePreview${index}" class="phase-preview"></div>`}
+                <div id="phasePreview${index}" class="phase-preview"></div>
                 <div style="height: 10px;"></div>
                 <label>
                     <input type="checkbox" ${channel.reverse ? 'checked' : ''} id="reverse${index}" onchange="queueChannelUpdate(${index})">
@@ -297,7 +295,9 @@
     const PHASE_ANGLES_DEG = { 1: 0, 2: 120, 3: -120 }; // same convention as firmware
 
     function isThreePhaseInstall() {
-        return Object.values(channelData).some(ch => ch && ch.active && (ch.phase === 2 || ch.phase === 3));
+        const basePhase = channelData[0] ? channelData[0].phase : 1;
+        return Object.values(channelData).some(ch => ch && ch.active &&
+            (ch.phase in PHASE_ANGLES_DEG) && ch.phase !== basePhase);
     }
 
     function computePhaseCandidates(channel, basePhase, data) {
@@ -333,6 +333,13 @@
         if (!channel || !channel.active || !isThreePhaseInstall() ||
             !(channel.phase in PHASE_ANGLES_DEG) || !(basePhase in PHASE_ANGLES_DEG)) {
             el.innerHTML = '';
+            return;
+        }
+
+        // Channel 0 carries the voltage reference: its phase defines the frame the
+        // other channels are measured in, so candidates for it are meaningless.
+        if (index == 0) {
+            el.innerHTML = 'Voltage reference &ndash; defines the phases of all other channels';
             return;
         }
 

--- a/source/html/channel.html
+++ b/source/html/channel.html
@@ -287,9 +287,14 @@
                     const powerElement = document.getElementById(`power${index}`);
                     
                     // Only show power if channel is active
-                    if (powerElement && channelData[index] && channelData[index].active && 
+                    if (powerElement && channelData[index] && channelData[index].active &&
                         channelMeterData.data && channelMeterData.data.activePower !== undefined) {
-                        powerElement.innerHTML = `${channelMeterData.data.activePower.toFixed(1)} W`;
+                        // Absolute PF: in this firmware the PF sign carries inductive/capacitive,
+                        // not flow direction (that is the sign of active power)
+                        const pfText = channelMeterData.data.apparentPower > 0
+                            ? ` &middot; PF ${Math.abs(channelMeterData.data.powerFactor).toFixed(2)}`
+                            : '';
+                        powerElement.innerHTML = `${channelMeterData.data.activePower.toFixed(1)} W${pfText}`;
                     } else if (powerElement && channelData[index] && !channelData[index].active) {
                         // Clear power display for inactive channels
                         powerElement.innerHTML = '';

--- a/source/html/channel.html
+++ b/source/html/channel.html
@@ -33,7 +33,18 @@
             width: 90%;
             box-sizing: border-box;
         }
-        
+
+        .phase-preview {
+            font-size: 0.85em;
+            color: #666;
+            margin-top: 6px;
+            min-height: 1em;
+        }
+
+        .phase-preview strong {
+            color: #2e7d32;
+        }
+
         /* Page-specific mobile styles */
         @media screen and (max-width: 768px) {
             .channel-columns {
@@ -190,13 +201,16 @@
                     <span class="info-tooltip">
                         <button class="info-tooltip-icon" onclick="toggleTooltip(this, event)" aria-label="More info about Phase">ⓘ</button>
                         <div class="info-tooltip-popover" role="tooltip">
-                            The AC phase this CT is measuring. For single-phase or standard split-phase loads use Phase 1. For 3-phase installations, assign each CT to its matching phase so voltage and current are in sync. <strong>240V (Split Phase)</strong> is for North American 240V circuits spanning both L1 and L2 legs; the firmware automatically applies a ×2 voltage multiplier because the reference voltage is measured line-to-neutral (about 120&nbsp;V) while the circuit operates at 240&nbsp;V line-to-line.
+                            The AC phase this CT is measuring. For single-phase or standard split-phase loads use Phase 1. For 3-phase installations, assign each CT to its matching phase so voltage and current are in sync. While the load is drawing power, the live preview below shows what each phase choice would read &ndash; the right one typically shows positive power with PF close to 1. Channel 0 carries the voltage reference, so it has no preview: every other channel's phase is measured relative to it. <strong>240V (Split Phase)</strong> is for North American 240V circuits spanning both L1 and L2 legs; the firmware automatically applies a ×2 voltage multiplier because the reference voltage is measured line-to-neutral (about 120&nbsp;V) while the circuit operates at 240&nbsp;V line-to-line.
                         </div>
                     </span>
                     <select id="phase${index}" onchange="queueChannelUpdate(${index})">
                         ${phaseOptions}
                     </select>
                 </label>
+                ${isChannel0
+                    ? '<div class="phase-preview">Voltage reference &ndash; the phases of all other channels are measured relative to this one, so its own assignment is correct by definition</div>'
+                    : `<div id="phasePreview${index}" class="phase-preview"></div>`}
                 <div style="height: 10px;"></div>
                 <label>
                     <input type="checkbox" ${channel.reverse ? 'checked' : ''} id="reverse${index}" onchange="queueChannelUpdate(${index})">
@@ -271,6 +285,73 @@
         startGlobalPowerUpdates();
     }
 
+    // Live "what would each phase read" preview for 3-phase installs.
+    //
+    // The single voltage reference (L1) means a channel's phase assignment is pure
+    // math on the measured angle between voltage and current: the firmware rotates
+    // it by 0/+120/-120 degrees (phase 1/2/3, see _calculatePhaseShift in
+    // src/ade7953.cpp). So from one published reading (P, Q, S) we can reconstruct
+    // that angle and show what active power and PF every phase choice would yield -
+    // the installer picks the one that looks like a real load (PF near 1, plausible
+    // sign) instead of guessing from the breaker panel.
+    const PHASE_ANGLES_DEG = { 1: 0, 2: 120, 3: -120 }; // same convention as firmware
+
+    function isThreePhaseInstall() {
+        return Object.values(channelData).some(ch => ch && ch.active && (ch.phase === 2 || ch.phase === 3));
+    }
+
+    function computePhaseCandidates(channel, basePhase, data) {
+        const p = data.activePower, q = data.reactivePower, s = data.apparentPower;
+        if (!(s > 0)) return { state: 'noload' };
+        // Negative reading clamped to zero this cycle (load/PV): angle not recoverable
+        if (p === 0) return { state: 'clamped' };
+
+        // The two firmware measurement branches publish reactivePower with different
+        // sign conventions: the energy-register branch (configured phase == base
+        // phase) gives the chip's signed Q, while the angle branch applies sign(PF),
+        // which mirrors Q whenever active power is negative. Undo that so atan2
+        // always sees the angle in the same frame as the published active power.
+        const revSign = channel.reverse ? -1 : 1;
+        const qEff = (channel.phase === basePhase) ? q : q * Math.sign(p) * revSign;
+        const psi = Math.atan2(qEff, p);
+
+        const candidates = {};
+        [1, 2, 3].forEach(c => {
+            const deltaRad = (PHASE_ANGLES_DEG[c] - PHASE_ANGLES_DEG[channel.phase]) * Math.PI / 180;
+            const cosC = Math.cos(psi + deltaRad);
+            candidates[c] = { power: s * cosC, pf: Math.abs(cosC) };
+        });
+        return { state: 'ok', candidates };
+    }
+
+    function updatePhasePreview(index, data) {
+        const el = document.getElementById(`phasePreview${index}`);
+        if (!el) return;
+
+        const channel = channelData[index];
+        const basePhase = channelData[0] ? channelData[0].phase : 1;
+        if (!channel || !channel.active || !isThreePhaseInstall() ||
+            !(channel.phase in PHASE_ANGLES_DEG) || !(basePhase in PHASE_ANGLES_DEG)) {
+            el.innerHTML = '';
+            return;
+        }
+
+        const res = computePhaseCandidates(channel, basePhase, data);
+        if (res.state === 'noload') {
+            el.innerHTML = 'No load &ndash; phase preview unavailable';
+            return;
+        }
+        if (res.state === 'clamped') return; // transient, keep last preview
+
+        const bestPhase = [1, 2, 3].reduce((best, c) =>
+            res.candidates[c].pf > res.candidates[best].pf ? c : best, 1);
+        el.innerHTML = [1, 2, 3].map(c => {
+            const cand = res.candidates[c];
+            const text = `L${c}: ${cand.power.toFixed(1)} W (PF ${cand.pf.toFixed(2)})`;
+            return c === bestPhase ? `<strong>${text}</strong>` : text;
+        }).join('<br>');
+    }
+
     function startGlobalPowerUpdates() {
         // Stop any existing interval
         if (powerUpdateInterval) {
@@ -295,6 +376,7 @@
                             ? ` &middot; PF ${Math.abs(channelMeterData.data.powerFactor).toFixed(2)}`
                             : '';
                         powerElement.innerHTML = `${channelMeterData.data.activePower.toFixed(1)} W${pfText}`;
+                        updatePhasePreview(index, channelMeterData.data);
                     } else if (powerElement && channelData[index] && !channelData[index].active) {
                         // Clear power display for inactive channels
                         powerElement.innerHTML = '';
@@ -342,6 +424,10 @@
         const powerElement = document.getElementById(`power${index}`);
         if (powerElement) {
             powerElement.innerHTML = '';
+        }
+        const previewElement = document.getElementById(`phasePreview${index}`);
+        if (previewElement) {
+            previewElement.innerHTML = '';
         }
     }
 

--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -230,8 +230,8 @@
 
 // Guardrails and thresholds
 #define MAXIMUM_POWER_FACTOR_CLAMP 1.10f // Values above 1 but below this are still accepted (rounding errors and similar). I noticed I still had a lot of spurious readings with PF around 1.06-1.07 (mainly close to fridge activations, probably due to the compressor)
-#define MINIMUM_CURRENT_THREE_PHASE_APPROXIMATION_NO_LOAD 0.01f // The minimum current value for the three-phase approximation to be used as the no-load feature cannot be used
-#define MINIMUM_CURRENT_FOR_VALIDATION 0.02f // Below this current threshold, skip invalidating the reading as measurements are unreliable (noise dominates)
+#define MINIMUM_CURRENT_RATIO_THREE_PHASE_NO_LOAD 0.0005f // 5/10000 of the CT rating: below this the three-phase approximation reads as no-load (the hardware no-load feature only covers the base-phase energy registers)
+#define MINIMUM_CURRENT_RATIO_VALIDATION 0.001f // 10/10000 of the CT rating: below this, measurements are noise-dominated - zero the reading instead of invalidating it, and it carries no polarity-vote/boost information
 #define MINIMUM_POWER_FACTOR 0.10f // Measuring such low power factors is virtually impossible with such CTs
 #define POLARITY_DETECT_VOTE_THRESHOLD 5 // Net consistent-sign votes (over conducting samples) needed to decide CT orientation. Magnitude-independent, so a steady -4 W reversed CT is caught like a -4 kW one
 #define POLARITY_DETECT_MAX_CONDUCTING_READS 40 // Give up CT-reversal detection after this many CONDUCTING reads without a decision (only trips on a sign-oscillating channel; a no-load channel waits indefinitely)

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -770,10 +770,11 @@ namespace Ade7953
             return false;
         }
 
-        // Snapshot old role, active state, and reverse flag before applying new data
+        // Snapshot old role, active state, reverse flag and phase before applying new data
         ChannelRole oldRole = _channelData[channelIndex].role;
         bool wasInactive = !_channelData[channelIndex].active;
         bool oldReverse = _channelData[channelIndex].reverse;
+        Phase oldPhase = _channelData[channelIndex].phase;
 
         if (!acquireMutex(&_channelDataMutex)) {
             LOG_ERROR("Failed to acquire mutex for channel data");
@@ -802,6 +803,7 @@ namespace Ade7953
             bool reverseChanged = (oldReverse != _channelData[channelIndex].reverse);
             bool activated = (wasInactive && _channelData[channelIndex].active);
             bool roleChangedActive = (!wasInactive && _channelData[channelIndex].active && oldRole != _channelData[channelIndex].role);
+            bool phaseChangedActive = (!wasInactive && _channelData[channelIndex].active && oldPhase != _channelData[channelIndex].phase);
 
             if (reverseChanged) {
                 // A manual reverse change is the trusted value: disarm CT-reversal
@@ -812,10 +814,16 @@ namespace Ade7953
                 _polarityVoteCount[channelIndex] = 0;
                 _polarityConductingReads[channelIndex] = 0;
                 if (channelIndex > 0) _channelData[channelIndex]._pendingPriorityRead = true;
-            } else if (activated || roleChangedActive) {
-                // Fresh activation / role change with no explicit polarity choice: arm
-                // auto-detection from a clean vote count. The sign convention can
-                // legitimately differ between roles, so a role change re-validates.
+            } else if (activated || roleChangedActive || phaseChangedActive) {
+                // Fresh activation / role / phase change with no explicit polarity
+                // choice: arm auto-detection from a clean vote count. The sign
+                // convention can legitimately differ between roles, so a role change
+                // re-validates. A phase change invalidates the detector's premise
+                // outright (the sign of active power is only meaningful if the phase
+                // is right), and re-arming also self-heals the stale case where a
+                // wrong phase made a correctly-wired CT read steady-negative and the
+                // detector flipped reverse: once the user fixes the phase, the next
+                // votes flip it back within seconds (issue #174).
                 _channelData[channelIndex]._pendingPolarityCheck = true;
                 _polarityVoteCount[channelIndex] = 0;
                 _polarityConductingReads[channelIndex] = 0;

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -3637,6 +3637,12 @@ namespace Ade7953
 
         Phase basePhase = _channelData[0].phase; // Not using channelData since it is only accessed here and it is an integer so very low probability of race condition
 
+        // Noise floors scale with the CT: a fixed threshold suited to a 30 A clamp is far
+        // below the offset noise of a 100 A one (and too strict for a small one), so both
+        // thresholds are fractions of the channel's CT rating. At 30 A: 15 mA / 30 mA.
+        float minCurrentThreePhaseNoLoad = channelData.ctSpecification.currentRating * MINIMUM_CURRENT_RATIO_THREE_PHASE_NO_LOAD;
+        float minCurrentValidation = channelData.ctSpecification.currentRating * MINIMUM_CURRENT_RATIO_VALIDATION;
+
         // Split-phase 240V circuits use same-phase path (only 180° shift, so only the sign changes) so we can use the accurate energy registers, but accounting for a 2x multiplier
         bool isSplitPhase240 = (channelData.phase == PHASE_SPLIT_240);
         if (channelData.phase == basePhase || isSplitPhase240) { // The phase is not necessarily PHASE_A, so use as reference the one of channel A
@@ -3749,6 +3755,18 @@ namespace Ade7953
             apparentPower = current * voltage; // S = Vrms * Irms
             activePower = current * voltage * abs(powerFactor) * (channelData.reverse ? -1.0f : 1.0f) * (isActivePowerNegative ? -1.0f : 1.0f); // P = Vrms * Irms * PF
             reactivePower = float(sqrt(pow(apparentPower, 2) - pow(activePower, 2))) * (channelData.reverse ? -1.0f : 1.0f) * (powerFactor >= 0 ? 1.0f : -1.0f); // Q = sqrt(S^2 - P^2) * sign(PF)
+
+            // Synthetic no-load: the ADE7953's no-load feature only gates the energy
+            // registers of the base-phase branch; here a sub-threshold current is offset
+            // noise reading a garbage angle, so zero the whole reading. This keeps the
+            // published contract "nonzero values are reliable" (the web UI relies on it).
+            if (current < minCurrentThreePhaseNoLoad) {
+                current = 0.0f;
+                activePower = 0.0f;
+                reactivePower = 0.0f;
+                apparentPower = 0.0f;
+                powerFactor = 0.0f;
+            }
         }
 
         apparentPower = abs(apparentPower); // Apparent power must be positive
@@ -3796,7 +3814,7 @@ namespace Ade7953
             !_validatePower(apparentPower) || 
             !_validatePowerFactor(powerFactor)
         ) {
-            if (current >= MINIMUM_CURRENT_FOR_VALIDATION) {
+            if (current >= minCurrentValidation) {
                 // If the measurement is invalid AND we have enough current flowing (thus we should be reading correct values), then discard the reading
                 LOG_WARNING("%s (%d): Invalid reading (%.1fV, %.1fW, %.3fA, %.1fVAr, %.1fVA, %.3f)", channelData.label, channelIndex, voltage, activePower, current, reactivePower, apparentPower, powerFactor);
                 _recordFailure();
@@ -3841,7 +3859,7 @@ namespace Ade7953
         // or earn the armed boost. The same signal drives _lastConducting below, so the
         // vote and the boost always agree on whether the channel is drawing power.
         bool conducting = MeterLogic::isConductingReading(
-            activePower, current, MINIMUM_CURRENT_FOR_VALIDATION);
+            activePower, current, minCurrentValidation);
 
         if (_channelData[channelIndex]._pendingPolarityCheck && conducting) {
             bool flipped = false;
@@ -3856,7 +3874,7 @@ namespace Ade7953
                     MeterLogic::PolarityConfig cfg{
                         POLARITY_DETECT_VOTE_THRESHOLD,
                         POLARITY_DETECT_MAX_CONDUCTING_READS,
-                        MINIMUM_CURRENT_FOR_VALIDATION
+                        minCurrentValidation
                     };
                     MeterLogic::PolarityResult res = MeterLogic::updatePolarity(state, activePower, current, cfg);
                     _polarityVoteCount[channelIndex] = res.state.voteCount;
@@ -3935,7 +3953,7 @@ namespace Ade7953
 
         // If the phase is not the phase of the main channel, set the energy not to 0 if the current
         // is above the threshold since we cannot use the ADE7593 no-load feature in this approximation
-        if (channelData.phase != basePhase && current > MINIMUM_CURRENT_THREE_PHASE_APPROXIMATION_NO_LOAD) {
+        if (channelData.phase != basePhase && current > minCurrentThreePhaseNoLoad) {
             activeEnergy = 1;
             reactiveEnergy = 1;
             apparentEnergy = 1;

--- a/source/test/test_meter_logic/test_meter_logic.cpp
+++ b/source/test/test_meter_logic/test_meter_logic.cpp
@@ -20,7 +20,7 @@ void tearDown(void) {}
 
 // Config values mirror the firmware defaults so the tests track real behaviour.
 static const WeightConfig WCFG = {0.4f, 0.4f, 0.1f, 1.5f, 2.0f};
-static const float MIN_A = 0.02f;              // MINIMUM_CURRENT_FOR_VALIDATION
+static const float MIN_A = 0.02f;              // validation threshold (firmware: CT rating * MINIMUM_CURRENT_RATIO_VALIDATION, e.g. 20 A * 0.001)
 static const PolarityConfig PCFG = {5, 50, MIN_A};
 static const float COND_A = 1.0f;              // a nominal "real load" current (>= MIN_A)
 


### PR DESCRIPTION
## Summary

Software-only install aid for 3-phase setups, replacing the interactive wizard proposed in #174: instead of detecting/judging, the channel page now *shows* and the installer decides.

- **Live PF readout** next to active power on every active channel (absolute PF; the sign carries inductive/capacitive, flow direction is already in the W sign). A heater steady at PF ~0.5 is the fingerprint of a wrong phase assignment - interpretation guidance belongs in the manual.
- **Per-phase preview** under the phase selector (rendered only when the install uses phase 2/3): from one published reading (P, Q, S) the page reconstructs the voltage-current angle and shows what each phase choice would read, highlighting the candidate with PF closest to 1. Handles both firmware publication conventions (energy-register branch vs angle branch, including the sign(PF) mirror on negative power) and the reverse flag. Channel 0 shows an explanatory notice instead: it carries the voltage reference, so its own phase is correct by definition.
- **Firmware: re-arm CT-polarity detection on a phase change.** The detector's premise (phase correct) is invalidated by a phase change; re-arming also self-heals the stale case where a wrong phase made a correctly-wired CT read steady-negative and the detector flipped `reverse` - after the user fixes the phase, the next conducting votes flip it back within seconds.

## Verification

- 63/63 native unit tests pass (`pio test -e native`, WSL)
- Candidate math verified against simulated firmware publications for both branches (wrong-phase field case reconstructs L2 +146 W / PF 1.00 from a published -73 W / PF -0.5 reading)
- E2E on bench device: OTA dev build, phase PATCH round-trip exercises the re-arm path with no false flip at no-load (conduction gate holds), no errors; UI behavior confirmed by Jibril with live loads

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)