### PR TITLE
fix(ade7953): lower conduction gate for small reversed loads (#180)

### DIFF
--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -231,7 +231,7 @@
 // Guardrails and thresholds
 #define MAXIMUM_POWER_FACTOR_CLAMP 1.10f // Values above 1 but below this are still accepted (rounding errors and similar). I noticed I still had a lot of spurious readings with PF around 1.06-1.07 (mainly close to fridge activations, probably due to the compressor)
 #define MINIMUM_CURRENT_RATIO_THREE_PHASE_NO_LOAD 0.0005f // 5/10000 of the CT rating: below this the three-phase approximation reads as no-load (the hardware no-load feature only covers the base-phase energy registers)
-#define MINIMUM_CURRENT_RATIO_VALIDATION 0.001f // 10/10000 of the CT rating: reserved for reference; the polarity-vote and WDRR-boost paths now use MINIMUM_CURRENT_RATIO_CONDUCTING
+#define MINIMUM_CURRENT_RATIO_VALIDATION 0.001f // 10/10000 of the CT rating: validation-discard gate - an electrically invalid reading at this current is a genuine failure worth logging
 #define MINIMUM_CURRENT_RATIO_CONDUCTING 0.0003f // 3/10000 of the CT rating: gate for the polarity-vote and WDRR-armed-boost path. Sits above the ADE7953 offset-noise floor (~0 A consistent-sign bias) yet below real small loads (~2 W on a 30 A CT = ~9 mA). Lower than MINIMUM_CURRENT_RATIO_VALIDATION so a reversed 2-3 W load still earns votes and the armed boost instead of reading a constant 0.
 #define MINIMUM_POWER_FACTOR 0.10f // Measuring such low power factors is virtually impossible with such CTs
 #define POLARITY_DETECT_VOTE_THRESHOLD 5 // Net consistent-sign votes (over conducting samples) needed to decide CT orientation. Magnitude-independent, so a steady -4 W reversed CT is caught like a -4 kW one

--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -231,7 +231,8 @@
 // Guardrails and thresholds
 #define MAXIMUM_POWER_FACTOR_CLAMP 1.10f // Values above 1 but below this are still accepted (rounding errors and similar). I noticed I still had a lot of spurious readings with PF around 1.06-1.07 (mainly close to fridge activations, probably due to the compressor)
 #define MINIMUM_CURRENT_RATIO_THREE_PHASE_NO_LOAD 0.0005f // 5/10000 of the CT rating: below this the three-phase approximation reads as no-load (the hardware no-load feature only covers the base-phase energy registers)
-#define MINIMUM_CURRENT_RATIO_VALIDATION 0.001f // 10/10000 of the CT rating: below this, measurements are noise-dominated, so it carries no polarity-vote/boost information
+#define MINIMUM_CURRENT_RATIO_VALIDATION 0.001f // 10/10000 of the CT rating: reserved for reference; the polarity-vote and WDRR-boost paths now use MINIMUM_CURRENT_RATIO_CONDUCTING
+#define MINIMUM_CURRENT_RATIO_CONDUCTING 0.0003f // 3/10000 of the CT rating: gate for the polarity-vote and WDRR-armed-boost path. Sits above the ADE7953 offset-noise floor (~0 A consistent-sign bias) yet below real small loads (~2 W on a 30 A CT = ~9 mA). Lower than MINIMUM_CURRENT_RATIO_VALIDATION so a reversed 2-3 W load still earns votes and the armed boost instead of reading a constant 0.
 #define MINIMUM_POWER_FACTOR 0.10f // Measuring such low power factors is virtually impossible with such CTs
 #define POLARITY_DETECT_VOTE_THRESHOLD 5 // Net consistent-sign votes (over conducting samples) needed to decide CT orientation. Magnitude-independent, so a steady -4 W reversed CT is caught like a -4 kW one
 #define POLARITY_DETECT_MAX_CONDUCTING_READS 40 // Give up CT-reversal detection after this many CONDUCTING reads without a decision (only trips on a sign-oscillating channel; a no-load channel waits indefinitely)

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -3656,7 +3656,8 @@ namespace Ade7953
         // below the offset noise of a 100 A one (and too strict for a small one), so both
         // thresholds are fractions of the channel's CT rating.
         float minCurrentThreePhaseNoLoad = channelData.ctSpecification.currentRating * MINIMUM_CURRENT_RATIO_THREE_PHASE_NO_LOAD;
-        float minCurrentConducting = channelData.ctSpecification.currentRating * MINIMUM_CURRENT_RATIO_CONDUCTING;
+        float minCurrentValidation = channelData.ctSpecification.currentRating * MINIMUM_CURRENT_RATIO_VALIDATION;   // validation discard: a reading invalid at this current is a real failure
+        float minCurrentConducting  = channelData.ctSpecification.currentRating * MINIMUM_CURRENT_RATIO_CONDUCTING;  // polarity-vote / WDRR-boost gate: lower, catches small real loads
 
         // Split-phase 240V circuits use same-phase path (only 180° shift, so only the sign changes) so we can use the accurate energy registers, but accounting for a 2x multiplier
         bool isSplitPhase240 = (channelData.phase == PHASE_SPLIT_240);

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -3656,7 +3656,7 @@ namespace Ade7953
         // below the offset noise of a 100 A one (and too strict for a small one), so both
         // thresholds are fractions of the channel's CT rating.
         float minCurrentThreePhaseNoLoad = channelData.ctSpecification.currentRating * MINIMUM_CURRENT_RATIO_THREE_PHASE_NO_LOAD;
-        float minCurrentValidation = channelData.ctSpecification.currentRating * MINIMUM_CURRENT_RATIO_VALIDATION;
+        float minCurrentConducting = channelData.ctSpecification.currentRating * MINIMUM_CURRENT_RATIO_CONDUCTING;
 
         // Split-phase 240V circuits use same-phase path (only 180° shift, so only the sign changes) so we can use the accurate energy registers, but accounting for a 2x multiplier
         bool isSplitPhase240 = (channelData.phase == PHASE_SPLIT_240);
@@ -3869,12 +3869,14 @@ namespace Ade7953
         // setChannelData arm/disarm is neither lost nor double-fired. (The unsynced
         // _pendingPolarityCheck pre-check is an atomic-bool fast path; it is re-tested
         // under the mutex before any state change.)
-        // Current-gate "conducting" so ADE7953 offset noise at ~0 A (a small, steady,
-        // signed power) cannot vote a false reversal on an unclamped role (grid/battery)
-        // or earn the armed boost. The same signal drives _lastConducting below, so the
-        // vote and the boost always agree on whether the channel is drawing power.
+        // Current-gate "conducting" with MINIMUM_CURRENT_RATIO_CONDUCTING (lower than the
+        // old MINIMUM_CURRENT_RATIO_VALIDATION) so small real loads (~2 W on a 30 A CT)
+        // still earn votes and the WDRR boost, while ADE7953 offset noise at near-zero
+        // current (consistent-sign but well below the gate) cannot vote a false reversal
+        // or hog the scheduler on an unclamped role (grid/battery). The same signal drives
+        // _lastConducting below, so the vote and the boost always agree.
         bool conducting = MeterLogic::isConductingReading(
-            activePower, current, minCurrentValidation);
+            activePower, current, minCurrentConducting);
 
         if (_channelData[channelIndex]._pendingPolarityCheck && conducting) {
             bool flipped = false;
@@ -3889,7 +3891,7 @@ namespace Ade7953
                     MeterLogic::PolarityConfig cfg{
                         POLARITY_DETECT_VOTE_THRESHOLD,
                         POLARITY_DETECT_MAX_CONDUCTING_READS,
-                        minCurrentValidation
+                        minCurrentConducting
                     };
                     MeterLogic::PolarityResult res = MeterLogic::updatePolarity(state, activePower, current, cfg);
                     _polarityVoteCount[channelIndex] = res.state.voteCount;

--- a/source/test/test_meter_logic/test_meter_logic.cpp
+++ b/source/test/test_meter_logic/test_meter_logic.cpp
@@ -21,8 +21,12 @@ void tearDown(void) {}
 // Config values mirror the firmware defaults so the tests track real behaviour.
 static const WeightConfig WCFG = {0.4f, 0.4f, 0.1f, 1.5f, 2.0f};
 static const float MIN_A = 0.02f;              // validation threshold (firmware: CT rating * MINIMUM_CURRENT_RATIO_VALIDATION, e.g. 20 A * 0.001)
+static const float COND_MIN_A = 0.006f;        // conducting gate (firmware: CT rating * MINIMUM_CURRENT_RATIO_CONDUCTING, e.g. 20 A * 0.0003)
 static const PolarityConfig PCFG = {5, 50, MIN_A};
+static const PolarityConfig PCFG_SMALL = {5, 50, COND_MIN_A}; // mirrors firmware cfg after the small-load-polarity fix
 static const float COND_A = 1.0f;              // a nominal "real load" current (>= MIN_A)
+static const float SMALL_LOAD_A = 0.009f;      // between COND_MIN_A and MIN_A: a real small load that should now vote
+static const float NOISE_A = 0.004f;           // below COND_MIN_A: offset noise that must never vote
 
 // ============================================================================
 // updatePolarity
@@ -913,6 +917,67 @@ void test_low_current_noise_does_not_burn_the_bound(void) {
 }
 
 // ============================================================================
+// Small-load conducting gate (#180: MINIMUM_CURRENT_RATIO_CONDUCTING)
+// ============================================================================
+
+void test_small_reversed_load_flips_with_conducting_gate(void) {
+    // THE REGRESSION from #180: a ~2.5 W reversed load on a 30 A CT sits below
+    // MINIMUM_CURRENT_RATIO_VALIDATION (~7 W) but above MINIMUM_CURRENT_RATIO_CONDUCTING
+    // (~2 W). With the old PCFG it was non-conducting and read a constant 0 forever.
+    // With PCFG_SMALL (the firmware's new cfg) it must vote and flip within threshold reads.
+    PolarityState s{true, 0, 0};
+    // SMALL_LOAD_A (0.009) > COND_MIN_A (0.006) but < MIN_A (0.02)
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 10; i++) {
+        PolarityResult r = updatePolarity(s, -2.5f, SMALL_LOAD_A, PCFG_SMALL);
+        s = r.state;
+        action = r.action;
+        if (action != PolarityAction::Continue) break;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Flip, action);
+
+    // Same load is non-conducting (and therefore never votes) with the old strict gate.
+    PolarityState s2{true, 0, 0};
+    for (int i = 0; i < 100; i++) {
+        PolarityResult r = updatePolarity(s2, -2.5f, SMALL_LOAD_A, PCFG);
+        s2 = r.state;
+        TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
+    }
+    TEST_ASSERT_TRUE(s2.armed);
+    TEST_ASSERT_EQUAL_INT8(0, s2.voteCount);
+}
+
+void test_noise_below_conducting_gate_does_not_vote(void) {
+    // Offset noise at NOISE_A (0.004 A) is below both gates. With PCFG_SMALL it must
+    // still produce no votes (the lower gate still excludes it).
+    PolarityState s{true, 0, 0};
+    for (int i = 0; i < 1000; i++) {
+        PolarityResult r = updatePolarity(s, 1.2f, NOISE_A, PCFG_SMALL);
+        s = r.state;
+        TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
+    }
+    TEST_ASSERT_TRUE(s.armed);
+    TEST_ASSERT_EQUAL_INT8(0, s.voteCount);
+    TEST_ASSERT_EQUAL_UINT16(0, s.conductingReads);
+}
+
+void test_small_reversed_load_earns_armed_boost(void) {
+    // isConductingReading with the new lower gate must return true for SMALL_LOAD_A,
+    // so the WDRR armed boost fires and the channel resolves quickly.
+    bool conducting = isConductingReading(-2.5f, SMALL_LOAD_A, COND_MIN_A);
+    TEST_ASSERT_TRUE(conducting);
+
+    // The same reading is non-conducting under the old strict gate.
+    bool notConductingOld = isConductingReading(-2.5f, SMALL_LOAD_A, MIN_A);
+    TEST_ASSERT_FALSE(notConductingOld);
+
+    // Verify the boost is awarded when conducting=true under the new gate.
+    ChannelWeightInput in{true, 0.0f /*clamped*/, 0.0f, true /*armed*/, CHANNEL_ROLE_LOAD, conducting};
+    float w = computeChannelWeight(in, 0.0f, 0.0f, WCFG);
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, WCFG.minBase + WCFG.armedBoost, w);
+}
+
+// ============================================================================
 // runner
 // ============================================================================
 
@@ -993,6 +1058,10 @@ int main(int, char **) {
     RUN_TEST(test_offset_noise_never_false_flips_unclamped_role);
     RUN_TEST(test_offset_noise_earns_no_boost);
     RUN_TEST(test_low_current_noise_does_not_burn_the_bound);
+
+    RUN_TEST(test_small_reversed_load_flips_with_conducting_gate);
+    RUN_TEST(test_noise_below_conducting_gate_does_not_vote);
+    RUN_TEST(test_small_reversed_load_earns_armed_boost);
 
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

- Introduces `MINIMUM_CURRENT_RATIO_CONDUCTING` (`0.0003` of CT rating) as a separate, lower gate used only by the polarity-vote and WDRR-armed-boost path
- A 2.5 W / 11 mA reversed load on a 30 A CT was silently reading 0 and never self-correcting because the old `MINIMUM_CURRENT_RATIO_VALIDATION` gate (~7 W on 30 A) excluded it from voting entirely
- With the new gate (~2 W on 30 A), small reversed loads earn the polarity vote and the armed boost, resolving in ~1-2 s like any larger reversed load
- Offset noise at near-zero current (calibrated hardware: well below 5 mA) stays below the new gate and cannot produce a false flip

## What changed

- `include/ade7953.h`: new `MINIMUM_CURRENT_RATIO_CONDUCTING 0.0003f` constant; old `MINIMUM_CURRENT_RATIO_VALIDATION` kept for reference
- `src/ade7953.cpp`: `minCurrentValidation` renamed to `minCurrentConducting`, computed from the new constant; used in `isConductingReading` and `PolarityConfig`
- `test/test_meter_logic/test_meter_logic.cpp`: 3 new tests covering the small-load flip, noise exclusion, and armed-boost award

## Test plan

- [x] `pio test -e native` - all 95 tests pass (3 new, 92 unchanged)
- [x] Hardware: activate a channel with a ~2-3 W reversed load on a 30 A CT and confirm it auto-flips within a few seconds instead of reading constant 0

Closes #180