### PR TITLE
feat(utils): add DurationFormat::humanizeDuration helper

### DIFF
--- a/source/CLAUDE.md
+++ b/source/CLAUDE.md
@@ -66,4 +66,4 @@ Firmware for the EnergyMe Home energy monitor. ESP32-S3-N16R2 (16 MB flash, 2 MB
 - Be concise; stick to the request.
 - **Never create new files (especially Markdown / docs) unless explicitly asked.** Propose first.
 - Don't remove TODO/FIXME comments unless the underlying task is actually done.
-- **Never run firmware builds** (`pio run`, `platformio run`, etc.). Jibril always compiles and flashes himself. After code edits, stop - do not verify via compilation.
+- **Don't compile on your own initiative** (`pio run`, `platformio run`, etc. are slow and CPU-intensive). Default after code edits: stop - do not verify via compilation. When Jibril explicitly asks for a build, or the task he assigned requires one (e.g. "test it on the dev device"), building and OTA-flashing the dev device is allowed.

--- a/source/html/calibration.html
+++ b/source/html/calibration.html
@@ -365,6 +365,7 @@
     </div>
 
     <script src="/js/api-client.js"></script>
+    <script src="/js/issues.js"></script>
     <script src="/js/tooltip.js"></script>
     <script>
         var channelData = {};

--- a/source/html/channel.html
+++ b/source/html/channel.html
@@ -128,6 +128,7 @@
 </body>
 
 <script src="/js/api-client.js"></script>
+<script src="/js/issues.js"></script>
 <script src="/js/tooltip.js"></script>
 <script>
     var channelData = {};
@@ -190,7 +191,7 @@
             const activeChecked = isChannel0 ? 'checked' : (channel.active ? 'checked' : '');
 
             box.innerHTML = `
-                <h3>Channel ${index}</h3>
+                <h3>Channel ${index}<span id="issueChip${index}"></span></h3>
                 <label>
                     Label:
                     <input type="text" value="${channel.label || ''}" id="label${index}" onchange="queueChannelUpdate(${index})">
@@ -203,7 +204,7 @@
                         <div class="info-tooltip-popover" role="tooltip">
                             The AC phase this CT is measuring.<br><br>
                             <strong>Single-phase</strong>: leave everything on Phase 1.<br><br>
-                            <strong>3-phase</strong>: assign each CT to its physical phase. While the load is drawing power, the live preview below shows what each choice would read &ndash; the right one shows positive power with PF close to 1. Channel 0 carries the voltage reference, so its phase is correct by definition.<br><br>
+                            <strong>3-phase</strong>: assign each CT to its physical phase. While the load is drawing power, the live preview below shows what each choice would read &ndash; the right one has PF close to 1 (the power sign is irrelevant, it just flips with the CT orientation). Channel 0 carries the voltage reference, so its phase is correct by definition.<br><br>
                             <strong>240V (Split Phase)</strong>: North American 240V circuits spanning both legs. A ×2 voltage multiplier is applied automatically, since the reference voltage is measured line-to-neutral (about 120&nbsp;V).
                         </div>
                     </span>
@@ -293,9 +294,10 @@
     // math on the measured angle between voltage and current: the firmware rotates
     // it by 0/+120/-120 degrees (phase 1/2/3, see _calculatePhaseShift in
     // src/ade7953.cpp). So from one published reading (P, Q, S) we can reconstruct
-    // that angle and show what active power and PF every phase choice would yield -
-    // the installer picks the one that looks like a real load (PF near 1, plausible
-    // sign) instead of guessing from the breaker panel.
+    // that angle and show what |active power| and PF every phase choice would yield -
+    // the installer picks the one that looks like a real load (PF near 1) instead of
+    // guessing from the breaker panel. The power sign is omitted: it is always
+    // flippable via the reverse flag, so it says nothing about the right phase.
     const PHASE_ANGLES_DEG = { 1: 0, 2: 120, 3: -120 }; // same convention as firmware
 
     function isThreePhaseInstall() {
@@ -358,7 +360,9 @@
             res.candidates[c].pf > res.candidates[best].pf ? c : best, 1);
         el.innerHTML = [1, 2, 3].map(c => {
             const cand = res.candidates[c];
-            const text = `L${c}: ${cand.power.toFixed(1)} W (PF ${cand.pf.toFixed(2)})`;
+            // Show |power|: the sign is always flippable via the reverse flag, so it
+            // carries no information about which phase is correct - PF magnitude does.
+            const text = `L${c}: ${Math.abs(cand.power).toFixed(1)} W (PF ${cand.pf.toFixed(2)})`;
             return c === bestPhase ? `<strong>${text}</strong>` : text;
         }).join('<br>');
     }
@@ -623,6 +627,17 @@
             startGlobalPowerUpdates();
         }
     }
+
+    // Channel-scoped issue chips, fed by the issues.js poll. A chip appears next
+    // to the channel title whenever the registry has a visible issue for it;
+    // clicking opens the shared issues panel.
+    window.addEventListener('energyme-issues', (event) => {
+        const issues = (event.detail && event.detail.issues) || [];
+        Object.keys(channelData).forEach(index => {
+            const chip = document.getElementById(`issueChip${index}`);
+            if (chip) window.energymeIssues.renderChip(chip, issues.filter(i => i.channel == index));
+        });
+    });
 
     async function resetChannelEnergy(channelIndex) {
         const channel = channelData[channelIndex];

--- a/source/html/channel.html
+++ b/source/html/channel.html
@@ -33,7 +33,18 @@
             width: 90%;
             box-sizing: border-box;
         }
-        
+
+        .phase-preview {
+            font-size: 0.85em;
+            color: #666;
+            margin-top: 6px;
+            min-height: 1em;
+        }
+
+        .phase-preview strong {
+            color: #2e7d32;
+        }
+
         /* Page-specific mobile styles */
         @media screen and (max-width: 768px) {
             .channel-columns {
@@ -190,13 +201,17 @@
                     <span class="info-tooltip">
                         <button class="info-tooltip-icon" onclick="toggleTooltip(this, event)" aria-label="More info about Phase">ⓘ</button>
                         <div class="info-tooltip-popover" role="tooltip">
-                            The AC phase this CT is measuring. For single-phase or standard split-phase loads use Phase 1. For 3-phase installations, assign each CT to its matching phase so voltage and current are in sync. <strong>240V (Split Phase)</strong> is for North American 240V circuits spanning both L1 and L2 legs; the firmware automatically applies a ×2 voltage multiplier because the reference voltage is measured line-to-neutral (about 120&nbsp;V) while the circuit operates at 240&nbsp;V line-to-line.
+                            The AC phase this CT is measuring.<br><br>
+                            <strong>Single-phase</strong>: leave everything on Phase 1.<br><br>
+                            <strong>3-phase</strong>: assign each CT to its physical phase. While the load is drawing power, the live preview below shows what each choice would read &ndash; the right one shows positive power with PF close to 1. Channel 0 carries the voltage reference, so its phase is correct by definition.<br><br>
+                            <strong>240V (Split Phase)</strong>: North American 240V circuits spanning both legs. A ×2 voltage multiplier is applied automatically, since the reference voltage is measured line-to-neutral (about 120&nbsp;V).
                         </div>
                     </span>
                     <select id="phase${index}" onchange="queueChannelUpdate(${index})">
                         ${phaseOptions}
                     </select>
                 </label>
+                <div id="phasePreview${index}" class="phase-preview"></div>
                 <div style="height: 10px;"></div>
                 <label>
                     <input type="checkbox" ${channel.reverse ? 'checked' : ''} id="reverse${index}" onchange="queueChannelUpdate(${index})">
@@ -204,7 +219,8 @@
                     <span class="info-tooltip">
                         <button class="info-tooltip-icon" onclick="toggleTooltip(this, event)" aria-label="More info about Reverse">ⓘ</button>
                         <div class="info-tooltip-popover" role="tooltip">
-                            Inverted CT readings? Do not worry: software comes to the rescue! Check "Reverse" to flip the sign of all readings from this channel.
+                            Flips the sign of all readings from this channel. You should rarely need it: when current first flows, the firmware detects a reversed CT and sets this flag by itself.<br><br>
+                            Note that loads never display negative power (negative readings are clamped to 0&nbsp;W), so a reversed CT reads 0&nbsp;W until the auto-detection corrects it &ndash; usually within seconds of real load. Changing it manually disables auto-detection for this channel.
                         </div>
                     </span>
                 </label>
@@ -271,6 +287,82 @@
         startGlobalPowerUpdates();
     }
 
+    // Live "what would each phase read" preview for 3-phase installs.
+    //
+    // The single voltage reference (L1) means a channel's phase assignment is pure
+    // math on the measured angle between voltage and current: the firmware rotates
+    // it by 0/+120/-120 degrees (phase 1/2/3, see _calculatePhaseShift in
+    // src/ade7953.cpp). So from one published reading (P, Q, S) we can reconstruct
+    // that angle and show what active power and PF every phase choice would yield -
+    // the installer picks the one that looks like a real load (PF near 1, plausible
+    // sign) instead of guessing from the breaker panel.
+    const PHASE_ANGLES_DEG = { 1: 0, 2: 120, 3: -120 }; // same convention as firmware
+
+    function isThreePhaseInstall() {
+        const basePhase = channelData[0] ? channelData[0].phase : 1;
+        return Object.values(channelData).some(ch => ch && ch.active &&
+            (ch.phase in PHASE_ANGLES_DEG) && ch.phase !== basePhase);
+    }
+
+    function computePhaseCandidates(channel, basePhase, data) {
+        const p = data.activePower, q = data.reactivePower, s = data.apparentPower;
+        if (!(s > 0)) return { state: 'noload' };
+        // Negative reading clamped to zero this cycle (load/PV): angle not recoverable
+        if (p === 0) return { state: 'clamped' };
+
+        // The two firmware measurement branches publish reactivePower with different
+        // sign conventions: the energy-register branch (configured phase == base
+        // phase) gives the chip's signed Q, while the angle branch applies sign(PF),
+        // which mirrors Q whenever active power is negative. Undo that so atan2
+        // always sees the angle in the same frame as the published active power.
+        const revSign = channel.reverse ? -1 : 1;
+        const qEff = (channel.phase === basePhase) ? q : q * Math.sign(p) * revSign;
+        const psi = Math.atan2(qEff, p);
+
+        const candidates = {};
+        [1, 2, 3].forEach(c => {
+            const deltaRad = (PHASE_ANGLES_DEG[c] - PHASE_ANGLES_DEG[channel.phase]) * Math.PI / 180;
+            const cosC = Math.cos(psi + deltaRad);
+            candidates[c] = { power: s * cosC, pf: Math.abs(cosC) };
+        });
+        return { state: 'ok', candidates };
+    }
+
+    function updatePhasePreview(index, data) {
+        const el = document.getElementById(`phasePreview${index}`);
+        if (!el) return;
+
+        const channel = channelData[index];
+        const basePhase = channelData[0] ? channelData[0].phase : 1;
+        if (!channel || !channel.active || !isThreePhaseInstall() ||
+            !(channel.phase in PHASE_ANGLES_DEG) || !(basePhase in PHASE_ANGLES_DEG)) {
+            el.innerHTML = '';
+            return;
+        }
+
+        // Channel 0 carries the voltage reference: its phase defines the frame the
+        // other channels are measured in, so candidates for it are meaningless.
+        if (index == 0) {
+            el.innerHTML = 'Voltage reference &ndash; defines the phases of all other channels';
+            return;
+        }
+
+        const res = computePhaseCandidates(channel, basePhase, data);
+        if (res.state === 'noload') {
+            el.innerHTML = 'No load &ndash; phase preview unavailable';
+            return;
+        }
+        if (res.state === 'clamped') return; // transient, keep last preview
+
+        const bestPhase = [1, 2, 3].reduce((best, c) =>
+            res.candidates[c].pf > res.candidates[best].pf ? c : best, 1);
+        el.innerHTML = [1, 2, 3].map(c => {
+            const cand = res.candidates[c];
+            const text = `L${c}: ${cand.power.toFixed(1)} W (PF ${cand.pf.toFixed(2)})`;
+            return c === bestPhase ? `<strong>${text}</strong>` : text;
+        }).join('<br>');
+    }
+
     function startGlobalPowerUpdates() {
         // Stop any existing interval
         if (powerUpdateInterval) {
@@ -287,9 +379,18 @@
                     const powerElement = document.getElementById(`power${index}`);
                     
                     // Only show power if channel is active
-                    if (powerElement && channelData[index] && channelData[index].active && 
+                    if (powerElement && channelData[index] && channelData[index].active &&
                         channelMeterData.data && channelMeterData.data.activePower !== undefined) {
-                        powerElement.innerHTML = `${channelMeterData.data.activePower.toFixed(1)} W`;
+                        // Current and absolute PF only on a genuine reading: zeroed readings
+                        // (no-load / noise / clamp) have PF 0 by design, which carries no
+                        // information. PF sign carries inductive/capacitive in this firmware,
+                        // not flow direction (that is the sign of active power).
+                        const d = channelMeterData.data;
+                        const extraText = d.apparentPower > 0
+                            ? ` &middot; ${d.current.toFixed(3)} A &middot; PF ${Math.abs(d.powerFactor).toFixed(2)}`
+                            : '';
+                        powerElement.innerHTML = `${d.activePower.toFixed(1)} W${extraText}`;
+                        updatePhasePreview(index, channelMeterData.data);
                     } else if (powerElement && channelData[index] && !channelData[index].active) {
                         // Clear power display for inactive channels
                         powerElement.innerHTML = '';
@@ -337,6 +438,10 @@
         const powerElement = document.getElementById(`power${index}`);
         if (powerElement) {
             powerElement.innerHTML = '';
+        }
+        const previewElement = document.getElementById(`phasePreview${index}`);
+        if (previewElement) {
+            previewElement.innerHTML = '';
         }
     }
 

--- a/source/html/configuration.html
+++ b/source/html/configuration.html
@@ -60,7 +60,7 @@
                 height: 20px;
                 margin: 10px 0;
             }
-            
+
             .slider::-webkit-slider-thumb {
                 width: 30px;
                 height: 30px;
@@ -71,6 +71,47 @@
                 height: 30px;
             }
 
+        }
+
+        .portal-banner {
+            display: none;
+            margin-top: 18px;
+            padding: 14px 18px;
+            background: linear-gradient(135deg, rgba(8,191,129,0.08), rgba(3,160,155,0.13));
+            border: 1px solid rgba(8,191,129,0.28);
+            border-radius: 12px;
+        }
+
+        .portal-banner p {
+            margin: 0 0 12px 0;
+            font-size: 0.88em;
+            color: #555;
+        }
+
+        .portal-cta {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 9px 22px;
+            background: linear-gradient(135deg, #08bf81, #03a09b);
+            color: #fff;
+            border-radius: 50px;
+            text-decoration: none;
+            font-weight: bold;
+            font-size: 0.92em;
+            box-shadow: 0 4px 14px rgba(8,191,129,0.32);
+            transition: box-shadow 0.18s ease, transform 0.18s ease;
+            letter-spacing: 0.01em;
+        }
+
+        .portal-cta:hover {
+            box-shadow: 0 6px 20px rgba(8,191,129,0.52);
+            transform: translateY(-1px);
+        }
+
+        .portal-cta:active {
+            transform: scale(0.97);
+            box-shadow: 0 2px 8px rgba(8,191,129,0.22);
         }
     </style>
 </head>
@@ -90,6 +131,12 @@
         <label for="cloudServices">Enable cloud services</label>
         <br><br>
         <button class="buttonForm" onclick="setCloudServices()" id="setCloudServicesButton">☁️ Set cloud services</button>
+        <div id="portalBanner" class="portal-banner">
+            <p>Ready to monitor remotely? Add this meter to your EnergyMe Portal.</p>
+            <a id="portalLink" href="#" target="_blank" rel="noopener noreferrer" class="portal-cta">
+                ☁️ Add to EnergyMe Portal &#8250;
+            </a>
+        </div>
     </div>
 
     <div class="section-box">
@@ -591,6 +638,30 @@
             }
         }
 
+        let _deviceId = '';
+        let _devBuild = false;
+
+        async function loadDeviceInfo() {
+            try {
+                const data = await energyApi.getSystemInfo();
+                _deviceId = (data.static && data.static.device && data.static.device.id) || '';
+                _devBuild = (data.static && data.static.device && data.static.device.devBuild) || false;
+                updatePortalLink();
+            } catch (error) {
+                console.log('Error loading device info: ' + error.message);
+            }
+        }
+
+        function updatePortalLink() {
+            const banner = document.getElementById('portalBanner');
+            if (!_deviceId) { banner.style.display = 'none'; return; }
+            const base = _devBuild
+                ? 'https://portal-dev.energyme.net'
+                : 'https://portal.energyme.net';
+            document.getElementById('portalLink').href = base + '/devices/claim?device_id=' + _deviceId;
+            banner.style.display = 'block';
+        }
+
         function getCloudServices() {
             energyApi.getMqttCloudServices()
                 .then(data => {
@@ -886,6 +957,9 @@
 
             try {
                 console.log("Loading configuration data sequentially...");
+
+                await loadDeviceInfo();
+                await delay(DELAY_BETWEEN_REQUESTS);
 
                 await getCloudServices();
                 await delay(DELAY_BETWEEN_REQUESTS);

--- a/source/html/configuration.html
+++ b/source/html/configuration.html
@@ -654,7 +654,8 @@
 
         function updatePortalLink() {
             const banner = document.getElementById('portalBanner');
-            if (!_deviceId) { banner.style.display = 'none'; return; }
+            const cloudEnabled = document.getElementById('cloudServices').checked;
+            if (!_deviceId || !cloudEnabled) { banner.style.display = 'none'; return; }
             const base = _devBuild
                 ? 'https://portal-dev.energyme.net'
                 : 'https://portal.energyme.net';
@@ -666,6 +667,7 @@
             energyApi.getMqttCloudServices()
                 .then(data => {
                     document.getElementById("cloudServices").checked = data.enabled;
+                    updatePortalLink();
                 })
                 .catch(error => {
                     console.log("Error getting cloud services status. Response: " + error.message);
@@ -697,6 +699,7 @@
                 await energyApi.setMqttCloudServices(isEnabled);
 
                 showStatus('Cloud services updated', 'success');
+                updatePortalLink();
             } catch (error) {
                 showStatus('Error: ' + error.message, 'error');
             } finally {

--- a/source/html/configuration.html
+++ b/source/html/configuration.html
@@ -74,7 +74,6 @@
         }
 
         .portal-banner {
-            display: none;
             margin-top: 18px;
             padding: 14px 18px;
             background: linear-gradient(135deg, rgba(8,191,129,0.08), rgba(3,160,155,0.13));
@@ -113,6 +112,14 @@
             transform: scale(0.97);
             box-shadow: 0 2px 8px rgba(8,191,129,0.22);
         }
+
+        .portal-cta-disabled {
+            background: linear-gradient(135deg, #b0b0b0, #c8c8c8);
+            box-shadow: 0 2px 8px rgba(0,0,0,0.10);
+            opacity: 0.72;
+            pointer-events: none;
+            cursor: default;
+        }
     </style>
 </head>
 
@@ -131,10 +138,10 @@
         <label for="cloudServices">Enable cloud services</label>
         <br><br>
         <button class="buttonForm" onclick="setCloudServices()" id="setCloudServicesButton">☁️ Set cloud services</button>
-        <div id="portalBanner" class="portal-banner">
-            <p>Ready to monitor remotely? Add this meter to your EnergyMe Portal.</p>
-            <a id="portalLink" href="#" target="_blank" rel="noopener noreferrer" class="portal-cta">
-                ☁️ Add to EnergyMe Portal &#8250;
+        <div id="portalBanner" class="portal-banner" style="display:none">
+            <p id="portalMsg">Enable cloud services above to unlock remote monitoring on EnergyMe Portal.</p>
+            <a id="portalLink" href="#" target="_blank" rel="noopener noreferrer" class="portal-cta portal-cta-disabled">
+                &#128274; Add to EnergyMe Portal &#8250;
             </a>
         </div>
     </div>
@@ -640,6 +647,7 @@
 
         let _deviceId = '';
         let _devBuild = false;
+        let _cloudEnabled = false;
 
         async function loadDeviceInfo() {
             try {
@@ -654,19 +662,30 @@
 
         function updatePortalLink() {
             const banner = document.getElementById('portalBanner');
-            const cloudEnabled = document.getElementById('cloudServices').checked;
-            if (!_deviceId || !cloudEnabled) { banner.style.display = 'none'; return; }
-            const base = _devBuild
-                ? 'https://portal-dev.energyme.net'
-                : 'https://portal.energyme.net';
-            document.getElementById('portalLink').href = base + '/devices/claim?device_id=' + _deviceId;
+            if (!_deviceId) { banner.style.display = 'none'; return; }
             banner.style.display = 'block';
+            const link = document.getElementById('portalLink');
+            if (_cloudEnabled) {
+                const base = _devBuild
+                    ? 'https://portal-dev.energyme.net'
+                    : 'https://portal.energyme.net';
+                link.href = base + '/devices/claim?device_id=' + _deviceId;
+                link.classList.remove('portal-cta-disabled');
+                link.textContent = '☁️ Add to EnergyMe Portal ›';
+                document.getElementById('portalMsg').textContent = 'Ready to monitor remotely? Add this meter to your EnergyMe Portal.';
+            } else {
+                link.href = '#';
+                link.classList.add('portal-cta-disabled');
+                link.textContent = '🔒 Add to EnergyMe Portal ›';
+                document.getElementById('portalMsg').textContent = 'Enable cloud services above to unlock remote monitoring on EnergyMe Portal.';
+            }
         }
 
         function getCloudServices() {
             energyApi.getMqttCloudServices()
                 .then(data => {
                     document.getElementById("cloudServices").checked = data.enabled;
+                    _cloudEnabled = data.enabled;
                     updatePortalLink();
                 })
                 .catch(error => {
@@ -699,7 +718,7 @@
                 await energyApi.setMqttCloudServices(isEnabled);
 
                 showStatus('Cloud services updated', 'success');
-                updatePortalLink();
+                getCloudServices();
             } catch (error) {
                 showStatus('Error: ' + error.message, 'error');
             } finally {

--- a/source/html/configuration.html
+++ b/source/html/configuration.html
@@ -284,6 +284,7 @@
     </div>
 
     <script src="/js/api-client.js"></script>
+    <script src="/js/issues.js"></script>
     <script>
         var logLevels = ["Verbose", "Debug", "Info", "Warning", "Error", "Fatal"];
 

--- a/source/html/index.html
+++ b/source/html/index.html
@@ -253,6 +253,7 @@
     
     <!-- EnergyMe modules -->
     <script src="/js/api-client.js"></script>
+    <script src="/js/issues.js"></script>
     <script src="/js/data-helpers.js"></script>
     <script src="/js/chart-helpers.js"></script>
     <script src="/js/power-flow.js"></script>

--- a/source/html/info.html
+++ b/source/html/info.html
@@ -17,6 +17,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 
     <script src="/js/api-client.js"></script>
+    <script src="/js/issues.js"></script>
 
     <title>Device Information</title>
     <style>

--- a/source/html/integrations.html
+++ b/source/html/integrations.html
@@ -429,6 +429,7 @@
     </div>
 
     <script src="/js/api-client.js"></script>
+    <script src="/js/issues.js"></script>
     <script>
         // Global variables
         var customMqttConfig;

--- a/source/html/log.html
+++ b/source/html/log.html
@@ -18,6 +18,7 @@
     <title>Log</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <script src="/js/api-client.js"></script>
+    <script src="/js/issues.js"></script>
     <style>
         .log-table {
             width: 100%;

--- a/source/html/update.html
+++ b/source/html/update.html
@@ -271,6 +271,7 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/spark-md5/3.0.2/spark-md5.min.js"></script>
     <script src="/js/api-client.js"></script>
+    <script src="/js/issues.js"></script>
     <script src="/js/tooltip.js"></script>
     <script>
         var file_size = 341760; // Default to ESP32 firmware size to avoid division by zero

--- a/source/html/waveform.html
+++ b/source/html/waveform.html
@@ -17,6 +17,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 
     <script src="/js/api-client.js"></script>
+    <script src="/js/issues.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0"></script>
 
     <title>Waveform Capture</title>

--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -231,7 +231,8 @@
 // Guardrails and thresholds
 #define MAXIMUM_POWER_FACTOR_CLAMP 1.10f // Values above 1 but below this are still accepted (rounding errors and similar). I noticed I still had a lot of spurious readings with PF around 1.06-1.07 (mainly close to fridge activations, probably due to the compressor)
 #define MINIMUM_CURRENT_RATIO_THREE_PHASE_NO_LOAD 0.0005f // 5/10000 of the CT rating: below this the three-phase approximation reads as no-load (the hardware no-load feature only covers the base-phase energy registers)
-#define MINIMUM_CURRENT_RATIO_VALIDATION 0.001f // 10/10000 of the CT rating: below this, measurements are noise-dominated, so it carries no polarity-vote/boost information
+#define MINIMUM_CURRENT_RATIO_VALIDATION 0.001f // 10/10000 of the CT rating: validation-discard gate - an electrically invalid reading at this current is a genuine failure worth logging
+#define MINIMUM_CURRENT_RATIO_CONDUCTING 0.0003f // 3/10000 of the CT rating: gate for the polarity-vote and WDRR-armed-boost path. Sits above the ADE7953 offset-noise floor (~0 A consistent-sign bias) yet below real small loads (~2 W on a 30 A CT = ~9 mA). Lower than MINIMUM_CURRENT_RATIO_VALIDATION so a reversed 2-3 W load still earns votes and the armed boost instead of reading a constant 0.
 #define MINIMUM_POWER_FACTOR 0.10f // Measuring such low power factors is virtually impossible with such CTs
 #define POLARITY_DETECT_VOTE_THRESHOLD 5 // Net consistent-sign votes (over conducting samples) needed to decide CT orientation. Magnitude-independent, so a steady -4 W reversed CT is caught like a -4 kW one
 #define POLARITY_DETECT_MAX_CONDUCTING_READS 40 // Give up CT-reversal detection after this many CONDUCTING reads without a decision (only trips on a sign-oscillating channel; a no-load channel waits indefinitely)

--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -243,6 +243,12 @@
 #define ADE7953_MAX_FAILURES_BEFORE_RESTART 100
 #define ADE7953_FAILURE_RESET_TIMEOUT_MS (1 * 60 * 1000)
 
+// Polarity-mismatch evidence floor: a reading below the conduction gate still
+// counts as evidence when |active power| clearly exceeds the offset-noise band
+// (sign of a small but real load, e.g. 2.5 W at 24 mA). Random offset noise
+// cannot sustain a high clamped fraction at this magnitude.
+#define MISMATCH_EVIDENCE_MIN_POWER_W 1.0f
+
 // ADE7953 Critical Failure Detection (missed interrupts)
 #ifdef ENV_DEV
 #define ADE7953_MAX_CRITICAL_FAILURES_BEFORE_REBOOT (100 * 5) // 5x higher limit in dev environment
@@ -480,6 +486,18 @@ struct ChannelData
     }
 };
 
+// Per-channel runtime facts for the issue registry (issue #145). All values are
+// RAM-only and monotonic within the current boot; the single writer is the meter
+// task and readers rely on 32-bit loads being atomic on the ESP32-S3.
+struct ChannelIssueFacts
+{
+  uint32_t evidenceReads;        // readings carrying polarity evidence since boot: conducting OR |P| >= MISMATCH_EVIDENCE_MIN_POWER_W (pre-clamp)
+  uint32_t clampedEvidenceReads; // evidence readings zeroed by the LOAD/PV negative clamp
+  uint32_t polarityFlipCount;    // CT auto-detection flips since boot
+
+  ChannelIssueFacts() : evidenceReads(0), clampedEvidenceReads(0), polarityFlipCount(0) {}
+};
+
 // ADE7953 Configuration structure
 struct Ade7953Configuration
 {
@@ -632,6 +650,9 @@ namespace Ade7953
 
     // Grid frequency
     float getGridFrequency();
+
+    // Issue registry facts (RAM-only, safe to call cross-task)
+    bool getChannelIssueFacts(uint8_t channelIndex, ChannelIssueFacts &facts);
 
     // Task information
     TaskInfo getMeterReadingTaskInfo();

--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -231,7 +231,7 @@
 // Guardrails and thresholds
 #define MAXIMUM_POWER_FACTOR_CLAMP 1.10f // Values above 1 but below this are still accepted (rounding errors and similar). I noticed I still had a lot of spurious readings with PF around 1.06-1.07 (mainly close to fridge activations, probably due to the compressor)
 #define MINIMUM_CURRENT_RATIO_THREE_PHASE_NO_LOAD 0.0005f // 5/10000 of the CT rating: below this the three-phase approximation reads as no-load (the hardware no-load feature only covers the base-phase energy registers)
-#define MINIMUM_CURRENT_RATIO_VALIDATION 0.001f // 10/10000 of the CT rating: below this, measurements are noise-dominated - zero the reading instead of invalidating it, and it carries no polarity-vote/boost information
+#define MINIMUM_CURRENT_RATIO_VALIDATION 0.001f // 10/10000 of the CT rating: below this, measurements are noise-dominated, so it carries no polarity-vote/boost information
 #define MINIMUM_POWER_FACTOR 0.10f // Measuring such low power factors is virtually impossible with such CTs
 #define POLARITY_DETECT_VOTE_THRESHOLD 5 // Net consistent-sign votes (over conducting samples) needed to decide CT orientation. Magnitude-independent, so a steady -4 W reversed CT is caught like a -4 kW one
 #define POLARITY_DETECT_MAX_CONDUCTING_READS 40 // Give up CT-reversal detection after this many CONDUCTING reads without a decision (only trips on a sign-oscillating channel; a no-load channel waits indefinitely)

--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -230,8 +230,8 @@
 
 // Guardrails and thresholds
 #define MAXIMUM_POWER_FACTOR_CLAMP 1.10f // Values above 1 but below this are still accepted (rounding errors and similar). I noticed I still had a lot of spurious readings with PF around 1.06-1.07 (mainly close to fridge activations, probably due to the compressor)
-#define MINIMUM_CURRENT_THREE_PHASE_APPROXIMATION_NO_LOAD 0.01f // The minimum current value for the three-phase approximation to be used as the no-load feature cannot be used
-#define MINIMUM_CURRENT_FOR_VALIDATION 0.02f // Below this current threshold, skip invalidating the reading as measurements are unreliable (noise dominates)
+#define MINIMUM_CURRENT_RATIO_THREE_PHASE_NO_LOAD 0.0005f // 5/10000 of the CT rating: below this the three-phase approximation reads as no-load (the hardware no-load feature only covers the base-phase energy registers)
+#define MINIMUM_CURRENT_RATIO_VALIDATION 0.001f // 10/10000 of the CT rating: below this, measurements are noise-dominated - zero the reading instead of invalidating it, and it carries no polarity-vote/boost information
 #define MINIMUM_POWER_FACTOR 0.10f // Measuring such low power factors is virtually impossible with such CTs
 #define POLARITY_DETECT_VOTE_THRESHOLD 5 // Net consistent-sign votes (over conducting samples) needed to decide CT orientation. Magnitude-independent, so a steady -4 W reversed CT is caught like a -4 kW one
 #define POLARITY_DETECT_MAX_CONDUCTING_READS 40 // Give up CT-reversal detection after this many CONDUCTING reads without a decision (only trips on a sign-oscillating channel; a no-load channel waits indefinitely)

--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -26,6 +26,9 @@
 #include "utils.h"
 #include "hardware_profile.h"
 
+#include "channel_types.h"   // ChannelRole (shared, Arduino-free - see lib/meter_logic)
+#include "meter_logic.h"     // pure CT-polarity / clamp / WDRR decisions (host-testable)
+
 // SPI
 #define ADE7953_SPI_FREQUENCY 2000000 // The maximum SPI frequency for the ADE7953 is 2MHz
 #define ADE7953_SPI_MUTEX_TIMEOUT_MS 100
@@ -79,6 +82,8 @@
 #define VARIABILITY_EMA_ALPHA 0.3f   // Exponential moving average smoothing for variability (0-1, lower = smoother)
 #define CHANNEL_MAX_GAP_MS 15000ULL  // Watchdog: max time between successful reads before forcing a pick
 #define MAX_CHANNEL_DEFICIT_BOUND 5.0f // Symmetric clamp on per-channel deficit (safety net against arithmetic edge cases)
+#define WEIGHT_ARMED_BOOST 1.5f      // Extra weight for a channel running CT-reversal detection WHILE CONDUCTING, so it is sampled rapidly and resolves in ~1-2 s
+#define WEIGHT_ROLE_PRIORITY_MULT 2.0f // Weight multiplier for grid / battery roles - mains and storage flow are sampled more often (matters most on 3-phase)
 
 // Default values for ADE7953 registers
 #define UNLOCK_OPTIMUM_REGISTER_VALUE 0xAD // Register to write to unlock the optimum register
@@ -228,7 +233,8 @@
 #define MINIMUM_CURRENT_THREE_PHASE_APPROXIMATION_NO_LOAD 0.01f // The minimum current value for the three-phase approximation to be used as the no-load feature cannot be used
 #define MINIMUM_CURRENT_FOR_VALIDATION 0.02f // Below this current threshold, skip invalidating the reading as measurements are unreliable (noise dominates)
 #define MINIMUM_POWER_FACTOR 0.10f // Measuring such low power factors is virtually impossible with such CTs
-#define AUTO_POLARITY_MIN_POWER_W 5.0f // Below this absolute active power, the auto-polarity check stays armed (avoids flipping on noise / idle circuits)
+#define POLARITY_DETECT_VOTE_THRESHOLD 5 // Net consistent-sign votes (over conducting samples) needed to decide CT orientation. Magnitude-independent, so a steady -4 W reversed CT is caught like a -4 kW one
+#define POLARITY_DETECT_MAX_CONDUCTING_READS 40 // Give up CT-reversal detection after this many CONDUCTING reads without a decision (only trips on a sign-oscillating channel; a no-load channel waits indefinitely)
 #define ADE7953_MIN_LINECYC 10UL // Below this the readings are unstable (200 ms)
 #define ADE7953_MAX_LINECYC 1000UL // Above this too much time passes (20 seconds)
 #define INVALID_SPI_READ_WRITE 0xDEADDEAD // Custom, used to indicate an invalid SPI read/write operation
@@ -418,18 +424,9 @@ struct CtSpecification
       whLsb(1.0f), varhLsb(1.0f), vahLsb(1.0f) {}
 };
 
-// Channel role enum
-enum ChannelRole : uint8_t {
-    CHANNEL_ROLE_LOAD     = 0, // Default - regular load/consumption (negatives discarded)
-    CHANNEL_ROLE_GRID     = 1, // Grid meter (+ import, - export)
-    CHANNEL_ROLE_PV       = 2, // PV/Solar production (+ generation, negatives discarded)
-    CHANNEL_ROLE_BATTERY  = 3, // Battery (+ discharge, - charge)
-    CHANNEL_ROLE_INVERTER = 4, // Hybrid inverter: PV + battery DC-coupled, AC output (negatives allowed)
-    CHANNEL_ROLE_COUNT    = 5  // Total number of roles
-};
-
-#define DEFAULT_CHANNEL_ROLE CHANNEL_ROLE_LOAD
-#define DEFAULT_CHANNEL_0_ROLE CHANNEL_ROLE_GRID // Channel 0 is typically the grid meter
+// ChannelRole and its DEFAULT_CHANNEL_*_ROLE defaults live in channel_types.h
+// (included above) so the host-testable meter_logic library can use them without
+// pulling in Arduino.
 
 struct ChannelData
 {

--- a/source/include/binaries.h
+++ b/source/include/binaries.h
@@ -34,6 +34,8 @@ extern const char chart_helpers_js[]    asm("_binary_js_chart_helpers_js_start")
 extern const char chart_helpers_js_end[]asm("_binary_js_chart_helpers_js_end");
 extern const char data_helpers_js[]     asm("_binary_js_data_helpers_js_start");
 extern const char data_helpers_js_end[] asm("_binary_js_data_helpers_js_end");
+extern const char issues_js[]           asm("_binary_js_issues_js_start");
+extern const char issues_js_end[]       asm("_binary_js_issues_js_end");
 extern const char power_flow_js[]       asm("_binary_js_power_flow_js_start");
 extern const char power_flow_js_end[]   asm("_binary_js_power_flow_js_end");
 extern const char tooltip_js[]          asm("_binary_js_tooltip_js_start");

--- a/source/include/custommqtt.h
+++ b/source/include/custommqtt.h
@@ -98,6 +98,10 @@ namespace CustomMqtt
     // Runtime status
     bool getRuntimeStatus(char *statusBuffer, size_t statusSize, char *timestampBuffer, size_t timestampSize);
 
+    // Facts for the issue registry (all RAM-derived, safe to call cross-task)
+    bool isEnabled();
+    bool isConnected();
+
     // Task information
     TaskInfo getTaskInfo();
 }

--- a/source/include/customserver.h
+++ b/source/include/customserver.h
@@ -24,6 +24,7 @@
 #include "customtime.h"
 #include "mqtt.h"
 #include "influxdbclient.h"
+#include "issueregistry.h"
 #include "ade7953.h"
 #include "globals.h"
 #include "binaries.h"
@@ -81,6 +82,7 @@
 #define HTTP_MAX_CONTENT_LENGTH_MQTT_CLOUD_SERVICES 64
 #define HTTP_MAX_CONTENT_LENGTH_PASSWORD 256
 #define HTTP_MAX_CONTENT_LENGTH_NETWORK 256
+#define HTTP_MAX_CONTENT_LENGTH_ISSUES_ACK 128
 
 // Crash dump chunk sizes
 #define CRASH_DUMP_DEFAULT_CHUNK_SIZE (1 * 1024)

--- a/source/include/influxdbclient.h
+++ b/source/include/influxdbclient.h
@@ -117,6 +117,9 @@ namespace InfluxDbClient
     // Get runtime status
     bool getRuntimeStatus(char *statusBuffer, size_t statusSize, char *timestampBuffer, size_t timestampSize);
 
+    // Fact for the issue registry (RAM-derived, safe to call cross-task)
+    bool isEnabled();
+
     // Task information
     TaskInfo getTaskInfo();
 }

--- a/source/include/issueregistry.h
+++ b/source/include/issueregistry.h
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#pragma once
+
+#include <AdvancedLogger.h>
+#include <Arduino.h>
+#include <ArduinoJson.h>
+
+#include "issue_logic.h" // lib/issue_logic - pure lifecycle + predicates (host-tested)
+#include "constants.h"
+#include "structs.h"
+
+// Device issue registry (issue #145). One periodic tick derives every issue
+// from current runtime facts (counters, flags, RTC state) through the pure
+// predicates in lib/issue_logic - nothing is persisted, so a stale issue is
+// impossible by construction. Modules never call into the registry; the
+// dependency arrow points one way, registry -> facts.
+
+// Task
+#define ISSUE_REGISTRY_TASK_NAME "issue_reg_task"
+#define ISSUE_REGISTRY_TASK_STACK_SIZE (6 * 1024) // Internal RAM: the tick reads LittleFS usage (flash I/O)
+#define ISSUE_REGISTRY_TASK_PRIORITY 1
+#define ISSUE_REGISTRY_TICK_INTERVAL (5 * 1000)
+
+// Instance table
+#define ISSUE_MAX_INSTANCES 32
+#define ISSUE_MESSAGE_BUFFER_SIZE 192 // Longest catalog message (channel mismatch with label) is ~160 chars
+#define ISSUE_GLOBAL_SCOPE 255 // channel value for globally-scoped codes
+
+// Hysteresis (windows are one tick long, ~5 s). The thresholds encode durations,
+// so they scale with the tick: the "over X s" messages derive from streak * tick.
+#define ISSUE_STREAK_TO_RAISE 12              // ~1 min of sustained bad evidence
+#define ISSUE_CONNECTIVITY_STREAK_TO_RAISE 24 // ~2 min: rides out boot/reconnect blips
+
+// Per-code thresholds
+#define ISSUE_MISMATCH_MIN_EVIDENCE_READS 4
+#define ISSUE_MISMATCH_MIN_CLAMPED_FRACTION 0.9f
+#define ISSUE_HEAP_LOW_THRESHOLD_BYTES (25 * 1024)
+#define ISSUE_LITTLEFS_USED_FRACTION_RAISE 0.90f
+#define ISSUE_LITTLEFS_USED_FRACTION_CLEAR 0.85f
+#define ISSUE_VOLTAGE_TOLERANCE_FRACTION 0.10f
+#define ISSUE_FREQUENCY_TOLERANCE_HZ 1.0f
+#define ISSUE_ADE7953_FAILURES_PER_WINDOW 7 // failures in one ~5 s window to count as bad
+#define ISSUE_NTP_BOOT_GRACE_MS (5 * 60 * 1000)
+
+namespace IssueRegistry
+{
+    void begin();
+    void stop();
+
+    // REST support. issuesToJson fills {"issues":[...]}; clients derive any counts.
+    bool issuesToJson(JsonDocument &doc);
+
+    // Acknowledge one instance (channel = ISSUE_GLOBAL_SCOPE for global codes).
+    // Returns false if the code string is unknown or no such instance exists.
+    bool ack(const char *codeStr, uint8_t channel);
+
+    // Acknowledge every visible instance. Returns the number acked.
+    uint32_t ackAll();
+
+    // Task information
+    TaskInfo getTaskInfo();
+}

--- a/source/include/mqtt.h
+++ b/source/include/mqtt.h
@@ -132,6 +132,7 @@ namespace Mqtt
     // Cloud services methods
     void setCloudServicesEnabled(bool enabled);
     bool isCloudServicesEnabled();
+    bool isConnected(); // Connection fact for the issue registry (updated once per task loop)
     
     // Public methods for requesting MQTT publications
     void requestChannelPublish();

--- a/source/include/structs.h
+++ b/source/include/structs.h
@@ -233,6 +233,7 @@ struct SystemDynamicInfo {
     TaskInfo ade7953EnergySaveTaskInfo;
     TaskInfo ade7953HourlyCsvTaskInfo;
     TaskInfo maintenanceTaskInfo;
+    TaskInfo issueRegistryTaskInfo;
 
     SystemDynamicInfo() {
         memset(this, 0, sizeof(*this));

--- a/source/include/utils.h
+++ b/source/include/utils.h
@@ -34,6 +34,7 @@
 #include "crashmonitor.h"
 #include "custommqtt.h"
 #include "influxdbclient.h"
+#include "issueregistry.h"
 #include "customserver.h"
 #include "modbustcp.h"
 #include "led.h"

--- a/source/js/chart-helpers.js
+++ b/source/js/chart-helpers.js
@@ -391,7 +391,8 @@ const ChartHelpers = {
                     },
                     y: {
                         stacked: true,
-                        min: 0,
+                        // No min: 0 - lets a negative "Other" and export bars render below
+                        // zero, consistent with the balance chart. See issue #169.
                         title: { display: true, text: 'Energy (kWh)' },
                         ticks: { font: { size: isMobile ? 10 : 12 } }
                     }
@@ -813,19 +814,12 @@ const ChartHelpers = {
             });
         });
 
-        // Calculate total consumption
-        const totalConsumption = Object.values(channelTotals).reduce((sum, val) => sum + val, 0);
-
         const totalRowEl = document.getElementById('consumption-total-row');
         const valueEl = document.getElementById('consumption-total-value');
 
-        if (totalConsumption === 0) {
-            sharingSection.style.display = 'none';
-            if (totalRowEl) totalRowEl.style.display = 'none';
-            return;
-        }
-
-        // Sort channels by consumption (highest first)
+        // Sort channels by consumption (highest first). A pie slice cannot be negative, so a
+        // negative "Other" is dropped here; the total below is summed over the displayed
+        // slices only, keeping the percentages and total consistent (see issue #169).
         const sortedChannels = Object.entries(channelTotals)
             .sort(([, a], [, b]) => b - a)
             .filter(([, value]) => value > 0);
@@ -835,6 +829,9 @@ const ChartHelpers = {
             if (totalRowEl) totalRowEl.style.display = 'none';
             return;
         }
+
+        // Total over the displayed (positive) slices only
+        const totalConsumption = sortedChannels.reduce((sum, [, value]) => sum + value, 0);
 
         // Prepare data for pie chart
         const labels = sortedChannels.map(([channelKey]) => this.getDisplayLabel(channelKey, channelData));

--- a/source/js/data-helpers.js
+++ b/source/js/data-helpers.js
@@ -384,7 +384,10 @@ const DataHelpers = {
             }
         });
 
-        return Math.max(0, totalAvailable - trackedLoadConsumption);
+        // Not clamped to 0: a negative "Other" (tracked loads exceed available energy) is a
+        // real signal - calibration mismatch, mis-assigned role, double-counting or CT
+        // reversal - and the bar chart renders it below zero. See issue #169.
+        return totalAvailable - trackedLoadConsumption;
     },
 
     /**

--- a/source/js/issues.js
+++ b/source/js/issues.js
@@ -1,0 +1,275 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+    Copyright (C) 2025 Jibril Sharafi */
+
+/**
+ * EnergyMe device issues widget (issue #145).
+ * Self-contained: injects a badge fixed to the top-right corner on every page
+ * that includes it (after api-client.js), polls /api/v1/system/issues and
+ * opens an overlay panel with the issue list and acknowledge actions.
+ * Dispatches a window 'energyme-issues' CustomEvent on every poll so pages
+ * can render their own channel-scoped chips (see channel.html).
+ */
+(function () {
+    'use strict';
+
+    const POLL_INTERVAL_MS = 5000;
+    const SEVERITY_ORDER = { info: 0, warning: 1, error: 2 };
+    const SEVERITY_ICON = { info: 'ℹ️', warning: '⚠️', error: '🔴' };
+    const ACTIVE_ACKED_ICON = '🟠';
+
+    let lastData = null;
+    let panelOpen = false;
+
+    const style = document.createElement('style');
+    style.textContent = `
+        .issues-badge {
+            position: fixed; top: 12px; right: 12px; z-index: 1000;
+            display: none; align-items: center; gap: 6px;
+            padding: 6px 12px; border-radius: 16px; cursor: pointer;
+            font-family: inherit; font-size: 14px; font-weight: bold; color: #fff;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.25); user-select: none;
+        }
+        .issues-badge.error { background-color: #dc3545; color: #fff; }
+        .issues-badge.warning { background-color: #ffc107; color: #333; }
+        .issues-badge.info { background-color: #0d6efd; color: #fff; }
+        .issues-badge.active-acked { background-color: #fd7e14; color: #fff; }
+        .issues-badge.acked { background-color: #6c757d; color: #fff; }
+        .issues-overlay {
+            position: fixed; inset: 0; z-index: 1001;
+            display: none; background: rgba(0,0,0,0.4);
+        }
+        .issues-panel {
+            position: absolute; top: 50px; right: 12px;
+            width: min(440px, calc(100vw - 24px)); max-height: 75vh; overflow-y: auto;
+            background: #fff; border-radius: 8px; box-shadow: 0 4px 16px rgba(0,0,0,0.3);
+            padding: 12px; font-size: 14px; text-align: left;
+        }
+        .issues-panel h3 { margin: 4px 4px 10px 4px; font-size: 16px; }
+        .issues-item {
+            border: 1px solid #e0e0e0; border-left-width: 4px; border-radius: 6px;
+            padding: 8px 10px; margin-bottom: 8px; background: #fafafa;
+        }
+        .issues-item.error { border-left-color: #dc3545; }
+        .issues-item.warning { border-left-color: #fd7e14; }
+        .issues-item.info { border-left-color: #0d6efd; }
+        .issues-item.resolved { border-left-color: #6c757d !important; background: #fff !important; }
+        /* active-acked: keep the severity border, tint the card a light shade of the same color */
+        .issues-item.active-acked.error { background: #fdecea; }
+        .issues-item.active-acked.warning { background: #fff6e5; }
+        .issues-item.active-acked.info { background: #e7f1ff; }
+        .issues-item.resolving {
+            overflow: hidden;
+            animation: issues-resolve-out 0.6s ease forwards;
+        }
+        @keyframes issues-resolve-out {
+            0%   { background: #d4edda; max-height: 200px; opacity: 1; margin-bottom: 8px; }
+            30%  { background: #d4edda; }
+            100% { max-height: 0; opacity: 0; padding-top: 0; padding-bottom: 0; margin-bottom: 0; }
+        }
+        .issues-item-title { font-weight: bold; margin-bottom: 4px; }
+        .issues-item-message { margin-bottom: 6px; word-break: break-word; }
+        .issues-item-meta { color: #666; font-size: 12px; margin-bottom: 6px; }
+        .issues-ack-button {
+            padding: 3px 10px; border: 1px solid #6c757d; border-radius: 4px;
+            background: #fff; color: #333; cursor: pointer; font-size: 12px;
+        }
+        .issues-ack-button:hover { background: #f0f0f0; }
+        .issues-ack-all { margin-bottom: 10px; }
+        .issues-empty { color: #666; padding: 8px 4px; }
+        .issues-chip {
+            display: inline-flex; align-items: center; gap: 4px; cursor: pointer;
+            padding: 2px 8px; border-radius: 10px; font-size: 12px; font-weight: bold;
+            color: #fff; vertical-align: middle; margin-left: 6px;
+        }
+        .issues-chip.error { background-color: #dc3545; }
+        .issues-chip.warning { background-color: #fd7e14; }
+        .issues-chip.info { background-color: #0d6efd; }
+        .issues-chip.acked { background-color: #6c757d; }
+    `;
+    document.head.appendChild(style);
+
+    const badge = document.createElement('div');
+    badge.className = 'issues-badge';
+    badge.title = 'Device issues';
+    badge.addEventListener('click', openPanel);
+
+    const overlay = document.createElement('div');
+    overlay.className = 'issues-overlay';
+    overlay.addEventListener('click', (event) => {
+        if (event.target === overlay) closePanel();
+    });
+
+    const panel = document.createElement('div');
+    panel.className = 'issues-panel';
+    overlay.appendChild(panel);
+
+    function isUnacked(issue) {
+        return issue.state === 'active_unacked' || issue.state === 'cleared_unacked';
+    }
+
+    function topSeverity(issues) {
+        return issues.reduce((best, i) =>
+            SEVERITY_ORDER[i.severity] > SEVERITY_ORDER[best.severity] ? i : best).severity;
+    }
+
+    // Render a channel-scoped chip into the given element (used by channel.html).
+    // Owns the severity/state mapping so pages never duplicate it.
+    function renderChip(element, channelIssues) {
+        let html = '';
+        if (channelIssues.length > 0) {
+            const cls = channelIssues.some(isUnacked) ? topSeverity(channelIssues) : 'acked';
+            const titleText = channelIssues.map(i => i.message).join('\n').replace(/"/g, '&quot;');
+            html = `<span class="issues-chip ${cls}" title="${titleText}">⚠ ${channelIssues.length}</span>`;
+        }
+        if (element._issuesChipHtml === html) return; // unchanged - skip the DOM write
+        element._issuesChipHtml = html;
+        element.innerHTML = html;
+        const chip = element.querySelector('.issues-chip');
+        if (chip) chip.onclick = openPanel;
+    }
+
+    function formatTime(unixSeconds) {
+        if (!unixSeconds) return 'unknown';
+        return new Date(unixSeconds * 1000).toLocaleString();
+    }
+
+    function titleFor(issue) {
+        // code is snake_case; humanize it
+        const text = issue.code.replace(/_/g, ' ');
+        return text.charAt(0).toUpperCase() + text.slice(1);
+    }
+
+    function updateBadge(data) {
+        const issues = (data && data.issues) || [];
+        if (issues.length === 0) {
+            badge.style.display = 'none';
+            return;
+        }
+
+        // Every visible issue is in exactly one of these three states
+        const activeUnacked = issues.filter(i => i.state === 'active_unacked');
+        const activeAcked = issues.filter(i => i.state === 'active_acked');
+        const clearedUnacked = issues.filter(i => i.state === 'cleared_unacked');
+
+        let badgeClass, badgeText, badgeTitle;
+        if (activeUnacked.length > 0) {
+            // Live problem not yet seen - alarming (red/yellow by severity)
+            badgeClass = topSeverity(activeUnacked);
+            badgeText = `${SEVERITY_ICON[badgeClass]} ${activeUnacked.length}`;
+            badgeTitle = `${activeUnacked.length} active unacknowledged issue(s) - click for details`;
+        } else if (activeAcked.length > 0) {
+            // All active issues acked but still happening - orange dot, not a new alarm
+            badgeClass = 'active-acked';
+            badgeText = `${ACTIVE_ACKED_ICON} ${activeAcked.length}`;
+            badgeTitle = `${activeAcked.length} acknowledged but still-active issue(s) - click for details`;
+        } else {
+            // Everything resolved but user hasn't dismissed the notifications yet - grey
+            badgeClass = 'acked';
+            badgeText = `✓ ${clearedUnacked.length}`;
+            badgeTitle = `${clearedUnacked.length} resolved issue(s) to dismiss - click for details`;
+        }
+        badge.style.display = 'flex';
+        badge.className = 'issues-badge ' + badgeClass;
+        badge.textContent = badgeText;
+        badge.title = badgeTitle;
+    }
+
+    function renderPanel(data) {
+        const issues = (data && data.issues) ? data.issues.slice() : [];
+        issues.sort((a, b) => (SEVERITY_ORDER[b.severity] - SEVERITY_ORDER[a.severity]));
+
+        let html = '<h3>Device issues</h3>';
+        if (issues.length === 0) {
+            html += '<div class="issues-empty">No active issues. All good! ✨</div>';
+        } else {
+            if (issues.some(isUnacked)) {
+                html += '<button class="issues-ack-button issues-ack-all" data-ack-all="1">Acknowledge all</button>';
+            }
+            issues.forEach((issue) => {
+                const resolved = issue.state === 'cleared_unacked';
+                const activeAcked = issue.state === 'active_acked';
+                const channelText = issue.channel !== undefined ? ` &middot; channel ${issue.channel}` : '';
+                const stateText = resolved ? 'resolved, unseen' : (activeAcked ? 'active, acknowledged' : 'active');
+                const extraClass = resolved ? ' resolved' : activeAcked ? ' active-acked' : '';
+                html += `
+                    <div class="issues-item ${issue.severity}${extraClass}">
+                        <div class="issues-item-title">${activeAcked ? ACTIVE_ACKED_ICON : (SEVERITY_ICON[issue.severity] || '')} ${titleFor(issue)}</div>
+                        <div class="issues-item-message">${issue.message || ''}</div>
+                        <div class="issues-item-meta">
+                            ${stateText}${channelText} &middot; first seen ${formatTime(issue.firstSeenUnix)}
+                            ${issue.occurrences > 1 ? ` &middot; ${issue.occurrences} occurrences` : ''}
+                        </div>
+                        ${isUnacked(issue) ? `<button class="issues-ack-button" data-code="${issue.code}" data-channel="${issue.channel !== undefined ? issue.channel : ''}">Acknowledge</button>` : ''}
+                    </div>`;
+            });
+        }
+        panel.innerHTML = html;
+
+        panel.querySelectorAll('.issues-ack-button').forEach((button) => {
+            button.addEventListener('click', async () => {
+                const card = button.closest('.issues-item');
+                const isResolved = card && card.classList.contains('resolved');
+                try {
+                    if (button.dataset.ackAll) {
+                        await window.energyApi.post('system/issues/ack', { all: true });
+                    } else {
+                        const body = { code: button.dataset.code };
+                        if (button.dataset.channel !== '') body.channel = parseInt(button.dataset.channel, 10);
+                        await window.energyApi.post('system/issues/ack', body);
+                    }
+                    if (isResolved && card && !button.dataset.ackAll) {
+                        card.classList.add('resolving');
+                        await new Promise(resolve => setTimeout(resolve, 600));
+                    }
+                    await poll(); // re-renders the open panel with the fresh data
+                } catch (error) {
+                    console.error('Failed to acknowledge issue:', error);
+                    if (typeof showStatus === 'function') showStatus('Failed to acknowledge issue', 'error');
+                }
+            });
+        });
+    }
+
+    function openPanel() {
+        panelOpen = true;
+        renderPanel(lastData);
+        overlay.style.display = 'block';
+    }
+
+    function closePanel() {
+        panelOpen = false;
+        overlay.style.display = 'none';
+    }
+
+    async function poll() {
+        if (document.hidden) return; // hidden tabs poll again on visibilitychange
+        try {
+            const data = await window.energyApi.get('system/issues');
+            lastData = data;
+            updateBadge(data);
+            if (panelOpen) renderPanel(data);
+            window.dispatchEvent(new CustomEvent('energyme-issues', { detail: data }));
+        } catch (error) {
+            // Polling failure is not itself an issue worth surfacing; just log it
+            console.debug('Issues poll failed:', error);
+        }
+    }
+
+    // Public hooks for pages (e.g. channel chips): open the panel, render a chip
+    window.energymeIssues = {
+        open: openPanel,
+        renderChip: renderChip
+    };
+
+    function init() {
+        document.body.appendChild(badge);
+        document.body.appendChild(overlay);
+        poll();
+        setInterval(poll, POLL_INTERVAL_MS);
+        document.addEventListener('visibilitychange', () => {
+            if (!document.hidden) poll();
+        });
+    }
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+    else init();
+})();

--- a/source/js/power-flow.js
+++ b/source/js/power-flow.js
@@ -187,7 +187,13 @@ const PowerFlowHelpers = {
      * Update energy flow diagram with real-time data (Simple Layout)
      */
     updateEnergyFlow(meterData, channelData) {
-        if (!meterData || meterData.length === 0 || !channelData || !Array.isArray(channelData)) return;
+        const flowSection = document.getElementById('energy-flow-section');
+
+        // Nothing to draw without data: hide the whole section instead of showing an empty box
+        if (!meterData || !Array.isArray(meterData) || meterData.length === 0 || !channelData || !Array.isArray(channelData)) {
+            if (flowSection) flowSection.style.display = 'none';
+            return;
+        }
 
         const gridChannels = ChannelCache.grid;
         const productionChannels = ChannelCache.production;
@@ -198,16 +204,39 @@ const PowerFlowHelpers = {
         const hasInverter = inverterChannels.length > 0;
         const hasBattery = batteryChannels.length > 0;
         const hasGrid = gridChannels.length > 0;
+        const hasStorage = hasInverter || hasBattery;
+        const hasAnySource = hasGrid || hasPV || hasStorage;
 
-        // Always show energy flow section
-        const flowSection = document.getElementById('energy-flow-section');
-        flowSection.classList.add('visible');
+        // Monitored loads = any channel that is not a known source
+        const sourceIndices = new Set([
+            ...gridChannels.map(ch => ch.index),
+            ...productionChannels.map(ch => ch.index),
+            ...batteryChannels.map(ch => ch.index),
+            ...inverterChannels.map(ch => ch.index)
+        ]);
+        let loadSum = 0;
+        let hasLoads = false;
+        meterData.forEach(m => {
+            if (!sourceIndices.has(m.index)) {
+                loadSum += m.data.activePower;
+                hasLoads = true;
+            }
+        });
 
-        // Show/hide nodes
+        // The house is drawn whenever there is at least one source or one load.
+        const hasHome = hasAnySource || hasLoads;
+        if (flowSection) {
+            flowSection.style.display = hasHome ? '' : 'none';
+            flowSection.classList.add('visible');
+        }
+        if (!hasHome) return;
+
+        // Show/hide nodes - only ever draw what actually exists (no ghost sources)
         const pfSolar = document.getElementById('pf-solar');
         const pfBattery = document.getElementById('pf-battery');
         const pfGrid = document.getElementById('pf-grid');
         const pfHome = document.getElementById('pf-home');
+        const pfCenter = flowSection ? flowSection.querySelector('.pf-center') : null;
 
         // Solar node: only show pure PV channels
         if (pfSolar) {
@@ -215,17 +244,16 @@ const PowerFlowHelpers = {
             const solarIcon = pfSolar.querySelector('.pf-icon');
             if (solarIcon) solarIcon.textContent = '☀️';
         }
-        
+
         // Battery/Inverter node: show inverter if available, else battery if available
         // Inverter replaces battery in the UI since it controls battery charging/discharging
         if (pfBattery) {
-            const showBatteryNode = (hasInverter || hasBattery);
-            pfBattery.style.display = showBatteryNode ? 'flex' : 'none';
-            
+            pfBattery.style.display = hasStorage ? 'flex' : 'none';
+
             // Update icon and value ID based on what we're showing
             const batteryIcon = pfBattery.querySelector('.pf-icon');
             const batteryValue = pfBattery.querySelector('.pf-value');
-            
+
             if (hasInverter && batteryIcon) {
                 batteryIcon.textContent = '⚙️';
                 if (batteryValue) batteryValue.id = 'inverter-power';
@@ -234,6 +262,28 @@ const PowerFlowHelpers = {
                 if (batteryValue) batteryValue.id = 'battery-power';
             }
         }
+
+        // Grid node: shown only with a grid channel. When absent but other sources exist we
+        // keep its (invisible) slot so the junction stays centred under the solar/battery
+        // connectors; with loads only we collapse it so the house centres on its own.
+        if (pfGrid) {
+            if (hasGrid) {
+                pfGrid.style.display = 'flex';
+                pfGrid.style.visibility = '';
+            } else if (hasAnySource) {
+                pfGrid.style.display = 'flex';
+                pfGrid.style.visibility = 'hidden';
+            } else {
+                pfGrid.style.display = 'none';
+                pfGrid.style.visibility = '';
+            }
+        }
+
+        // Home node: always shown here (we have at least one source or load)
+        if (pfHome) pfHome.style.display = 'flex';
+
+        // Center junction: only meaningful when at least one source feeds the home
+        if (pfCenter) pfCenter.style.display = hasAnySource ? 'flex' : 'none';
 
         // Calculate power values
         let gridPower = 0;
@@ -263,25 +313,18 @@ const PowerFlowHelpers = {
             if (meter) batteryPower += meter.data.activePower;
         });
 
-        // Calculate home power based on what storage devices we have
-        let homePower;
-        if (hasInverter) {
-            // If inverter exists, it handles battery internally
-            // Home power = grid + solar + inverter output
-            homePower = gridPower + solarPower + inverterPower;
-        } else {
-            // Otherwise: grid + solar + battery
-            homePower = gridPower + solarPower + batteryPower;
-        }
+        // Storage net power: inverter takes priority (it controls the battery)
+        const storagePower = hasInverter ? inverterPower : batteryPower;
+
+        // Home power = sum of available sources (all incoming energy goes to the house).
+        // With no source monitored we cannot derive it from supply, so fall back to the
+        // sum of monitored loads - all we know in that case.
+        const homePower = hasAnySource ? (gridPower + solarPower + storagePower) : loadSum;
 
         // Record history
         this.addToFlowHistory('solar', solarPower);
         this.addToFlowHistory('grid', gridPower);
-        if (hasInverter) {
-            this.addToFlowHistory('battery', inverterPower);
-        } else {
-            this.addToFlowHistory('battery', batteryPower);
-        }
+        this.addToFlowHistory('battery', storagePower);
         this.addToFlowHistory('home', Math.max(0, homePower));
 
         // Update display values
@@ -291,23 +334,23 @@ const PowerFlowHelpers = {
         const storageValueId = hasInverter ? 'inverter-power' : 'battery-power';
         const storagePowerEl = document.getElementById(storageValueId);
         
-        if (gridPowerEl) gridPowerEl.textContent = this.formatPower(gridPower);
+        if (hasGrid && gridPowerEl) gridPowerEl.textContent = this.formatPower(gridPower);
         if (homePowerEl) homePowerEl.textContent = this.formatPower(Math.max(0, homePower));
         if (hasPV && solarPowerEl) solarPowerEl.textContent = this.formatPower(solarPower);
-        if ((hasInverter || hasBattery) && storagePowerEl) {
-            const storagePower = hasInverter ? inverterPower : batteryPower;
-            storagePowerEl.textContent = this.formatPower(storagePower);
-        }
+        if (hasStorage && storagePowerEl) storagePowerEl.textContent = this.formatPower(storagePower);
 
-        // Update connectors
+        // Update connectors - a connector is hidden (display:none) when its node does not
+        // exist, so no orphan stub is left pointing at nothing. The home connector follows
+        // the sources: with loads only there is no junction flow to animate.
         this.updateConnector('pf-solar', solarPower, hasPV);
-        this.updateConnector('pf-grid', gridPower, true);
-        this.updateConnector('pf-home', homePower, true);
-        this.updateConnector('pf-battery', hasInverter ? inverterPower : batteryPower, hasInverter || hasBattery);
+        this.updateConnector('pf-grid', gridPower, hasGrid);
+        // Home flow follows the displayed (clamped) value: when net consumption is <= 0
+        // (e.g. net export, or storage charging) nothing flows into the house, so no pulse.
+        this.updateConnector('pf-home', Math.max(0, homePower), hasAnySource);
+        this.updateConnector('pf-battery', storagePower, hasStorage);
 
         // Update load breakdown
-        const storageNetPower = hasInverter ? inverterPower : batteryPower;
-        this.updateLoadBreakdown(hasGrid, hasPV, hasInverter || hasBattery, gridPower, solarPower, storageNetPower, homePower, meterData, channelData);
+        this.updateLoadBreakdown(hasGrid, hasPV, hasStorage, gridPower, solarPower, storagePower, homePower, meterData, channelData);
     },
 
     /**
@@ -320,7 +363,14 @@ const PowerFlowHelpers = {
         const connector = node.querySelector('.pf-connector');
         if (!connector) return;
 
-        if (!isVisible) return;
+        // The base connector is a static gray bar; when the node is absent we must hide the
+        // bar itself, not just stop the animation, or it dangles pointing at nothing.
+        if (!isVisible) {
+            connector.style.display = 'none';
+            connector.classList.remove('active', 'reversed');
+            return;
+        }
+        connector.style.display = '';
 
         const isActive = Math.abs(power) > PowerFlowConfig.ACTIVE_LINE_THRESHOLD;
         connector.classList.toggle('active', isActive);

--- a/source/lib/duration_format/duration_format.cpp
+++ b/source/lib/duration_format/duration_format.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#include "duration_format.h"
+#include <cstdio>
+
+namespace DurationFormat {
+
+static constexpr uint64_t MS_PER_S   =     1000ULL;
+static constexpr uint64_t MS_PER_MIN =    60000ULL;
+static constexpr uint64_t MS_PER_H   =  3600000ULL;
+static constexpr uint64_t MS_PER_D   = 86400000ULL;
+
+void humanizeDuration(uint64_t ms, char *out, size_t outSize) {
+    if (!out || outSize == 0) return;
+
+    if (ms < MS_PER_S) {
+        snprintf(out, outSize, "%llu ms", (unsigned long long)ms);
+    } else if (ms < MS_PER_MIN) {
+        snprintf(out, outSize, "%.1f s", (double)ms / MS_PER_S);
+    } else if (ms < MS_PER_H) {
+        snprintf(out, outSize, "%llu min", (unsigned long long)(ms / MS_PER_MIN));
+    } else if (ms < MS_PER_D) {
+        snprintf(out, outSize, "%llu h", (unsigned long long)(ms / MS_PER_H));
+    } else {
+        snprintf(out, outSize, "%llu d", (unsigned long long)(ms / MS_PER_D));
+    }
+}
+
+}  // namespace DurationFormat

--- a/source/lib/duration_format/duration_format.cpp
+++ b/source/lib/duration_format/duration_format.cpp
@@ -17,7 +17,7 @@ void humanizeDuration(uint64_t ms, char *out, size_t outSize) {
     if (ms < MS_PER_S) {
         snprintf(out, outSize, "%llu ms", (unsigned long long)ms);
     } else if (ms < MS_PER_MIN) {
-        snprintf(out, outSize, "%.1f s", (double)ms / MS_PER_S);
+        snprintf(out, outSize, "%llu s", (unsigned long long)(ms / MS_PER_S));
     } else if (ms < MS_PER_H) {
         snprintf(out, outSize, "%llu min", (unsigned long long)(ms / MS_PER_MIN));
     } else if (ms < MS_PER_D) {

--- a/source/lib/duration_format/duration_format.h
+++ b/source/lib/duration_format/duration_format.h
@@ -10,7 +10,7 @@
 //
 // Formats a millisecond count into the most readable unit:
 //   <1 s    ->  "850 ms"
-//   <60 s   ->  "2.4 s"   (one decimal)
+//   <60 s   ->  "2 s"
 //   <60 min ->  "3 min"
 //   <24 h   ->  "5 h"
 //   >=24 h  ->  "2 d"

--- a/source/lib/duration_format/duration_format.h
+++ b/source/lib/duration_format/duration_format.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// Pure, dependency-free duration formatter.
+//
+// Formats a millisecond count into the most readable unit:
+//   <1 s    ->  "850 ms"
+//   <60 s   ->  "2.4 s"   (one decimal)
+//   <60 min ->  "3 min"
+//   <24 h   ->  "5 h"
+//   >=24 h  ->  "2 d"
+//
+// Output is ASCII-only and null-terminated. If `outSize` is 0 the call
+// is a no-op. A minimum buffer of 16 bytes covers all representable values.
+namespace DurationFormat {
+
+void humanizeDuration(uint64_t ms, char *out, size_t outSize);
+
+}  // namespace DurationFormat

--- a/source/lib/issue_logic/issue_logic.cpp
+++ b/source/lib/issue_logic/issue_logic.cpp
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#include "issue_logic.h"
+
+#include <cmath>
+
+namespace IssueLogic {
+
+// Issue catalog: one row per Code, indexed by the enum value. The static_assert
+// makes a missing row a compile error instead of a silent "unknown" fallback.
+struct CodeDescriptor {
+    const char* str;
+    Severity severity;
+};
+
+static constexpr CodeDescriptor CODE_TABLE[] = {
+    {"ct_polarity_flipped",         Severity::Info},    // Code::CtPolarityFlipped
+    {"channel_polarity_mismatch",   Severity::Error},   // Code::ChannelPolarityMismatch
+    {"custom_mqtt_connect_failed",  Severity::Warning}, // Code::CustomMqttConnectFailed
+    {"cloud_mqtt_disconnected",     Severity::Warning}, // Code::CloudMqttDisconnected
+    {"influxdb_upload_failing",     Severity::Warning}, // Code::InfluxDbUploadFailing
+    {"ntp_not_synced",              Severity::Warning}, // Code::NtpNotSynced
+    {"panic_reboot",                Severity::Warning}, // Code::PanicReboot
+    {"safe_mode_active",            Severity::Error},   // Code::SafeModeActive
+    {"heap_low",                    Severity::Warning}, // Code::HeapLow
+    {"littlefs_near_full",          Severity::Warning}, // Code::LittleFsNearFull
+    {"voltage_out_of_range",        Severity::Warning}, // Code::VoltageOutOfRange
+    {"grid_frequency_out_of_range", Severity::Warning}, // Code::GridFrequencyOutOfRange
+    {"ade7953_read_failures",       Severity::Warning}, // Code::Ade7953ReadFailures
+};
+static_assert(sizeof(CODE_TABLE) / sizeof(CODE_TABLE[0]) == (size_t)Code::Count,
+              "every IssueLogic::Code needs a CODE_TABLE row");
+
+const char* codeToString(Code code) {
+    if ((uint8_t)code >= (uint8_t)Code::Count) return "unknown";
+    return CODE_TABLE[(uint8_t)code].str;
+}
+
+const char* severityToString(Severity severity) {
+    switch (severity) {
+        case Severity::Info:    return "info";
+        case Severity::Warning: return "warning";
+        case Severity::Error:   return "error";
+        default:                return "unknown";
+    }
+}
+
+Severity codeSeverity(Code code) {
+    if ((uint8_t)code >= (uint8_t)Code::Count) return Severity::Warning;
+    return CODE_TABLE[(uint8_t)code].severity;
+}
+
+Transition step(State current, bool conditionTrue) {
+    switch (current) {
+        case State::Inactive:
+            if (conditionTrue) return {State::ActiveUnacked, true, false};
+            return {State::Inactive, false, false};
+        case State::ActiveUnacked:
+            if (conditionTrue) return {State::ActiveUnacked, false, false};
+            return {State::ClearedUnacked, false, true};
+        case State::ActiveAcked:
+            if (conditionTrue) return {State::ActiveAcked, false, false};
+            return {State::Inactive, false, true}; // seen and resolved - gone
+        case State::ClearedUnacked:
+            if (conditionTrue) return {State::ActiveUnacked, true, false}; // re-raise
+            return {State::ClearedUnacked, false, false};                  // linger until ack
+        default:
+            return {State::Inactive, false, false};
+    }
+}
+
+State applyAck(State current) {
+    switch (current) {
+        case State::ActiveUnacked:  return State::ActiveAcked;
+        case State::ClearedUnacked: return State::Inactive;
+        default:                    return current;
+    }
+}
+
+uint64_t counterDelta(uint64_t previous, uint64_t current) {
+    if (current < previous) return 0;
+    return current - previous;
+}
+
+Evidence rateEvidence(uint64_t okDelta, uint64_t errorDelta) {
+    if (okDelta > 0) return Evidence::Good;
+    if (errorDelta > 0) return Evidence::Bad;
+    return Evidence::None;
+}
+
+uint16_t updateStreak(uint16_t streak, Evidence evidence) {
+    switch (evidence) {
+        case Evidence::Bad:
+            return (streak == UINT16_MAX) ? streak : (uint16_t)(streak + 1);
+        case Evidence::Good:
+            return 0;
+        case Evidence::None:
+        default:
+            return streak;
+    }
+}
+
+Evidence channelMismatchEvidence(uint32_t evidenceDelta, uint32_t clampedDelta,
+                                 uint32_t minEvidenceReads, float minClampedFraction) {
+    if (evidenceDelta < minEvidenceReads) return Evidence::None;
+    float fraction = (float)clampedDelta / (float)evidenceDelta;
+    return (fraction >= minClampedFraction) ? Evidence::Bad : Evidence::Good;
+}
+
+Evidence readFailureEvidence(uint64_t failureDelta, uint64_t failureThreshold) {
+    return (failureDelta >= failureThreshold) ? Evidence::Bad : Evidence::Good;
+}
+
+float nearestNominalVoltage(float voltage) {
+    return (std::fabs(voltage - 120.0f) < std::fabs(voltage - 230.0f)) ? 120.0f : 230.0f;
+}
+
+float nearestNominalFrequency(float frequency) {
+    return (std::fabs(frequency - 50.0f) < std::fabs(frequency - 60.0f)) ? 50.0f : 60.0f;
+}
+
+Evidence voltageEvidence(float voltage, float fractionTolerance) {
+    if (!(voltage > 0.0f) || std::isnan(voltage)) return Evidence::None; // no reading
+    float nominal = nearestNominalVoltage(voltage);
+    return (std::fabs(voltage - nominal) > nominal * fractionTolerance) ? Evidence::Bad
+                                                                        : Evidence::Good;
+}
+
+Evidence frequencyEvidence(float frequency, float hzTolerance) {
+    if (!(frequency > 0.0f) || std::isnan(frequency)) return Evidence::None; // no reading
+    float nominal = nearestNominalFrequency(frequency);
+    return (std::fabs(frequency - nominal) > hzTolerance) ? Evidence::Bad : Evidence::Good;
+}
+
+} // namespace IssueLogic

--- a/source/lib/issue_logic/issue_logic.h
+++ b/source/lib/issue_logic/issue_logic.h
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#pragma once
+
+#include <cstdint>
+
+// Pure decision logic for the device issue registry (issue #145).
+//
+// Everything here is free-standing: no Arduino, no FreeRTOS, no logging, no
+// global state. The firmware registry (src/issueregistry.cpp) gathers runtime
+// facts from the modules, feeds them through these functions on a periodic
+// tick, and acts on the decisions (instance table updates, log lines, REST).
+// That boundary is what lets the lifecycle and every predicate be unit-tested
+// on the host (see test/test_issue_logic) without any hardware.
+namespace IssueLogic {
+
+// ============================================================================
+// Issue catalog
+// ============================================================================
+
+enum class Severity : uint8_t {
+    Info,    // System acted autonomously / informational - nothing to fix
+    Warning, // Degraded but functioning - should be looked at
+    Error,   // Data loss or functionality loss - needs fixing
+};
+
+enum class Code : uint8_t {
+    CtPolarityFlipped = 0,    // channel-scoped event: auto-detection flipped the reverse flag
+    ChannelPolarityMismatch,  // channel-scoped: conducting but readings persistently clamped to 0
+    CustomMqttConnectFailed,  // custom MQTT enabled but cannot connect
+    CloudMqttDisconnected,    // cloud services enabled but AWS MQTT down
+    InfluxDbUploadFailing,    // InfluxDB enabled but uploads failing
+    NtpNotSynced,             // time never synced (data timestamps unreliable)
+    PanicReboot,              // event: last reset was a crash
+    SafeModeActive,           // restart protection engaged
+    HeapLow,                  // free internal heap below threshold
+    LittleFsNearFull,         // filesystem close to capacity
+    VoltageOutOfRange,        // sustained deviation from nominal mains voltage
+    GridFrequencyOutOfRange,  // sustained deviation from nominal grid frequency
+    Ade7953ReadFailures,      // sustained meter reading failures
+    Count
+};
+
+const char* codeToString(Code code);
+const char* severityToString(Severity severity);
+Severity codeSeverity(Code code);
+
+// ============================================================================
+// Lifecycle (ISA-18.2-lite four-state machine)
+// ============================================================================
+// Two orthogonal axes: condition (active / cleared) and acknowledgement
+// (unacked / acked). An instance is removed only when the condition is gone
+// AND a human has seen it: ack never hides a live problem, clearing never
+// hides an unseen one. Instantaneous events (CT flip, panic reboot) pulse the
+// condition true for one tick and land in ClearedUnacked, lingering until
+// acked. Everything is RAM-derived from current runtime signals, so a stale
+// issue is impossible by construction (and a reboot wipes unseen events -
+// the firmware log stays the forensic record).
+
+enum class State : uint8_t {
+    Inactive,       // no instance (not shown anywhere)
+    ActiveUnacked,  // condition true, not seen - alarming
+    ActiveAcked,    // condition true, seen - calm but listed (cannot be dismissed)
+    ClearedUnacked, // condition gone, not seen - listed greyed until acked
+};
+
+struct Transition {
+    State state;
+    bool raised;  // condition edge false->true happened (log "issue raised")
+    bool cleared; // condition edge true->false happened (log "issue cleared")
+};
+
+// One lifecycle step given the current condition value.
+Transition step(State current, bool conditionTrue);
+
+// User acknowledgement: ActiveUnacked -> ActiveAcked, ClearedUnacked -> Inactive.
+// Other states are unchanged (acking is idempotent).
+State applyAck(State current);
+
+// True if the state is visible to the user (i.e. an instance exists).
+inline bool isVisible(State s) { return s != State::Inactive; }
+inline bool isActive(State s) { return s == State::ActiveUnacked || s == State::ActiveAcked; }
+inline bool isUnacked(State s) { return s == State::ActiveUnacked || s == State::ClearedUnacked; }
+
+// ============================================================================
+// Window evidence helpers
+// ============================================================================
+// The registry tick samples monotonic counters and derives per-window deltas.
+// Modules only ever increment counters (the existing Statistics pattern); all
+// windowing and hysteresis lives here, centrally.
+
+// Delta between two samples of a monotonic counter. A backwards counter
+// (module restarted its counters) yields 0 - one window of no evidence,
+// absorbed by the streak hysteresis.
+uint64_t counterDelta(uint64_t previous, uint64_t current);
+
+// Per-window evidence for a "configured X is failing" condition.
+enum class Evidence : uint8_t {
+    None, // nothing happened this window - keep current streak
+    Good, // at least one success - reset streak
+    Bad,  // failures and no successes - extend streak
+};
+
+Evidence rateEvidence(uint64_t okDelta, uint64_t errorDelta);
+
+// Consecutive-bad-windows streak with no-evidence freeze. Returns the updated
+// streak. Raise predicates compare the streak against a per-code threshold;
+// one good window collapses it to zero (immediate clear).
+uint16_t updateStreak(uint16_t streak, Evidence evidence);
+
+// ============================================================================
+// Per-code predicates
+// ============================================================================
+
+// Channel polarity mismatch: a LOAD/PV channel whose evidence-carrying readings
+// (conducting, or sub-gate with |P| above the offset-noise floor) keep getting
+// clamped to zero (reverse flag and physical CT orientation disagree - either
+// side can be the fix, the symptom is the same). Evaluated over one tick window
+// of per-channel counter deltas. Windows with fewer than minEvidenceReads
+// evidence reads carry no evidence.
+Evidence channelMismatchEvidence(uint32_t evidenceDelta, uint32_t clampedDelta,
+                                 uint32_t minEvidenceReads, float minClampedFraction);
+
+// Sustained meter read failures: bad when the failure delta in this window
+// reaches failureThreshold, good when a window stays below it.
+Evidence readFailureEvidence(uint64_t failureDelta, uint64_t failureThreshold);
+
+// Nominal mains references (the supported grids): 120 V / 230 V, 50 Hz / 60 Hz.
+float nearestNominalVoltage(float voltage);
+float nearestNominalFrequency(float frequency);
+
+// Out-of-range checks return Evidence so they plug into the same streak
+// hysteresis (sustained deviation raises; one in-range window clears).
+// A non-positive / absurd reading carries no evidence (meter not reading).
+Evidence voltageEvidence(float voltage, float fractionTolerance);
+Evidence frequencyEvidence(float frequency, float hzTolerance);
+
+} // namespace IssueLogic

--- a/source/lib/meter_logic/channel_types.h
+++ b/source/lib/meter_logic/channel_types.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#pragma once
+
+#include <cstdint>
+
+// Shared channel-configuration types, deliberately free of any Arduino / FreeRTOS
+// dependency so that the pure measurement and scheduling logic in meter_logic can
+// be compiled and unit-tested on the host (see lib/meter_logic + test/).
+//
+// ChannelRole lives here (not in ade7953.h) so the host build never has to pull in
+// Arduino.h just to know what "GRID" or "LOAD" means.
+
+// Plain enum (not enum class) so it serializes directly to/from JSON as an integer.
+enum ChannelRole : uint8_t {
+    CHANNEL_ROLE_LOAD     = 0, // Default - regular load/consumption (negatives clamped to 0)
+    CHANNEL_ROLE_GRID     = 1, // Grid meter (+ import, - export)
+    CHANNEL_ROLE_PV       = 2, // PV/Solar production (+ generation, negatives clamped to 0)
+    CHANNEL_ROLE_BATTERY  = 3, // Battery (+ discharge, - charge)
+    CHANNEL_ROLE_INVERTER = 4, // Hybrid inverter: PV + battery DC-coupled, AC output (negatives allowed)
+    CHANNEL_ROLE_COUNT    = 5  // Total number of roles
+};
+
+#define DEFAULT_CHANNEL_ROLE CHANNEL_ROLE_LOAD
+#define DEFAULT_CHANNEL_0_ROLE CHANNEL_ROLE_GRID // Channel 0 is typically the grid meter

--- a/source/lib/meter_logic/meter_logic.cpp
+++ b/source/lib/meter_logic/meter_logic.cpp
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#include "meter_logic.h"
+
+#include <cmath>
+
+namespace MeterLogic {
+
+// ----------------------------------------------------------------------------
+// Reading classification
+// ----------------------------------------------------------------------------
+bool isConductingReading(float activePower, float current, float minCurrent) {
+    return !std::isnan(activePower) && activePower != 0.0f &&
+           !std::isnan(current) && current >= minCurrent;
+}
+
+// ----------------------------------------------------------------------------
+// CT polarity detector
+// ----------------------------------------------------------------------------
+PolarityResult updatePolarity(PolarityState state, float activePower, float current, PolarityConfig cfg) {
+    PolarityResult result{state, PolarityAction::Continue};
+
+    // Not armed: nothing to do. Defensive - callers should only invoke while armed.
+    if (!state.armed) return result;
+
+    // A non-positive threshold is a misconfiguration; treat it as a safe no-op
+    // rather than letting the sign comparisons below decide on the very first read.
+    if (cfg.voteThreshold <= 0) return result;
+
+    // Only conducting samples carry sign information. A non-conducting reading
+    // (no load, a reading the validation pipeline zeroed, or a small offset power at
+    // near-zero current) is a pure no-op: the channel stays armed and waits, without
+    // ever counting toward the bound. The current gate (cfg.minCurrent) is what stops
+    // ADE7953 offset noise on an unclamped role from voting a false reversal, and it
+    // is also what lets a CT clipped on a circuit that is off at install time still be
+    // checked once real load eventually flows.
+    if (!isConductingReading(activePower, current, cfg.minCurrent)) return result;
+
+    result.state.conductingReads++;
+    result.state.voteCount += (activePower < 0.0f) ? -1 : 1;
+
+    if (result.state.voteCount <= -cfg.voteThreshold) {
+        result.action = PolarityAction::Flip;
+        result.state.armed = false;
+        result.state.voteCount = 0;
+        result.state.conductingReads = 0;
+        return result;
+    }
+    if (result.state.voteCount >= cfg.voteThreshold) {
+        result.action = PolarityAction::Disarm;
+        result.state.armed = false;
+        result.state.voteCount = 0;
+        result.state.conductingReads = 0;
+        return result;
+    }
+
+    // Bound only the pathological case: a channel that keeps conducting but whose
+    // sign oscillates without ever reaching the threshold. Give up with no flip -
+    // an ambiguous signal cannot be oriented automatically.
+    if (cfg.maxConductingReads > 0 && result.state.conductingReads >= cfg.maxConductingReads) {
+        result.action = PolarityAction::Disarm;
+        result.state.armed = false;
+        result.state.voteCount = 0;
+        result.state.conductingReads = 0;
+    }
+
+    return result;
+}
+
+// ----------------------------------------------------------------------------
+// Negative-reading handling
+// ----------------------------------------------------------------------------
+bool shouldClampNegative(float activePower, ChannelRole role) {
+    return activePower < 0.0f &&
+           (role == CHANNEL_ROLE_LOAD || role == CHANNEL_ROLE_PV);
+}
+
+// ----------------------------------------------------------------------------
+// WDRR weighting
+// ----------------------------------------------------------------------------
+bool roleHasSchedulingPriority(ChannelRole role) {
+    return role == CHANNEL_ROLE_GRID || role == CHANNEL_ROLE_BATTERY;
+}
+
+float computeChannelWeight(const ChannelWeightInput& in, float powerShare,
+                           float variabilityShare, const WeightConfig& cfg) {
+    if (!in.active) return 0.0f;
+
+    float weight = cfg.powerShare * powerShare +
+                   cfg.variability * variabilityShare +
+                   cfg.minBase;
+
+    // Grid / battery are sampled more often (mains + storage flow matter most,
+    // especially on 3-phase). Applied to the base share before the armed boost so
+    // the boost stays a fixed, role-independent priority.
+    if (roleHasSchedulingPriority(in.role)) weight *= cfg.rolePriorityMult;
+
+    // Polarity-detection boost, gated on conduction (in.conducting, the caller's
+    // pre-clamp "drawing power right now" signal). An armed channel only earns the
+    // boost while actually conducting - so a CT clipped on an idle circuit waits at
+    // normal cadence (no starvation) yet is sampled rapidly the moment load appears,
+    // resolving in ~1 s. Using the pre-clamp signal (not activePower, which is 0 for
+    // a clamped reversed load/PV) means reversed loads get the boost too.
+    if (in.armed && in.conducting) weight += cfg.armedBoost;
+
+    return weight;
+}
+
+void computeWeights(const ChannelWeightInput* in, uint8_t count, uint8_t startIndex,
+                    const WeightConfig& cfg, float* outWeights) {
+    // Indices outside the scheduled range are not part of the rotation.
+    for (uint8_t i = 0; i < startIndex && i < count; i++) outWeights[i] = 0.0f;
+
+    // First pass: totals across active channels. NaN guard keeps a single bad
+    // reading from poisoning every share (and thus every weight).
+    float totalAbsPower = 0.0f;
+    float totalVariability = 0.0f;
+    for (uint8_t i = startIndex; i < count; i++) {
+        if (!in[i].active) continue;
+        if (!std::isnan(in[i].activePower)) totalAbsPower += std::fabs(in[i].activePower);
+        if (!std::isnan(in[i].variability)) totalVariability += in[i].variability;
+    }
+
+    // Second pass: per-channel weights.
+    for (uint8_t i = startIndex; i < count; i++) {
+        if (!in[i].active) {
+            outWeights[i] = 0.0f;
+            continue;
+        }
+
+        float powerShare = 0.0f;
+        if (totalAbsPower > 0.0f && !std::isnan(in[i].activePower)) {
+            powerShare = std::fabs(in[i].activePower) / totalAbsPower;
+        }
+
+        float variabilityShare = 0.0f;
+        if (totalVariability > 0.0f && !std::isnan(in[i].variability)) {
+            variabilityShare = in[i].variability / totalVariability;
+        }
+
+        outWeights[i] = computeChannelWeight(in[i], powerShare, variabilityShare, cfg);
+    }
+}
+
+// ----------------------------------------------------------------------------
+// WDRR scheduler core
+// ----------------------------------------------------------------------------
+uint8_t findStarvedChannel(const uint64_t* lastMillis, const bool* active,
+                           uint8_t count, uint8_t startIndex, uint64_t now,
+                           uint64_t maxGap) {
+    for (uint8_t i = startIndex; i < count; i++) {
+        if (!active[i]) continue;
+        if (lastMillis[i] == 0) continue; // never baselined - priority slot handles it
+        if (now - lastMillis[i] > maxGap) return i;
+    }
+    return NO_CHANNEL;
+}
+
+void wdrrAccumulate(const float* weights, float* deficits, const bool* active,
+                    uint8_t count, uint8_t startIndex, float deficitBound) {
+    for (uint8_t i = startIndex; i < count; i++) {
+        if (active[i]) deficits[i] += weights[i];
+        else deficits[i] = 0.0f;
+
+        if (std::isnan(deficits[i])) deficits[i] = 0.0f;
+        if (deficits[i] > deficitBound) deficits[i] = deficitBound;
+        else if (deficits[i] < -deficitBound) deficits[i] = -deficitBound;
+    }
+}
+
+uint8_t wdrrPick(float* deficits, const bool* active, uint8_t count,
+                 uint8_t startIndex, uint8_t* cursor) {
+    if (count <= startIndex) return NO_CHANNEL;
+    const uint8_t range = count - startIndex;
+
+    uint8_t bestChannel = NO_CHANNEL;
+    float bestDeficit = 0.0f; // only meaningful once bestChannel is set
+
+    // Iterate all schedulable channels starting one past the cursor, so that when
+    // deficits are tied (e.g. a fleet of idle channels) service rotates instead of
+    // the lowest index winning every time. The first active channel seeds the max
+    // (no sentinel, so the result is independent of the deficit scale); strict '>'
+    // thereafter makes the first-seen max win, preserving the rotation on ties.
+    for (uint8_t offset = 0; offset < range; offset++) {
+        uint8_t i = startIndex + ((*cursor - startIndex + 1 + offset) % range);
+        if (!active[i]) continue;
+        if (bestChannel == NO_CHANNEL || deficits[i] > bestDeficit) {
+            bestDeficit = deficits[i];
+            bestChannel = i;
+        }
+    }
+
+    if (bestChannel != NO_CHANNEL) {
+        deficits[bestChannel] -= 1.0f;
+        *cursor = bestChannel;
+    }
+
+    return bestChannel;
+}
+
+} // namespace MeterLogic

--- a/source/lib/meter_logic/meter_logic.h
+++ b/source/lib/meter_logic/meter_logic.h
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#pragma once
+
+#include <cstdint>
+#include "channel_types.h"
+
+// Pure measurement and scheduling decisions for the ADE7953 channel pipeline.
+//
+// Everything here is free-standing: no Arduino, no FreeRTOS, no SPI, no logging,
+// no global state. Inputs come in as plain values, decisions go out as plain
+// values, and the caller (src/ade7953.cpp) is responsible for all I/O, mutexes
+// and for acting on the decisions. That boundary is what lets this logic be
+// unit-tested on the host (see test/test_meter_logic) without any hardware.
+namespace MeterLogic {
+
+// ============================================================================
+// CT polarity (reversed-CT) detector
+// ============================================================================
+// A net consistent-sign vote accumulator. Each CONDUCTING reading votes +1
+// (power flows in the expected direction) or -1 (reversed). The orientation is
+// decided once the running net reaches +/- voteThreshold, which makes the
+// detector magnitude-independent (a steady -4 W reversed CT is caught like a
+// -4 kW one) and immune to transient sign flips (they cancel out).
+//
+// A non-conducting reading (no load) carries no sign information: it does NOT
+// vote and does NOT count toward any bound, so an armed channel with no load
+// simply waits - indefinitely if need be. This is deliberate: a CT clipped on a
+// circuit that happens to be off at install time must still be checked the moment
+// real load first flows. (Starvation is prevented separately, by gating the
+// scheduler boost on conduction - see computeChannelWeight - not by disarming.)
+//
+// maxConductingReads only bounds the pathological case of a channel that DOES
+// conduct but whose sign keeps oscillating (never reaching the threshold): after
+// that many conducting reads it gives up with no flip.
+
+enum class PolarityAction : uint8_t {
+    Continue, // still accumulating - caller does nothing
+    Flip,     // threshold of reversed votes reached - caller flips the reverse flag
+    Disarm,   // confirmed correct, or gave up on an ambiguous signal - caller stops, no flip
+};
+
+struct PolarityState {
+    bool armed;               // detection in progress for this channel
+    int8_t voteCount;         // running net vote (+ expected, - reversed)
+    uint16_t conductingReads; // conducting reads seen since arming (for the bound)
+};
+
+struct PolarityConfig {
+    int8_t voteThreshold;       // net votes needed to decide (e.g. 5)
+    uint16_t maxConductingReads; // give up after this many conducting reads w/o a decision (0 = no bound)
+    float minCurrent;            // a reading below this current is offset noise: no vote, no count
+};
+
+struct PolarityResult {
+    PolarityState state; // updated state to store back
+    PolarityAction action;
+};
+
+// True if a reading carries usable directional information: a real, non-zero
+// power backed by enough current (current >= minCurrent) that the ADE7953's
+// offset noise - which shows up as a small, consistent-sign power at essentially
+// zero current - cannot masquerade as a genuine (possibly reversed) load. This is
+// the one definition of "conducting" used across the pipeline: updatePolarity gates
+// the vote on it, and the firmware gates the scheduler's armed boost (_lastConducting,
+// feeding computeChannelWeight) on the same call, so the two can never disagree about
+// whether a channel is drawing power. NaN power or NaN current -> false.
+//
+// A reversed load/PV reads NEGATIVE power but with REAL current, so it stays
+// conducting - that is what lets a reversed CT both vote (to flip) and earn the boost.
+bool isConductingReading(float activePower, float current, float minCurrent);
+
+// One detector step for a single channel reading. Safe to call on every read of
+// an armed channel: a non-conducting reading is a no-op. The reading votes only if
+// isConductingReading(activePower, current, cfg.minCurrent) - so 0/NaN power, or a
+// small offset power at near-zero current, never votes and never counts toward the
+// bound. activePower's sign gives the vote direction.
+//
+// PRECONDITION: feed the RAW signed reading (both power and current). Do NOT
+// pre-clamp negative power to zero before calling - a reversed LOAD/PV reads
+// negative with real current, and clamping power to 0 first would make the reading
+// look non-conducting, so the reversal would never be detected. (The firmware runs
+// this detector before shouldClampNegative.) current is the post-validation current
+// (an invalid low-current reading is already zeroed upstream, which correctly reads
+// as non-conducting here).
+PolarityResult updatePolarity(PolarityState state, float activePower, float current, PolarityConfig cfg);
+
+// ============================================================================
+// Negative-reading handling
+// ============================================================================
+
+// True if a negative active-power reading on this role is physically impossible
+// and must be clamped to zero. Load and PV can only consume / generate one way;
+// grid, battery and hybrid inverters legitimately go negative (export / charge).
+bool shouldClampNegative(float activePower, ChannelRole role);
+
+// ============================================================================
+// WDRR weighting
+// ============================================================================
+// Weighted Deficit Round-Robin sampling weights. Higher weight -> sampled more
+// often. Weight = power-share + variability-share + a minimum base (so every
+// active channel is eventually serviced), with two priority bumps on top:
+//   - grid / battery roles get a multiplier (we want the mains and storage flow
+//     sampled more often, especially on 3-phase systems);
+//   - a channel actively running polarity detection AND currently conducting (the
+//     `conducting` input) gets a flat boost so it resolves quickly. Gating on
+//     conduction means an armed channel with no load gets no boost and cannot hog
+//     the scheduler while it waits for load (this prevents the no-load starvation),
+//     while a reversed load/PV - whose stored power is clamped to 0 but which is
+//     genuinely conducting - still earns the boost and resolves in ~1 s.
+
+struct WeightConfig {
+    float powerShare;       // contribution from |power| share
+    float variability;      // contribution from variability share
+    float minBase;          // floor for every active channel (anti-starvation)
+    float armedBoost;       // flat add-on while polarity detection is armed AND conducting
+    float rolePriorityMult; // multiplier for grid / battery roles (e.g. 2.0)
+};
+
+struct ChannelWeightInput {
+    bool active;
+    float activePower;       // signed; only the magnitude is used (for the power share)
+    float variability;       // EMA of |delta power|
+    bool armed;              // polarity detection in progress
+    ChannelRole role;
+    bool conducting = false; // is the channel drawing power *right now*? Drives the
+                             // armed boost. Deliberately separate from activePower!=0:
+                             // a reversed load/PV is stored clamped to 0 yet is really
+                             // conducting, so the caller passes the pre-clamp signal -
+                             // otherwise reversed loads would never earn the boost.
+};
+
+// True if this role is sampled more often (grid + battery).
+bool roleHasSchedulingPriority(ChannelRole role);
+
+// Weight for a single channel given its precomputed shares (each 0..1).
+float computeChannelWeight(const ChannelWeightInput& in, float powerShare,
+                           float variabilityShare, const WeightConfig& cfg);
+
+// Compute weights for channels [startIndex, count). Indices below startIndex are
+// set to 0 (the firmware reads channel 0 separately, outside the rotation).
+// NaN power / variability values are excluded from the totals and treated as 0,
+// so one bad reading cannot poison every other channel's weight.
+void computeWeights(const ChannelWeightInput* in, uint8_t count, uint8_t startIndex,
+                    const WeightConfig& cfg, float* outWeights);
+
+// ============================================================================
+// WDRR scheduler core
+// ============================================================================
+
+// Sentinel for "no channel". Deliberately NOT named INVALID_CHANNEL: the firmware
+// defines that as an object-like macro (#define INVALID_CHANNEL 255), which would
+// textually rewrite any `MeterLogic::INVALID_CHANNEL` into `MeterLogic::255`. The
+// firmware asserts NO_CHANNEL == its own INVALID_CHANNEL so the values stay in sync.
+constexpr uint8_t NO_CHANNEL = 255;
+
+// Lowest-index active channel whose gap (now - lastMillis) exceeds maxGap, over
+// [startIndex, count). Channels with lastMillis == 0 (never baselined) are
+// skipped. Returns NO_CHANNEL if none are starved. Pure lookup - the caller
+// updates lastMillis after forcing the read.
+uint8_t findStarvedChannel(const uint64_t* lastMillis, const bool* active,
+                           uint8_t count, uint8_t startIndex, uint64_t now,
+                           uint64_t maxGap);
+
+// Gain phase: add each active channel's weight to its deficit; zero inactive
+// channels; guard NaN; clamp symmetrically to +/- deficitBound. Operates on
+// [startIndex, count).
+void wdrrAccumulate(const float* weights, float* deficits, const bool* active,
+                    uint8_t count, uint8_t startIndex, float deficitBound);
+
+// Pick phase: select the highest-deficit active channel over [startIndex, count)
+// with a round-robin tie-break starting one past *cursor (so equal-deficit
+// channels rotate instead of letting the lowest index monopolise). Decrements
+// the winner's deficit by 1 and moves *cursor to it. Returns the winner, or
+// NO_CHANNEL if no active channel exists.
+uint8_t wdrrPick(float* deficits, const bool* active, uint8_t count,
+                 uint8_t startIndex, uint8_t* cursor);
+
+} // namespace MeterLogic

--- a/source/platformio.ini
+++ b/source/platformio.ini
@@ -91,6 +91,7 @@ board_build.embed_txtfiles =
 	js/api-client.js
 	js/chart-helpers.js
 	js/data-helpers.js
+	js/issues.js
 	js/power-flow.js
 	js/tooltip.js
 

--- a/source/platformio.ini
+++ b/source/platformio.ini
@@ -1,4 +1,13 @@
 ; ============================================================================
+; Project Configuration
+; ============================================================================
+; default_envs limits `pio run` to the firmware targets. The `native` env builds
+; host unit tests only (pio test -e native) and must never be a default build.
+; ============================================================================
+[platformio]
+default_envs = esp32s3-dev, esp32s3-prod
+
+; ============================================================================
 ; Common Configuration (shared by all environments)
 ; ============================================================================
 ; In general, it is required to always pin all the libraries and packages to the exact
@@ -267,3 +276,16 @@ lib_deps = ${common.lib_deps}
 
 ; Embedded Files
 board_build.embed_txtfiles = ${common.board_build.embed_txtfiles}
+
+; ============================================================================
+; Native host environment - unit tests only:  pio test -e native
+; Compiles the pure libraries (e.g. lib/meter_logic) + test/ with the host
+; compiler (no Arduino, no board). Never built by `pio run` (see default_envs).
+; ============================================================================
+[env:native]
+platform = native
+test_framework = unity
+build_flags =
+    -std=c++17
+    -Wall
+    -Wextra

--- a/source/resources/swagger.yaml
+++ b/source/resources/swagger.yaml
@@ -523,6 +523,91 @@ paths:
         '400':
           $ref: '#/components/responses/BadRequest'
 
+  /api/v1/system/issues:
+    get:
+      summary: Get device issues
+      description: List current device issues (runtime-derived, ISA-18.2-lite lifecycle). Issues disappear only when the condition is gone and the user acknowledged them.
+      tags:
+        - System
+      responses:
+        '200':
+          description: Device issues
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  issues:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        code:
+                          type: string
+                          description: Issue code (snake_case)
+                          example: "channel_polarity_mismatch"
+                        channel:
+                          type: integer
+                          description: Channel index (omitted for global issues)
+                          example: 0
+                        state:
+                          type: string
+                          enum: [active_unacked, active_acked, cleared_unacked]
+                          example: "active_unacked"
+                        severity:
+                          type: string
+                          enum: [info, warning, error]
+                          example: "error"
+                        firstSeenUnix:
+                          type: integer
+                          description: Unix timestamp when the issue was first raised
+                          example: 1781099726
+                        lastChangeUnix:
+                          type: integer
+                          description: Unix timestamp of the last state change
+                          example: 1781099726
+                        occurrences:
+                          type: integer
+                          description: Number of times the issue was raised this boot
+                          example: 1
+                        message:
+                          type: string
+                          description: Human-readable description
+                          example: "Channel 0: readings persistently negative and clamped to 0 W. The reverse flag and the physical CT orientation disagree - fix either."
+
+  /api/v1/system/issues/ack:
+    post:
+      summary: Acknowledge device issues
+      description: Acknowledge a single issue (by code, plus channel for channel-scoped codes) or all issues at once. Acknowledged active issues stay listed until their condition clears; acknowledged cleared issues are removed.
+      tags:
+        - System
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                all:
+                  type: boolean
+                  description: Acknowledge every unacknowledged issue
+                  example: true
+                code:
+                  type: string
+                  description: Issue code to acknowledge (alternative to all)
+                  example: "channel_polarity_mismatch"
+                channel:
+                  type: integer
+                  description: Channel index (required for channel-scoped codes)
+                  example: 0
+      responses:
+        '200':
+          $ref: '#/components/responses/Success'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /api/v1/firmware/update-info:
     get:
       summary: Get firmware update information

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -3654,7 +3654,7 @@ namespace Ade7953
 
         // Noise floors scale with the CT: a fixed threshold suited to a 30 A clamp is far
         // below the offset noise of a 100 A one (and too strict for a small one), so both
-        // thresholds are fractions of the channel's CT rating. At 30 A: 15 mA / 30 mA.
+        // thresholds are fractions of the channel's CT rating.
         float minCurrentThreePhaseNoLoad = channelData.ctSpecification.currentRating * MINIMUM_CURRENT_RATIO_THREE_PHASE_NO_LOAD;
         float minCurrentValidation = channelData.ctSpecification.currentRating * MINIMUM_CURRENT_RATIO_VALIDATION;
 

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -31,9 +31,18 @@ namespace Ade7953
     static float _prevActivePower[MAX_CHANNEL_COUNT] = {};   // Previous power reading for variability tracking
     static float _powerVariability[MAX_CHANNEL_COUNT] = {};  // EMA of |delta power| for variability scoring
     static uint8_t _wdrrCursor = 0;                          // Round-robin tie-break cursor for argmax
+    static int8_t _polarityVoteCount[MAX_CHANNEL_COUNT] = {}; // Net consistent-sign vote accumulator for CT-reversal detection (runtime only; reset on arm/decision)
+    static uint16_t _polarityConductingReads[MAX_CHANNEL_COUNT] = {}; // Conducting reads since arming - bounds a sign-oscillating channel (runtime only; reset on arm/decision)
+    static bool _lastConducting[MAX_CHANNEL_COUNT] = {}; // Was the channel's most recent reading conducting (pre-clamp)? Drives the CT-detection boost so a clamped reversed load/PV still gets it (meter-task only)
     static float _gridFrequency = 50.0f;
 
-    // Set by the meter task when an auto-polarity flip flips the persisted reverse flag.
+    // The library returns MeterLogic::NO_CHANNEL for "no channel"; the firmware
+    // compares scheduler results against its own INVALID_CHANNEL macro. They must
+    // hold the same value. (The library cannot reuse the name INVALID_CHANNEL: it
+    // is an object-like macro here and would rewrite MeterLogic::INVALID_CHANNEL.)
+    static_assert(INVALID_CHANNEL == MeterLogic::NO_CHANNEL, "INVALID_CHANNEL / MeterLogic::NO_CHANNEL value mismatch");
+
+    // Set by the meter task when the CT-reversal detector flips the persisted reverse flag.
     // Drained by the energy save task (internal-RAM stack, flash-capable) since the meter
     // task runs on a PSRAM stack and cannot perform NVS writes.
     static volatile bool _pendingPolaritySave[MAX_CHANNEL_COUNT] = {};
@@ -790,21 +799,27 @@ namespace Ade7953
         // re-runs the auto-polarity detection and can oscillate the persisted reverse
         // flag on channels that genuinely read negative at idle.
         if (armTransients) {
-            if (wasInactive && _channelData[channelIndex].active) {
-                _channelData[channelIndex]._pendingPolarityCheck = true;
+            bool reverseChanged = (oldReverse != _channelData[channelIndex].reverse);
+            bool activated = (wasInactive && _channelData[channelIndex].active);
+            bool roleChangedActive = (!wasInactive && _channelData[channelIndex].active && oldRole != _channelData[channelIndex].role);
+
+            if (reverseChanged) {
+                // A manual reverse change is the trusted value: disarm CT-reversal
+                // detection so it can never override the user's explicit choice, and
+                // (issue #149) read once now so the corrected sign lands immediately
+                // instead of up to 15 s away on a heavily loaded scheduler.
+                _channelData[channelIndex]._pendingPolarityCheck = false;
+                _polarityVoteCount[channelIndex] = 0;
+                _polarityConductingReads[channelIndex] = 0;
                 if (channelIndex > 0) _channelData[channelIndex]._pendingPriorityRead = true;
-            }
-            // Re-arm polarity check on role change while channel is active (sign convention
-            // can legitimately differ between roles; let the next reading re-validate).
-            if (!wasInactive && _channelData[channelIndex].active && oldRole != _channelData[channelIndex].role) {
+            } else if (activated || roleChangedActive) {
+                // Fresh activation / role change with no explicit polarity choice: arm
+                // auto-detection from a clean vote count. The sign convention can
+                // legitimately differ between roles, so a role change re-validates.
                 _channelData[channelIndex]._pendingPolarityCheck = true;
-            }
-            // Fix for issue #149: arm priority read when the user flips the reverse
-            // flag via API. Intent is "read me now with the corrected sign" - without
-            // this, the corrected reading lands on the next normal rotation slot,
-            // which can be up to 15 s away on a heavily loaded scheduler.
-            if (channelIndex > 0 && oldReverse != _channelData[channelIndex].reverse) {
-                _channelData[channelIndex]._pendingPriorityRead = true;
+                _polarityVoteCount[channelIndex] = 0;
+                _polarityConductingReads[channelIndex] = 0;
+                if (channelIndex > 0) _channelData[channelIndex]._pendingPriorityRead = true;
             }
         }
 
@@ -3798,22 +3813,48 @@ namespace Ade7953
 
         }
 
-        // Auto-detect a reversed CT clamp on the first meaningful reading after activation
-        // (or after a role change). If the active power is negative, toggle the persisted
-        // reverse flag, queue the NVS write for the energy save task, re-arm the priority
-        // slot so the corrected reading lands on the very next linecyc, and discard this
-        // reading. The threshold avoids flipping on noise when the circuit is essentially idle.
-        //
-        // Hold _channelDataMutex for the test-and-clear so a concurrent setChannelData arm
-        // is neither lost nor double-fired. The block only fires once per channel after
-        // activation / role change so the contention is negligible.
-        if (abs(activePower) >= AUTO_POLARITY_MIN_POWER_W) {
+        // CT-reversal detection. While a channel is armed (set on activation / role
+        // change without a manual reverse - see setChannelData) AND conducting, feed
+        // each reading to the net sign-vote detector (MeterLogic::updatePolarity).
+        // Only conducting samples carry sign information, so a no-load armed channel
+        // simply waits: it is never disarmed and (the boost being conduction-gated in
+        // _recalculateWeights) never starves its peers, so a CT clipped on a circuit
+        // that is off at install time is still checked the moment load first flows.
+        // Magnitude is irrelevant - only sign consistency matters - so a steady -4 W
+        // reversed CT is caught like a -4 kW one. A decisive run of reversed votes
+        // flips the persisted reverse flag once (and we negate this reading so it is
+        // stored with the corrected sign); a decisive run of forward votes confirms
+        // the CT. Hold _channelDataMutex for the test-and-update so a concurrent
+        // setChannelData arm/disarm is neither lost nor double-fired. (The unsynced
+        // _pendingPolarityCheck pre-check is an atomic-bool fast path; it is re-tested
+        // under the mutex before any state change.)
+        // Current-gate "conducting" so ADE7953 offset noise at ~0 A (a small, steady,
+        // signed power) cannot vote a false reversal on an unclamped role (grid/battery)
+        // or earn the armed boost. The same signal drives _lastConducting below, so the
+        // vote and the boost always agree on whether the channel is drawing power.
+        bool conducting = MeterLogic::isConductingReading(
+            activePower, current, MINIMUM_CURRENT_FOR_VALIDATION);
+
+        if (_channelData[channelIndex]._pendingPolarityCheck && conducting) {
             bool flipped = false;
             bool newReverse = false;
             if (acquireMutex(&_channelDataMutex)) {
                 if (_channelData[channelIndex]._pendingPolarityCheck) {
-                    _channelData[channelIndex]._pendingPolarityCheck = false;
-                    if (activePower < 0.0f) {
+                    MeterLogic::PolarityState state{
+                        true, // armed (guarded above and re-checked here)
+                        _polarityVoteCount[channelIndex],
+                        _polarityConductingReads[channelIndex]
+                    };
+                    MeterLogic::PolarityConfig cfg{
+                        POLARITY_DETECT_VOTE_THRESHOLD,
+                        POLARITY_DETECT_MAX_CONDUCTING_READS,
+                        MINIMUM_CURRENT_FOR_VALIDATION
+                    };
+                    MeterLogic::PolarityResult res = MeterLogic::updatePolarity(state, activePower, current, cfg);
+                    _polarityVoteCount[channelIndex] = res.state.voteCount;
+                    _polarityConductingReads[channelIndex] = res.state.conductingReads;
+                    _channelData[channelIndex]._pendingPolarityCheck = res.state.armed;
+                    if (res.action == MeterLogic::PolarityAction::Flip) {
                         _channelData[channelIndex].reverse = !_channelData[channelIndex].reverse;
                         _pendingPolaritySave[channelIndex] = true;
                         if (channelIndex > 0) _channelData[channelIndex]._pendingPriorityRead = true;
@@ -3824,35 +3865,41 @@ namespace Ade7953
                 releaseMutex(&_channelDataMutex);
             }
             if (flipped) {
+                // This reading was computed with the pre-flip sign; negate the signed
+                // quantities so it stores consistently with the new reverse flag
+                // (apparent power and current stay positive).
+                activePower = -activePower;
+                reactivePower = -reactivePower;
+                activeEnergy = -activeEnergy;
+                reactiveEnergy = -reactiveEnergy;
+                powerFactor = -powerFactor;
                 LOG_INFO(
-                    "%s (%u): auto-detected reversed CT (raw P=%.1fW, role=%s); reverse flag now %d, discarding this reading",
+                    "%s (%u): CT reversal detected (P now %.1fW, role=%s); reverse flag now %d",
                     channelData.label, channelIndex, activePower,
                     channelRoleToString(channelData.role), newReverse
                 );
-                _recordFailure();
-                return false;
             }
         }
 
-        // Discard negative readings for Load channels (likely CT installed backwards)
-        if (activePower < 0.0f && channelData.role == CHANNEL_ROLE_LOAD) {
-            LOG_DEBUG(
-                "%s (%d): Discarding negative reading (%.1fW) (Load channel, likely CT installed backwards)",
-                channelData.label,
-                channelIndex,
-                activePower
-            );
-            _recordFailure();
-            return false;
-        }
+        // Record whether this reading is conducting (computed above, current-gated)
+        // BEFORE the clamp below zeroes a reversed load/PV. The WDRR boost for an armed
+        // channel keys off this (not the stored power), so a reversed load/PV - stored
+        // as 0 but really drawing power - still gets sampled rapidly and resolves its
+        // orientation in ~1 s, while a near-zero-current offset reading earns no boost.
+        _lastConducting[channelIndex] = conducting;
 
-        // Clamp negative readings to zero for PV channels (expected inverter standby consumption, so no record failure)
-        if (activePower < 0.0f && channelData.role == CHANNEL_ROLE_PV) {
+        // Clamp negative active power to zero for load and PV channels. With the phase
+        // configured correctly a load/PV should not be net-negative; a residual negative
+        // is PV inverter standby or sub-detection noise. Clamp (do NOT discard) so the
+        // data cadence is preserved - a genuinely reversed CT is corrected by the
+        // reversal detector above, not by dropping readings (which created silent gaps).
+        if (MeterLogic::shouldClampNegative(activePower, channelData.role)) {
             LOG_DEBUG(
-                "%s (%d): Clamping negative reading (%.1fW) to 0 (PV channel, likely inverter standby consumption)",
+                "%s (%d): clamping negative reading (%.1fW) to 0 (role=%s)",
                 channelData.label,
                 channelIndex,
-                activePower
+                activePower,
+                channelRoleToString(channelData.role)
             );
             activePower = 0.0f;
             reactivePower = 0.0f;
@@ -4445,48 +4492,31 @@ namespace Ade7953
      * - Minimum base: every active channel gets a minimum weight to prevent starvation
      */
     static void _recalculateWeights() {
-        float totalAbsPower = 0.0f;
-        float totalVariability = 0.0f;
+        const uint8_t count = globalHwProfile->totalChannelCount;
 
-        // Sum totals across active multiplexed channels (skip channel 0).
-        // NaN guards: a NaN reading must not poison the totals - it would
-        // make every powerScore NaN, propagating into _channelWeight[] and
-        // breaking argmax in _findNextActiveChannel.
-        for (uint8_t i = 1; i < globalHwProfile->totalChannelCount; i++) {
-            if (_channelData[i].active) {
-                float ap = _meterValues[i].activePower;
-                float pv = _powerVariability[i];
-                if (!isnan(ap)) totalAbsPower += fabsf(ap);
-                if (!isnan(pv)) totalVariability += pv;
-            }
+        // Gather the per-channel inputs for the pure WDRR weight computation
+        // (MeterLogic::computeWeights handles the power/variability shares, the
+        // grid/battery multiplier, the conduction-gated polarity boost, and the
+        // NaN guards). Reads of _meterValues / _powerVariability here are unlocked,
+        // matching the original meter-task access pattern.
+        MeterLogic::ChannelWeightInput inputs[MAX_CHANNEL_COUNT] = {};
+        for (uint8_t i = 0; i < count; i++) {
+            inputs[i].active = _channelData[i].active;
+            inputs[i].activePower = _meterValues[i].activePower;
+            inputs[i].variability = _powerVariability[i];
+            inputs[i].armed = _channelData[i]._pendingPolarityCheck;
+            inputs[i].role = _channelData[i].role;
+            inputs[i].conducting = _lastConducting[i];
         }
 
-        // Compute per-channel weights
-        for (uint8_t i = 1; i < globalHwProfile->totalChannelCount; i++) {
-            if (!_channelData[i].active) {
-                _channelWeight[i] = 0.0f;
-                continue;
-            }
+        const MeterLogic::WeightConfig cfg{
+            WEIGHT_POWER_SHARE, WEIGHT_VARIABILITY, WEIGHT_MIN_BASE,
+            WEIGHT_ARMED_BOOST, WEIGHT_ROLE_PRIORITY_MULT
+        };
 
-            float powerScore = 0.0f;
-            if (totalAbsPower > 0.0f) {
-                float ap = _meterValues[i].activePower;
-                if (!isnan(ap)) powerScore = fabsf(ap) / totalAbsPower;
-            }
-
-            float variabilityScore = 0.0f;
-            if (totalVariability > 0.0f) {
-                float pv = _powerVariability[i];
-                if (!isnan(pv)) variabilityScore = pv / totalVariability;
-            }
-
-            _channelWeight[i] = WEIGHT_POWER_SHARE * powerScore
-                              + WEIGHT_VARIABILITY * variabilityScore
-                              + WEIGHT_MIN_BASE;
-        }
-
-        // Channel 0 is not scheduled (always read separately)
-        _channelWeight[0] = 0.0f;
+        // startIndex = 1: channel 0 is read separately, outside the rotation
+        // (computeWeights zeroes its weight for us).
+        MeterLogic::computeWeights(inputs, count, 1, cfg, _channelWeight);
     }
 
     /**
@@ -4502,43 +4532,38 @@ namespace Ade7953
     uint8_t _findNextActiveChannel(uint8_t currentChannel) {
         (void)currentChannel; // No longer needed for state tracking
 
+        const uint8_t count = globalHwProfile->totalChannelCount;
+
+        // Snapshot the active flags once (atomic bool reads, unlocked - matches the
+        // original access pattern) and reuse them for every WDRR step below.
+        bool active[MAX_CHANNEL_COUNT] = {};
+        for (uint8_t i = 0; i < count; i++) active[i] = _channelData[i].active;
+
         // Starvation watchdog (fix for issue #149): hard upper bound on the time
-        // between successful reads for any active mux channel. If a channel goes
-        // CHANNEL_MAX_GAP_MS without lastMillis advancing - whether because the
-        // WDRR weights are skewed, the channel is in a discard loop, or the meter
-        // task missed cycles during OTA - force-pick it now.
-        //
-        // After firing, we set lastMillis = now and reset the deficit. The
-        // lastMillis reset throttles the watchdog to one fire per
-        // CHANNEL_MAX_GAP_MS even when the read continues to fail (e.g., a
-        // permanently misclamped CT): user gets one warning per interval, not a
-        // torrent. The deficit reset prevents the channel from immediately
-        // re-winning the argmax on the next call.
-        //
-        // Hold _meterValuesMutex around the read and the write: a 32-bit ESP32
-        // cannot atomically store a uint64_t, so a concurrent setChannelData
-        // baseline write from the web task could be torn-read here.
+        // between successful reads for any active mux channel. MeterLogic::
+        // findStarvedChannel returns the lowest-index channel past CHANNEL_MAX_GAP_MS
+        // (skipping never-baselined ones); we then stamp lastMillis = now - which
+        // throttles the watchdog to one fire per interval even if the read keeps
+        // failing - and reset its deficit so it does not immediately re-win the
+        // argmax. Hold _meterValuesMutex around the 64-bit read + write: a 32-bit
+        // ESP32 cannot atomically store a uint64_t, so a concurrent setChannelData
+        // baseline write could otherwise be torn-read here.
         uint64_t nowMillis = millis64();
         uint8_t starvedChannel = INVALID_CHANNEL;
         uint64_t starvedGap = 0;
         if (acquireMutex(&_meterValuesMutex)) {
-            for (uint8_t i = 1; i < globalHwProfile->totalChannelCount; i++) {
-                if (!_channelData[i].active) continue;
-                uint64_t lastMs = _meterValues[i].lastMillis;
-                if (lastMs == 0) continue; // never baselined - priority slot handles it
-                uint64_t gap = nowMillis - lastMs;
-                if (gap > CHANNEL_MAX_GAP_MS) {
-                    starvedChannel = i;
-                    starvedGap = gap;
-                    _meterValues[i].lastMillis = nowMillis;
-                    break;
-                }
+            uint64_t lastMs[MAX_CHANNEL_COUNT] = {};
+            for (uint8_t i = 0; i < count; i++) lastMs[i] = _meterValues[i].lastMillis;
+            starvedChannel = MeterLogic::findStarvedChannel(lastMs, active, count, 1, nowMillis, CHANNEL_MAX_GAP_MS);
+            if (starvedChannel != INVALID_CHANNEL) {
+                starvedGap = nowMillis - lastMs[starvedChannel];
+                _meterValues[starvedChannel].lastMillis = nowMillis;
             }
             releaseMutex(&_meterValuesMutex);
         }
         if (starvedChannel != INVALID_CHANNEL) {
-            // This might happen in cases of high-value loads in some channels
-            // with static 0W channels, so it is not an error per se (thus DEBUG level)
+            // Can happen with high-power channels alongside static 0 W ones, so it is
+            // not an error per se (hence DEBUG level).
             LOG_DEBUG(
                 "%s (%u): scheduler starvation, %llu ms since last read; force-picking",
                 _channelData[starvedChannel].label, starvedChannel, starvedGap
@@ -4547,34 +4572,20 @@ namespace Ade7953
             return starvedChannel;
         }
 
-        // Add each channel's weight to its deficit. Done BEFORE the priority-claim
-        // loop so that a channel taking the priority slot still has its deficit
-        // updated in this round (fix for issue #149 - previously the priority
-        // branch returned early and skipped the gain phase entirely, leaving the
-        // claiming channel one round behind in the WDRR accounting).
-        // NaN guard + symmetric clamp keeps the deficit array in a sane range even
-        // in pathological cases (NaN injection from a broken read, weight-table
-        // shock from a sudden role change, OTA-induced timing jumps).
-        for (uint8_t i = 1; i < globalHwProfile->totalChannelCount; i++) {
-            if (_channelData[i].active) {
-                _channelDeficit[i] += _channelWeight[i];
-            } else {
-                _channelDeficit[i] = 0.0f;
-            }
-            if (isnan(_channelDeficit[i])) _channelDeficit[i] = 0.0f;
-            if (_channelDeficit[i] > MAX_CHANNEL_DEFICIT_BOUND) _channelDeficit[i] = MAX_CHANNEL_DEFICIT_BOUND;
-            else if (_channelDeficit[i] < -MAX_CHANNEL_DEFICIT_BOUND) _channelDeficit[i] = -MAX_CHANNEL_DEFICIT_BOUND;
-        }
+        // Gain phase: add each active channel's weight to its deficit (NaN-guarded
+        // and symmetrically clamped). Done BEFORE the priority-claim loop so a
+        // channel taking the priority slot still has its deficit advanced this round
+        // (fix for issue #149 - the priority branch used to return early and skip the
+        // gain phase, leaving the claiming channel one round behind).
+        MeterLogic::wdrrAccumulate(_channelWeight, _channelDeficit, active, count, 1, MAX_CHANNEL_DEFICIT_BOUND);
 
         // One-shot priority override: a freshly activated channel jumps the WDRR queue
-        // for exactly one read so the user gets immediate data (and so the auto-polarity
-        // check runs without waiting for the channel to win a normal slot). Take
-        // _channelDataMutex for the test-and-clear so a concurrent re-arm from
-        // setChannelData / the polarity check cannot be lost between read and write.
-        // Priority pick is a freebie: no deficit decrement, since the channel has
-        // not "consumed" a normal scheduling slot.
-        for (uint8_t i = 1; i < globalHwProfile->totalChannelCount; i++) {
-            if (!_channelData[i].active) continue;
+        // for exactly one read so the user gets immediate data (and so the polarity
+        // check runs without waiting for a normal slot). Take _channelDataMutex for
+        // the test-and-clear so a concurrent re-arm cannot be lost. Priority pick is a
+        // freebie: no deficit decrement, since the channel has not consumed a slot.
+        for (uint8_t i = 1; i < count; i++) {
+            if (!_channelData[i].active) continue; // live read (a channel may have just activated)
             bool claim = false;
             if (acquireMutex(&_channelDataMutex)) {
                 if (_channelData[i]._pendingPriorityRead) {
@@ -4586,32 +4597,11 @@ namespace Ade7953
             if (claim) return i;
         }
 
-        // Select the channel with the highest deficit, with a round-robin
-        // tie-break (iteration starts at _wdrrCursor + 1 wrapping back to 1).
-        // Without the rotation, when every active channel sits at the same
-        // deficit (e.g., a multi-channel discard storm or post-watchdog reset),
-        // the lowest-index active channel monopolises the scheduler. The cursor
-        // moves to the winning channel so the next call starts iteration one
-        // past it.
-        uint8_t bestChannel = INVALID_CHANNEL;
-        float bestDeficit = -1e9f; // Use a very large negative value to ensure any active channel is selectable
-
-        uint8_t n = globalHwProfile->totalChannelCount;
-        for (uint8_t offset = 1; offset < n; offset++) {
-            uint8_t i = ((_wdrrCursor + offset - 1) % (n - 1)) + 1;
-            if (_channelData[i].active && _channelDeficit[i] > bestDeficit) {
-                bestDeficit = _channelDeficit[i];
-                bestChannel = i;
-            }
-        }
-
-        // Decrement the selected channel's deficit and advance the cursor.
-        if (bestChannel != INVALID_CHANNEL) {
-            _channelDeficit[bestChannel] -= 1.0f;
-            _wdrrCursor = bestChannel;
-        }
-
-        return bestChannel;
+        // Pick the highest-deficit active channel, with a round-robin tie-break so
+        // that equal deficits (e.g. a fleet of idle channels) rotate instead of the
+        // lowest index monopolising the scheduler. Decrements the winner and advances
+        // _wdrrCursor.
+        return MeterLogic::wdrrPick(_channelDeficit, active, count, 1, &_wdrrCursor);
     }
 
     // Poor man's phase shift (doing with modulus didn't work properly,

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -770,10 +770,11 @@ namespace Ade7953
             return false;
         }
 
-        // Snapshot old role, active state, and reverse flag before applying new data
+        // Snapshot old role, active state, reverse flag and phase before applying new data
         ChannelRole oldRole = _channelData[channelIndex].role;
         bool wasInactive = !_channelData[channelIndex].active;
         bool oldReverse = _channelData[channelIndex].reverse;
+        Phase oldPhase = _channelData[channelIndex].phase;
 
         if (!acquireMutex(&_channelDataMutex)) {
             LOG_ERROR("Failed to acquire mutex for channel data");
@@ -802,6 +803,7 @@ namespace Ade7953
             bool reverseChanged = (oldReverse != _channelData[channelIndex].reverse);
             bool activated = (wasInactive && _channelData[channelIndex].active);
             bool roleChangedActive = (!wasInactive && _channelData[channelIndex].active && oldRole != _channelData[channelIndex].role);
+            bool phaseChangedActive = (!wasInactive && _channelData[channelIndex].active && oldPhase != _channelData[channelIndex].phase);
 
             if (reverseChanged) {
                 // A manual reverse change is the trusted value: disarm CT-reversal
@@ -812,10 +814,16 @@ namespace Ade7953
                 _polarityVoteCount[channelIndex] = 0;
                 _polarityConductingReads[channelIndex] = 0;
                 if (channelIndex > 0) _channelData[channelIndex]._pendingPriorityRead = true;
-            } else if (activated || roleChangedActive) {
-                // Fresh activation / role change with no explicit polarity choice: arm
-                // auto-detection from a clean vote count. The sign convention can
-                // legitimately differ between roles, so a role change re-validates.
+            } else if (activated || roleChangedActive || phaseChangedActive) {
+                // Fresh activation / role / phase change with no explicit polarity
+                // choice: arm auto-detection from a clean vote count. The sign
+                // convention can legitimately differ between roles, so a role change
+                // re-validates. A phase change invalidates the detector's premise
+                // outright (the sign of active power is only meaningful if the phase
+                // is right), and re-arming also self-heals the stale case where a
+                // wrong phase made a correctly-wired CT read steady-negative and the
+                // detector flipped reverse: once the user fixes the phase, the next
+                // votes flip it back within seconds (issue #174).
                 _channelData[channelIndex]._pendingPolarityCheck = true;
                 _polarityVoteCount[channelIndex] = 0;
                 _polarityConductingReads[channelIndex] = 0;
@@ -3629,6 +3637,12 @@ namespace Ade7953
 
         Phase basePhase = _channelData[0].phase; // Not using channelData since it is only accessed here and it is an integer so very low probability of race condition
 
+        // Noise floors scale with the CT: a fixed threshold suited to a 30 A clamp is far
+        // below the offset noise of a 100 A one (and too strict for a small one), so both
+        // thresholds are fractions of the channel's CT rating. At 30 A: 15 mA / 30 mA.
+        float minCurrentThreePhaseNoLoad = channelData.ctSpecification.currentRating * MINIMUM_CURRENT_RATIO_THREE_PHASE_NO_LOAD;
+        float minCurrentValidation = channelData.ctSpecification.currentRating * MINIMUM_CURRENT_RATIO_VALIDATION;
+
         // Split-phase 240V circuits use same-phase path (only 180° shift, so only the sign changes) so we can use the accurate energy registers, but accounting for a 2x multiplier
         bool isSplitPhase240 = (channelData.phase == PHASE_SPLIT_240);
         if (channelData.phase == basePhase || isSplitPhase240) { // The phase is not necessarily PHASE_A, so use as reference the one of channel A
@@ -3741,6 +3755,18 @@ namespace Ade7953
             apparentPower = current * voltage; // S = Vrms * Irms
             activePower = current * voltage * abs(powerFactor) * (channelData.reverse ? -1.0f : 1.0f) * (isActivePowerNegative ? -1.0f : 1.0f); // P = Vrms * Irms * PF
             reactivePower = float(sqrt(pow(apparentPower, 2) - pow(activePower, 2))) * (channelData.reverse ? -1.0f : 1.0f) * (powerFactor >= 0 ? 1.0f : -1.0f); // Q = sqrt(S^2 - P^2) * sign(PF)
+
+            // Synthetic no-load: the ADE7953's no-load feature only gates the energy
+            // registers of the base-phase branch; here a sub-threshold current is offset
+            // noise reading a garbage angle, so zero the whole reading. This keeps the
+            // published contract "nonzero values are reliable" (the web UI relies on it).
+            if (current < minCurrentThreePhaseNoLoad) {
+                current = 0.0f;
+                activePower = 0.0f;
+                reactivePower = 0.0f;
+                apparentPower = 0.0f;
+                powerFactor = 0.0f;
+            }
         }
 
         apparentPower = abs(apparentPower); // Apparent power must be positive
@@ -3788,7 +3814,7 @@ namespace Ade7953
             !_validatePower(apparentPower) || 
             !_validatePowerFactor(powerFactor)
         ) {
-            if (current >= MINIMUM_CURRENT_FOR_VALIDATION) {
+            if (current >= minCurrentValidation) {
                 // If the measurement is invalid AND we have enough current flowing (thus we should be reading correct values), then discard the reading
                 LOG_WARNING("%s (%d): Invalid reading (%.1fV, %.1fW, %.3fA, %.1fVAr, %.1fVA, %.3f)", channelData.label, channelIndex, voltage, activePower, current, reactivePower, apparentPower, powerFactor);
                 _recordFailure();
@@ -3833,7 +3859,7 @@ namespace Ade7953
         // or earn the armed boost. The same signal drives _lastConducting below, so the
         // vote and the boost always agree on whether the channel is drawing power.
         bool conducting = MeterLogic::isConductingReading(
-            activePower, current, MINIMUM_CURRENT_FOR_VALIDATION);
+            activePower, current, minCurrentValidation);
 
         if (_channelData[channelIndex]._pendingPolarityCheck && conducting) {
             bool flipped = false;
@@ -3848,7 +3874,7 @@ namespace Ade7953
                     MeterLogic::PolarityConfig cfg{
                         POLARITY_DETECT_VOTE_THRESHOLD,
                         POLARITY_DETECT_MAX_CONDUCTING_READS,
-                        MINIMUM_CURRENT_FOR_VALIDATION
+                        minCurrentValidation
                     };
                     MeterLogic::PolarityResult res = MeterLogic::updatePolarity(state, activePower, current, cfg);
                     _polarityVoteCount[channelIndex] = res.state.voteCount;
@@ -3927,7 +3953,7 @@ namespace Ade7953
 
         // If the phase is not the phase of the main channel, set the energy not to 0 if the current
         // is above the threshold since we cannot use the ADE7593 no-load feature in this approximation
-        if (channelData.phase != basePhase && current > MINIMUM_CURRENT_THREE_PHASE_APPROXIMATION_NO_LOAD) {
+        if (channelData.phase != basePhase && current > minCurrentThreePhaseNoLoad) {
             activeEnergy = 1;
             reactiveEnergy = 1;
             apparentEnergy = 1;

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -3,6 +3,7 @@
 
 #include "ade7953.h"
 #include "taskprofiler.h"
+#include "duration_format.h"
 
 namespace Ade7953
 {
@@ -1981,8 +1982,10 @@ namespace Ade7953
             
             // Safety timeout
             if (currentMicros - _captureStartMicros >= WAVEFORM_CAPTURE_MAX_DURATION_MICROS) {
-                LOG_WARNING("Waveform capture timeout after %llu ms, captured %u samples with %u zero crossings", 
-                    (currentMicros - _captureStartMicros) / 1000, _captureSampleCount, zeroCrossingCount);
+                char captureDurHuman[24];
+                DurationFormat::humanizeDuration((currentMicros - _captureStartMicros) / 1000, captureDurHuman, sizeof(captureDurHuman));
+                LOG_WARNING("Waveform capture timeout after %s, captured %u samples with %u zero crossings",
+                    captureDurHuman, _captureSampleCount, zeroCrossingCount);
                 break;
             }
             
@@ -2035,8 +2038,10 @@ namespace Ade7953
         uint64_t totalDurationMs = (micros64() - _captureStartMicros) / 1000;
         
         _captureState = CaptureState::COMPLETE;
-        LOG_INFO("Waveform capture complete for channel %u: %u samples in %llu ms with %u zero crossings", 
-            _captureChannel, _captureSampleCount, totalDurationMs, zeroCrossingCount);
+        char captureDurHuman[24];
+        DurationFormat::humanizeDuration(totalDurationMs, captureDurHuman, sizeof(captureDurHuman));
+        LOG_INFO("Waveform capture complete for channel %u: %u samples in %s with %u zero crossings",
+            _captureChannel, _captureSampleCount, captureDurHuman, zeroCrossingCount);
     }
 
     void _handleCrcChangeInterrupt() {
@@ -2368,7 +2373,9 @@ namespace Ade7953
 
             // Calculate milliseconds until next hour using CustomTime
             uint64_t msUntilNextHour = CustomTime::getMillisecondsUntilNextHour();
-            LOG_DEBUG("Waiting for %llu ms until next hour to save the hourly energy", msUntilNextHour);
+            char msUntilNextHourHuman[24];
+            DurationFormat::humanizeDuration(msUntilNextHour, msUntilNextHourHuman, sizeof(msUntilNextHourHuman));
+            LOG_DEBUG("Waiting for %s until next hour to save the hourly energy", msUntilNextHourHuman);
 
             // Wait for the calculated time or stop notification
             if (ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS((uint32_t)msUntilNextHour)) > 0) { // Needs to be casted to uint32_t otherwise it will crash
@@ -4258,7 +4265,9 @@ namespace Ade7953
         
         setSampleTime(sampleTime);
 
-        LOG_DEBUG("Loaded sample time %llu ms from preferences", sampleTime);
+        char sampleTimeHuman[24];
+        DurationFormat::humanizeDuration(sampleTime, sampleTimeHuman, sizeof(sampleTimeHuman));
+        LOG_DEBUG("Loaded sample time %s from preferences", sampleTimeHuman);
     }
 
     void _saveSampleTimeToPreferences() {
@@ -4270,7 +4279,9 @@ namespace Ade7953
         preferences.putULong64(CONFIG_SAMPLE_TIME_KEY, _sampleTime);
         preferences.end();
 
-        LOG_DEBUG("Saved sample time %llu ms to preferences", _sampleTime);
+        char sampleTimeHuman[24];
+        DurationFormat::humanizeDuration(_sampleTime, sampleTimeHuman, sizeof(sampleTimeHuman));
+        LOG_DEBUG("Saved sample time %s to preferences", sampleTimeHuman);
     }
 
     void _updateSampleTime() {
@@ -4287,7 +4298,9 @@ namespace Ade7953
         uint64_t calculatedLinecyc = _sampleTime * _lineFrequency * 2 / 1000;
         _setLinecyc((uint32_t)calculatedLinecyc);
 
-        LOG_DEBUG("Successfully updated sample time to %llu ms (%llu line cycles) with grid frequency %u Hz", _sampleTime, calculatedLinecyc, _lineFrequency);
+        char sampleTimeHuman[24];
+        DurationFormat::humanizeDuration(_sampleTime, sampleTimeHuman, sizeof(sampleTimeHuman));
+        LOG_DEBUG("Successfully updated sample time to %s (%llu line cycles) with grid frequency %u Hz", sampleTimeHuman, calculatedLinecyc, _lineFrequency);
     }
 
     // ADE7953 register reading functions
@@ -4362,7 +4375,9 @@ namespace Ade7953
     void _checkForTooManyFailures() {
         
         if (millis64() - _firstFailureTime > ADE7953_FAILURE_RESET_TIMEOUT_MS && _failureCount > 0) {
-            LOG_DEBUG("Failure timeout exceeded (%lu ms). Resetting failure count (reached %d)", millis64() - _firstFailureTime, _failureCount);
+            char failureDurHuman[24];
+            DurationFormat::humanizeDuration(millis64() - _firstFailureTime, failureDurHuman, sizeof(failureDurHuman));
+            LOG_DEBUG("Failure timeout exceeded (%s). Resetting failure count (reached %d)", failureDurHuman, _failureCount);
             
             _failureCount = 0;
             _firstFailureTime = 0;
@@ -4396,8 +4411,10 @@ namespace Ade7953
 
     void _checkForTooManyCriticalFailures() {
         if (millis64() - _firstCriticalFailureTime > ADE7953_CRITICAL_FAILURE_RESET_TIMEOUT_MS && _criticalFailureCount > 0) {
-            LOG_DEBUG("Critical failure timeout exceeded (%llu ms). Resetting critical failure count (reached %lu)", 
-                millis64() - _firstCriticalFailureTime, _criticalFailureCount);
+            char critFailDurHuman[24];
+            DurationFormat::humanizeDuration(millis64() - _firstCriticalFailureTime, critFailDurHuman, sizeof(critFailDurHuman));
+            LOG_DEBUG("Critical failure timeout exceeded (%s). Resetting critical failure count (reached %lu)",
+                critFailDurHuman, _criticalFailureCount);
             
             _criticalFailureCount = 0;
             _firstCriticalFailureTime = 0;
@@ -4621,9 +4638,11 @@ namespace Ade7953
         if (starvedChannel != INVALID_CHANNEL) {
             // Can happen with high-power channels alongside static 0 W ones, so it is
             // not an error per se (hence DEBUG level).
+            char starvedGapHuman[24];
+            DurationFormat::humanizeDuration(starvedGap, starvedGapHuman, sizeof(starvedGapHuman));
             LOG_DEBUG(
-                "%s (%u): scheduler starvation, %llu ms since last read; force-picking",
-                _channelData[starvedChannel].label, starvedChannel, starvedGap
+                "%s (%u): scheduler starvation, %s since last read; force-picking",
+                _channelData[starvedChannel].label, starvedChannel, starvedGapHuman
             );
             _channelDeficit[starvedChannel] = 0.0f;
             return starvedChannel;

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -3656,7 +3656,8 @@ namespace Ade7953
         // below the offset noise of a 100 A one (and too strict for a small one), so both
         // thresholds are fractions of the channel's CT rating.
         float minCurrentThreePhaseNoLoad = channelData.ctSpecification.currentRating * MINIMUM_CURRENT_RATIO_THREE_PHASE_NO_LOAD;
-        float minCurrentValidation = channelData.ctSpecification.currentRating * MINIMUM_CURRENT_RATIO_VALIDATION;
+        float minCurrentValidation = channelData.ctSpecification.currentRating * MINIMUM_CURRENT_RATIO_VALIDATION;   // validation discard: a reading invalid at this current is a real failure
+        float minCurrentConducting  = channelData.ctSpecification.currentRating * MINIMUM_CURRENT_RATIO_CONDUCTING;  // polarity-vote / WDRR-boost gate: lower, catches small real loads
 
         // Split-phase 240V circuits use same-phase path (only 180° shift, so only the sign changes) so we can use the accurate energy registers, but accounting for a 2x multiplier
         bool isSplitPhase240 = (channelData.phase == PHASE_SPLIT_240);
@@ -3869,12 +3870,14 @@ namespace Ade7953
         // setChannelData arm/disarm is neither lost nor double-fired. (The unsynced
         // _pendingPolarityCheck pre-check is an atomic-bool fast path; it is re-tested
         // under the mutex before any state change.)
-        // Current-gate "conducting" so ADE7953 offset noise at ~0 A (a small, steady,
-        // signed power) cannot vote a false reversal on an unclamped role (grid/battery)
-        // or earn the armed boost. The same signal drives _lastConducting below, so the
-        // vote and the boost always agree on whether the channel is drawing power.
+        // Current-gate "conducting" with MINIMUM_CURRENT_RATIO_CONDUCTING (lower than the
+        // old MINIMUM_CURRENT_RATIO_VALIDATION) so small real loads (~2 W on a 30 A CT)
+        // still earn votes and the WDRR boost, while ADE7953 offset noise at near-zero
+        // current (consistent-sign but well below the gate) cannot vote a false reversal
+        // or hog the scheduler on an unclamped role (grid/battery). The same signal drives
+        // _lastConducting below, so the vote and the boost always agree.
         bool conducting = MeterLogic::isConductingReading(
-            activePower, current, minCurrentValidation);
+            activePower, current, minCurrentConducting);
 
         if (_channelData[channelIndex]._pendingPolarityCheck && conducting) {
             bool flipped = false;
@@ -3889,7 +3892,7 @@ namespace Ade7953
                     MeterLogic::PolarityConfig cfg{
                         POLARITY_DETECT_VOTE_THRESHOLD,
                         POLARITY_DETECT_MAX_CONDUCTING_READS,
-                        minCurrentValidation
+                        minCurrentConducting
                     };
                     MeterLogic::PolarityResult res = MeterLogic::updatePolarity(state, activePower, current, cfg);
                     _polarityVoteCount[channelIndex] = res.state.voteCount;

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -47,6 +47,12 @@ namespace Ade7953
     // task runs on a PSRAM stack and cannot perform NVS writes.
     static volatile bool _pendingPolaritySave[MAX_CHANNEL_COUNT] = {};
 
+    // Issue-registry facts (issue #145), RAM-only and monotonic within this boot.
+    // Single writer is the meter task; the registry tick reads them as 32-bit loads.
+    static volatile uint32_t _factEvidenceReads[MAX_CHANNEL_COUNT] = {};
+    static volatile uint32_t _factClampedEvidenceReads[MAX_CHANNEL_COUNT] = {};
+    static volatile uint32_t _factPolarityFlipCount[MAX_CHANNEL_COUNT] = {};
+
     // Voltage-to-LSB conversion factors, computed once in begin() from globalHwProfile voltage divider.
     static float _voltPerLsb = 0.0f;
     static float _voltPerLsbInstantaneous = 0.0f;
@@ -1600,8 +1606,17 @@ namespace Ade7953
     // Grid frequency
     // ==============
 
-    float getGridFrequency() { 
-        return _gridFrequency; 
+    float getGridFrequency() {
+        return _gridFrequency;
+    }
+
+    bool getChannelIssueFacts(uint8_t channelIndex, ChannelIssueFacts &facts) {
+        if (!isChannelValid(channelIndex)) return false;
+
+        facts.evidenceReads = _factEvidenceReads[channelIndex];
+        facts.clampedEvidenceReads = _factClampedEvidenceReads[channelIndex];
+        facts.polarityFlipCount = _factPolarityFlipCount[channelIndex];
+        return true;
     }
 
     // Private function implementations
@@ -3891,6 +3906,9 @@ namespace Ade7953
                 releaseMutex(&_channelDataMutex);
             }
             if (flipped) {
+                // Record the flip fact for the issue registry (single-writer volatile)
+                _factPolarityFlipCount[channelIndex] = _factPolarityFlipCount[channelIndex] + 1;
+
                 // This reading was computed with the pre-flip sign; negate the signed
                 // quantities so it stores consistently with the new reverse flag
                 // (apparent power and current stay positive).
@@ -3914,12 +3932,22 @@ namespace Ade7953
         // orientation in ~1 s, while a near-zero-current offset reading earns no boost.
         _lastConducting[channelIndex] = conducting;
 
+        // Polarity-mismatch evidence: conducting, or sub-gate with |P| above the
+        // offset-noise floor - a persistent -2.5 W at 24 mA is a real reversed load,
+        // while idle-channel noise stays below the floor and carries no evidence.
+        // Only feeds the user-facing issue; the auto-flip detector stays current-gated.
+        bool mismatchEvidence = conducting || fabsf(activePower) >= MISMATCH_EVIDENCE_MIN_POWER_W;
+        if (mismatchEvidence) _factEvidenceReads[channelIndex] = _factEvidenceReads[channelIndex] + 1;
+
         // Clamp negative active power to zero for load and PV channels. With the phase
         // configured correctly a load/PV should not be net-negative; a residual negative
         // is PV inverter standby or sub-detection noise. Clamp (do NOT discard) so the
         // data cadence is preserved - a genuinely reversed CT is corrected by the
         // reversal detector above, not by dropping readings (which created silent gaps).
         if (MeterLogic::shouldClampNegative(activePower, channelData.role)) {
+            // An evidence reading that gets clamped is polarity-mismatch evidence for
+            // the issue registry (reverse flag and physical CT orientation disagree)
+            if (mismatchEvidence) _factClampedEvidenceReads[channelIndex] = _factClampedEvidenceReads[channelIndex] + 1;
             LOG_DEBUG(
                 "%s (%d): clamping negative reading (%.1fW) to 0 (role=%s)",
                 channelData.label,

--- a/source/src/buttonhandler.cpp
+++ b/source/src/buttonhandler.cpp
@@ -3,6 +3,7 @@
 
 #include "buttonhandler.h"
 #include "taskprofiler.h"
+#include "duration_format.h"
 
 namespace ButtonHandler
 {
@@ -142,7 +143,9 @@ namespace ButtonHandler
                 {
                     // Button was released - process the press
                     uint64_t pressDuration = millis64() - _buttonPressStartTime;
-                    LOG_DEBUG("Button released after %llu ms", pressDuration);
+                    char pressDurationHuman[24];
+                    DurationFormat::humanizeDuration(pressDuration, pressDurationHuman, sizeof(pressDurationHuman));
+                    LOG_DEBUG("Button released after %s", pressDurationHuman);
 
                     _processButtonPress(pressDuration);
                     _buttonPressStartTime = ZERO_START_TIME;
@@ -197,7 +200,9 @@ namespace ButtonHandler
         else
         {
             _currentPressType = ButtonPressType::NONE;
-            LOG_DEBUG("Button press duration %llu ms - no action", pressDuration);
+            char pressDurationHuman[24];
+            DurationFormat::humanizeDuration(pressDuration, pressDurationHuman, sizeof(pressDurationHuman));
+            LOG_DEBUG("Button press duration %s - no action", pressDurationHuman);
         }
     }
 

--- a/source/src/crashmonitor.cpp
+++ b/source/src/crashmonitor.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2025 Jibril Sharafi
 
 #include "crashmonitor.h"
+#include "duration_format.h"
 
 namespace CrashMonitor
 {
@@ -112,8 +113,11 @@ namespace CrashMonitor
         
         if (isQuickRestart) {
             _quickRestartCount++;
-            LOG_WARNING("Quick restart detected (#%lu): only %llu ms since last boot (threshold: %lu ms)", 
-                _quickRestartCount, timeSinceLastBoot, QUICK_RESTART_THRESHOLD);
+            char timeSinceLastBootHuman[24], thresholdHuman[24];
+            DurationFormat::humanizeDuration(timeSinceLastBoot, timeSinceLastBootHuman, sizeof(timeSinceLastBootHuman));
+            DurationFormat::humanizeDuration(QUICK_RESTART_THRESHOLD, thresholdHuman, sizeof(thresholdHuman));
+            LOG_WARNING("Quick restart detected (#%lu): only %s since last boot (threshold: %s)",
+                _quickRestartCount, timeSinceLastBootHuman, thresholdHuman);
             
             if (_quickRestartCount >= MAX_QUICK_RESTARTS) {
                 _safeModeActive = true;
@@ -126,8 +130,10 @@ namespace CrashMonitor
         } else {
             // Not a quick restart - reset quick restart counter (but keep crash/reset counters)
             if (_quickRestartCount > 0) {
-                LOG_DEBUG("Stable boot detected (%llu ms since last boot), resetting quick restart counter (was %lu)", 
-                    timeSinceLastBoot, _quickRestartCount);
+                char timeSinceLastBootHuman[24];
+                DurationFormat::humanizeDuration(timeSinceLastBoot, timeSinceLastBootHuman, sizeof(timeSinceLastBootHuman));
+                LOG_DEBUG("Stable boot detected (%s since last boot), resetting quick restart counter (was %lu)",
+                    timeSinceLastBootHuman, _quickRestartCount);
                 _quickRestartCount = 0;
                 // Note: We intentionally keep _consecutiveCrashCount and _consecutiveResetCount
                 // Those are reset by the separate _crashResetTask after COUNTERS_RESET_TIMEOUT
@@ -135,7 +141,9 @@ namespace CrashMonitor
             
             // Exit safe mode if we had a stable restart (user fixed the issue)
             if (_safeModeActive && timeSinceLastBoot >= SAFE_MODE_MIN_UPTIME) {
-                LOG_INFO("Exiting safe mode due to stable restart (%llu ms uptime)", timeSinceLastBoot);
+                char timeSinceLastBootHuman[24];
+                DurationFormat::humanizeDuration(timeSinceLastBoot, timeSinceLastBootHuman, sizeof(timeSinceLastBootHuman));
+                LOG_INFO("Exiting safe mode due to stable restart (%s uptime)", timeSinceLastBootHuman);
                 _safeModeActive = false;
             }
         }

--- a/source/src/custommqtt.cpp
+++ b/source/src/custommqtt.cpp
@@ -3,6 +3,7 @@
 
 #include "custommqtt.h"
 #include "taskprofiler.h"
+#include "duration_format.h"
 
 namespace CustomMqtt
 {
@@ -472,14 +473,16 @@ namespace CustomMqtt
             uint64_t _backoffDelay = calculateExponentialBackoff(_currentMqttConnectionAttempt, MQTT_CUSTOM_INITIAL_RECONNECT_INTERVAL, MQTT_CUSTOM_MAX_RECONNECT_INTERVAL, MQTT_CUSTOM_RECONNECT_MULTIPLIER);
             _nextMqttConnectionAttemptMillis = millis64() + _backoffDelay;
 
-            snprintf(_status, sizeof(_status), "Connection failed: %s (Attempt %lu). Retrying in %llu ms", _reason, _currentMqttConnectionAttempt, _backoffDelay);
+            char _backoffHuman[24];
+            DurationFormat::humanizeDuration(_backoffDelay, _backoffHuman, sizeof(_backoffHuman));
+            snprintf(_status, sizeof(_status), "Connection failed: %s (Attempt %lu). Retrying in %s", _reason, _currentMqttConnectionAttempt, _backoffHuman);
             _statusTimestampUnix = CustomTime::getUnixTime();
 
-            LOG_WARNING("Failed to connect to Custom MQTT (attempt %lu). Reason: %s (%ld). Retrying in %llu ms", 
+            LOG_WARNING("Failed to connect to Custom MQTT (attempt %lu). Reason: %s (%ld). Retrying in %s",
                            _currentMqttConnectionAttempt,
                            _reason,
                            currentState,
-                           _nextMqttConnectionAttemptMillis - millis64());
+                           _backoffHuman);
 
             return false;
         }

--- a/source/src/custommqtt.cpp
+++ b/source/src/custommqtt.cpp
@@ -20,6 +20,10 @@ namespace CustomMqtt
     static uint32_t _currentMqttConnectionAttempt = 0;
     static uint64_t _nextMqttConnectionAttemptMillis = 0;
 
+    // Connection state fact for the issue registry, updated once per task loop
+    // (the registry tick must not call _mqttClient.connected() cross-task)
+    static volatile bool _lastConnectedState = false;
+
     // Custom MQTT configuration
     static CustomMqttConfiguration _configuration;
     
@@ -223,6 +227,11 @@ namespace CustomMqtt
         return true;
     }
 
+    // Reading one aligned bool is atomic on the ESP32-S3 - no mutex or config copy needed
+    bool isEnabled() { return _isSetupDone && _configuration.enabled; }
+
+    bool isConnected() { return _lastConnectedState; }
+
     bool getRuntimeStatus(char *statusBuffer, size_t statusSize, char *timestampBuffer, size_t timestampSize)
     {
         if (!_isSetupDone) {
@@ -279,9 +288,11 @@ namespace CustomMqtt
         while (_taskShouldRun) {
             TASK_HEARTBEAT(_heartbeat);
             getConfiguration(config);
+            bool connectedNow = false;
             if (config.enabled) { // We have the custom MQTT enabled (atomic operation, no race condition)
                 if (CustomWifi::isFullyConnected()) { // We are connected (no need to check if time is synched)
                     if (_mqttClient.connected()) { // We are connected to MQTT
+                        connectedNow = true;
                         if (_currentMqttConnectionAttempt > 0) { // If we were having problems, reset the attempt counter since we are now connected
                             LOG_DEBUG("Custom MQTT reconnected successfully after %d attempts.", _currentMqttConnectionAttempt);
                             _currentMqttConnectionAttempt = 0;
@@ -298,13 +309,14 @@ namespace CustomMqtt
                     } else { // We are not connected to MQTT
                         if (millis64() >= _nextMqttConnectionAttemptMillis) { // Enough time has passed since last attempt (in case of failures) to retry connection
                             LOG_DEBUG("Custom MQTT client not connected. Attempting to connect...");
-                            _connectMqtt(config);
+                            connectedNow = _connectMqtt(config);
                         }
                     }
                 } else { // We are not connected to WiFi
                     LOG_DEBUG("Device is not connected to WiFi. Waiting for automatic connection...");
                 }
             }
+            _lastConnectedState = connectedNow;
 
             // Wait for stop notification with timeout (blocking) - zero CPU usage while waiting
             if (ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(CUSTOM_MQTT_TASK_CHECK_INTERVAL)) > 0) {
@@ -314,6 +326,7 @@ namespace CustomMqtt
         }
         
         _mqttClient.disconnect();
+        _lastConnectedState = false;
         LOG_DEBUG("Custom MQTT task stopping");
         _customMqttTaskHandle = nullptr;
         vTaskDelete(nullptr);

--- a/source/src/customserver.cpp
+++ b/source/src/customserver.cpp
@@ -3,6 +3,7 @@
 
 #include "customserver.h"
 #include "taskprofiler.h"
+#include "duration_format.h"
 
 namespace CustomServer
 {
@@ -2014,7 +2015,9 @@ namespace CustomServer
 
                 if (Ade7953::setSampleTime(sampleTime))
                 {
-                    LOG_INFO("ADE7953 sample time updated to %lu ms via API", sampleTime);
+                    char sampleTimeHuman[24];
+                    DurationFormat::humanizeDuration(sampleTime, sampleTimeHuman, sizeof(sampleTimeHuman));
+                    LOG_INFO("ADE7953 sample time updated to %s via API", sampleTimeHuman);
                     _sendSuccessResponse(request, "ADE7953 sample time updated successfully");
                 }
                 else

--- a/source/src/customserver.cpp
+++ b/source/src/customserver.cpp
@@ -68,6 +68,7 @@ namespace CustomServer
 
     // API endpoint groups
     static void _serveSystemEndpoints();
+    static void _serveIssueEndpoints();
     static void _serveNetworkEndpoints();
     static void _serveLoggingEndpoints();
     static void _serveHealthEndpoints();
@@ -609,6 +610,7 @@ namespace CustomServer
     {
         // Group endpoints by functionality
         _serveSystemEndpoints();
+        _serveIssueEndpoints();
         _serveNetworkEndpoints();
         _serveLoggingEndpoints();
         _serveHealthEndpoints();
@@ -781,6 +783,9 @@ namespace CustomServer
         });
         server.on("/js/data-helpers.js", HTTP_GET, [etag](AsyncWebServerRequest *request) {
             _sendStaticWithEtag(request, "application/javascript", EMBEDDED(data_helpers_js), etag);
+        });
+        server.on("/js/issues.js", HTTP_GET, [etag](AsyncWebServerRequest *request) {
+            _sendStaticWithEtag(request, "application/javascript", EMBEDDED(issues_js), etag);
         });
         server.on("/js/power-flow.js", HTTP_GET, [etag](AsyncWebServerRequest *request) {
             _sendStaticWithEtag(request, "application/javascript", EMBEDDED(power_flow_js), etag);
@@ -1633,6 +1638,56 @@ namespace CustomServer
     }
 
     // === NETWORK MANAGEMENT ENDPOINTS ===
+    // === ISSUE REGISTRY ENDPOINTS ===
+    static void _serveIssueEndpoints()
+    {
+        // Currently visible device issues (issue #145)
+        server.on("/api/v1/system/issues", HTTP_GET, [](AsyncWebServerRequest *request)
+                  {
+            SpiRamAllocator allocator;
+            JsonDocument doc(&allocator);
+
+            if (!IssueRegistry::issuesToJson(doc)) {
+                _sendErrorResponse(request, HTTP_CODE_INTERNAL_SERVER_ERROR, "Failed to retrieve issues");
+                return;
+            }
+            _sendJsonResponse(request, doc); });
+
+        // Acknowledge issues: {"all": true} or {"code": "...", "channel": <optional>}
+        static AsyncCallbackJsonWebHandler *ackIssueHandler = new AsyncCallbackJsonWebHandler(
+            "/api/v1/system/issues/ack",
+            [](AsyncWebServerRequest *request, JsonVariant &json)
+            {
+                if (!_validateRequest(request, "POST", HTTP_MAX_CONTENT_LENGTH_ISSUES_ACK)) return;
+
+                SpiRamAllocator allocator;
+                JsonDocument doc(&allocator);
+                doc.set(json);
+
+                if (doc["all"].is<bool>() && doc["all"].as<bool>()) {
+                    uint32_t ackedCount = IssueRegistry::ackAll();
+                    char message[STATUS_BUFFER_SIZE];
+                    snprintf(message, sizeof(message), "Acknowledged %lu issue(s)", (unsigned long)ackedCount);
+                    _sendSuccessResponse(request, message);
+                    return;
+                }
+
+                if (!doc["code"].is<const char*>()) {
+                    _sendErrorResponse(request, HTTP_CODE_BAD_REQUEST, "Missing 'code' (or 'all') parameter");
+                    return;
+                }
+
+                uint8_t channel = ISSUE_GLOBAL_SCOPE;
+                if (doc["channel"].is<uint8_t>()) channel = doc["channel"].as<uint8_t>();
+
+                if (IssueRegistry::ack(doc["code"].as<const char*>(), channel)) {
+                    _sendSuccessResponse(request, "Issue acknowledged");
+                } else {
+                    _sendErrorResponse(request, HTTP_CODE_NOT_FOUND, "No such issue instance");
+                } });
+        server.addHandler(ackIssueHandler);
+    }
+
     static void _serveNetworkEndpoints()
     {
         // WiFi reset

--- a/source/src/customtime.cpp
+++ b/source/src/customtime.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2025 Jibril Sharafi
 
 #include "customtime.h"
+#include "duration_format.h"
 
 namespace CustomTime {
     // Static variables to maintain state
@@ -39,14 +40,18 @@ namespace CustomTime {
         uint64_t millisUntilNextHour = 3600000ULL - millisSinceCurrentHour;
 
         // Check if we're close to either the current hour (just passed) or the next hour (approaching)
+        char toleranceHuman[24], sinceHourHuman[24], untilNextHuman[24];
+        DurationFormat::humanizeDuration(toleranceMillis, toleranceHuman, sizeof(toleranceHuman));
         if (millisSinceCurrentHour <= toleranceMillis) {
-            LOG_DEBUG("Current time is close to the current hour (within %llu ms since hour start)", toleranceMillis);
+            LOG_DEBUG("Current time is close to the current hour (within %s since hour start)", toleranceHuman);
             return true;
         } else if (millisUntilNextHour <= toleranceMillis) {
-            LOG_DEBUG("Current time is close to the next hour (within %llu ms)", toleranceMillis);
+            LOG_DEBUG("Current time is close to the next hour (within %s)", toleranceHuman);
             return true;
         } else {
-            LOG_DEBUG("Current time is not close to any hour (since hour: %llu ms, until next: %llu ms)", millisSinceCurrentHour, millisUntilNextHour);
+            DurationFormat::humanizeDuration(millisSinceCurrentHour, sinceHourHuman, sizeof(sinceHourHuman));
+            DurationFormat::humanizeDuration(millisUntilNextHour, untilNextHuman, sizeof(untilNextHuman));
+            LOG_DEBUG("Current time is not close to any hour (since hour: %s, until next: %s)", sinceHourHuman, untilNextHuman);
             return false;
         }
     }

--- a/source/src/influxdbclient.cpp
+++ b/source/src/influxdbclient.cpp
@@ -288,6 +288,9 @@ namespace InfluxDbClient
         return true;
     }
 
+    // Reading one aligned bool is atomic on the ESP32-S3 - no mutex or config copy needed
+    bool isEnabled() { return _isSetupDone && _configuration.enabled; }
+
     // Private function implementations
     // ================================
 

--- a/source/src/influxdbclient.cpp
+++ b/source/src/influxdbclient.cpp
@@ -3,6 +3,7 @@
 
 #include "influxdbclient.h"
 #include "taskprofiler.h"
+#include "duration_format.h"
 
 namespace InfluxDbClient
 {
@@ -677,7 +678,9 @@ namespace InfluxDbClient
             snprintf(_status, sizeof(_status), "Failed to send data (HTTP %ld - %s) - Attempt %u", httpCode, httpStatus, _currentSendAttempt);
             _statusTimestampUnix = CustomTime::getUnixTime();
 
-            LOG_WARNING("Failed to send data to InfluxDB (HTTP %ld - %s). Next attempt in %llu ms", httpCode, httpStatus, _nextSendAttemptMillis - millis64());
+            char backoffHuman[24];
+            DurationFormat::humanizeDuration(backoffDelay, backoffHuman, sizeof(backoffHuman));
+            LOG_WARNING("Failed to send data to InfluxDB (HTTP %ld - %s). Next attempt in %s", httpCode, httpStatus, backoffHuman);
         }
         
         _statusTimestampUnix = CustomTime::getUnixTime();

--- a/source/src/issueregistry.cpp
+++ b/source/src/issueregistry.cpp
@@ -1,0 +1,561 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#include "issueregistry.h"
+
+#include <LittleFS.h>
+
+#include "ade7953.h"
+#include "crashmonitor.h"
+#include "custommqtt.h"
+#include "customtime.h"
+#include "customwifi.h"
+#include "globals.h"
+#include "influxdbclient.h"
+#include "mqtt.h"
+#include "utils.h"
+
+namespace IssueRegistry
+{
+    static TaskHeartbeat _heartbeat;
+
+    // Instance table
+    // =========================================================
+    // A slot with state Inactive is free. Identity is (code, channel);
+    // globally-scoped codes use channel = ISSUE_GLOBAL_SCOPE.
+    struct IssueInstance {
+        IssueLogic::Code code;
+        uint8_t channel;
+        IssueLogic::State state;
+        uint32_t occurrences;     // raise edges seen by this instance
+        uint32_t firstSeenUnix;
+        uint32_t lastChangeUnix;
+        char message[ISSUE_MESSAGE_BUFFER_SIZE];
+    };
+
+    // Allocated from PSRAM in begin() (~6.6 KB that would otherwise sit in internal
+    // RAM). Safe in PSRAM: only ever accessed from tasks under _registryMutex, never
+    // from ISRs. The mutex is created only after a successful allocation, so a failed
+    // alloc disables the registry as a whole (acquireMutex on the NULL mutex fails).
+    static IssueInstance *_instances = nullptr;
+    static SemaphoreHandle_t _registryMutex = NULL;
+
+    // Per-code evaluator state (tick task only - no mutex needed)
+    // =========================================================
+    static uint32_t _prevFlipCount[MAX_CHANNEL_COUNT] = {};
+    static uint32_t _prevEvidenceReads[MAX_CHANNEL_COUNT] = {};
+    static uint32_t _prevClampedReads[MAX_CHANNEL_COUNT] = {};
+    static uint16_t _mismatchStreak[MAX_CHANNEL_COUNT] = {};
+
+    static uint16_t _customMqttStreak = 0;
+    static uint16_t _cloudMqttStreak = 0;
+    static uint16_t _influxStreak = 0;
+    static uint64_t _prevInfluxOk = 0;
+    static uint64_t _prevInfluxError = 0;
+    static uint16_t _heapStreak = 0;
+    static uint16_t _voltageStreak = 0;
+    static uint16_t _frequencyStreak = 0;
+    static uint16_t _readFailureStreak = 0;
+    static uint64_t _prevAde7953Failures = 0;
+    static bool _littleFsCondition = false;
+    static bool _firstTick = true;
+
+    // Task
+    static TaskHandle_t _taskHandle = NULL;
+    static bool _taskShouldRun = false;
+
+    // Private declarations
+    // =========================================================
+    static void _registryTask(void *parameter);
+    static void _evaluateChannelCodes();
+    static void _evaluateGlobalCodes();
+    static void _updateInstance(IssueLogic::Code code, uint8_t channel, bool conditionTrue, const char *message);
+    static IssueInstance* _findInstance(IssueLogic::Code code, uint8_t channel);
+    static IssueInstance* _allocateInstance();
+    static void _ackInstanceLocked(IssueInstance &inst);
+    static const char* _stateToString(IssueLogic::State state);
+    static bool _codeFromString(const char *codeStr, IssueLogic::Code &code);
+    static void _logTransition(const char *verb, bool raise, IssueLogic::Code code, uint8_t channel, const char *message);
+
+    // Public API
+    // =========================================================
+
+    void begin()
+    {
+        LOG_DEBUG("Setting up issue registry...");
+
+        if (_instances == nullptr) {
+            _instances = (IssueInstance*)ps_calloc(ISSUE_MAX_INSTANCES, sizeof(IssueInstance));
+            if (_instances == nullptr) {
+                LOG_ERROR("Failed to allocate issue instance table in PSRAM");
+                return;
+            }
+        }
+
+        if (!createMutexIfNeeded(&_registryMutex)) return;
+
+        if (_taskHandle != NULL) {
+            LOG_DEBUG("Issue registry task is already running");
+            return;
+        }
+
+        LOG_DEBUG("Starting issue registry task with %d bytes stack in internal RAM (reads LittleFS usage)", ISSUE_REGISTRY_TASK_STACK_SIZE);
+
+        BaseType_t result = xTaskCreate(
+            _registryTask,
+            ISSUE_REGISTRY_TASK_NAME,
+            ISSUE_REGISTRY_TASK_STACK_SIZE,
+            NULL,
+            ISSUE_REGISTRY_TASK_PRIORITY,
+            &_taskHandle);
+
+        if (result != pdPASS) {
+            LOG_ERROR("Failed to create issue registry task");
+            _taskHandle = NULL;
+        }
+    }
+
+    void stop()
+    {
+        stopTaskGracefully(&_taskHandle, "Issue registry task");
+    }
+
+    bool issuesToJson(JsonDocument &doc)
+    {
+        if (!acquireMutex(&_registryMutex)) {
+            LOG_ERROR("Failed to acquire registry mutex for issuesToJson");
+            return false;
+        }
+
+        // The table is tiny (a few KB): building the document under the mutex is
+        // memory-only work; network serialization happens outside, on the copy.
+        JsonArray issues = doc["issues"].to<JsonArray>();
+        for (uint8_t i = 0; i < ISSUE_MAX_INSTANCES; i++) {
+            const IssueInstance &inst = _instances[i];
+            if (!IssueLogic::isVisible(inst.state)) continue;
+
+            JsonObject obj = issues.add<JsonObject>();
+            obj["code"] = IssueLogic::codeToString(inst.code);
+            if (inst.channel != ISSUE_GLOBAL_SCOPE) obj["channel"] = inst.channel;
+            obj["state"] = _stateToString(inst.state);
+            obj["severity"] = IssueLogic::severityToString(IssueLogic::codeSeverity(inst.code));
+            obj["firstSeenUnix"] = inst.firstSeenUnix;
+            obj["lastChangeUnix"] = inst.lastChangeUnix;
+            obj["occurrences"] = inst.occurrences;
+            obj["message"] = inst.message;
+        }
+
+        releaseMutex(&_registryMutex);
+        return true;
+    }
+
+    bool ack(const char *codeStr, uint8_t channel)
+    {
+        IssueLogic::Code code;
+        if (!_codeFromString(codeStr, code)) return false;
+
+        bool acked = false;
+
+        if (!acquireMutex(&_registryMutex)) {
+            LOG_ERROR("Failed to acquire registry mutex for ack");
+            return false;
+        }
+        IssueInstance *inst = _findInstance(code, channel);
+        if (inst != nullptr && IssueLogic::isUnacked(inst->state)) {
+            _ackInstanceLocked(*inst);
+            acked = true;
+        }
+        releaseMutex(&_registryMutex);
+
+        if (acked) _logTransition("acked", false, code, channel, "");
+        return acked;
+    }
+
+    uint32_t ackAll()
+    {
+        uint32_t ackedCount = 0;
+        // Collect what was acked for logging outside the mutex
+        IssueLogic::Code ackedCodes[ISSUE_MAX_INSTANCES];
+        uint8_t ackedChannels[ISSUE_MAX_INSTANCES];
+
+        if (!acquireMutex(&_registryMutex)) {
+            LOG_ERROR("Failed to acquire registry mutex for ackAll");
+            return 0;
+        }
+        for (uint8_t i = 0; i < ISSUE_MAX_INSTANCES; i++) {
+            IssueInstance &inst = _instances[i];
+            if (!IssueLogic::isUnacked(inst.state)) continue;
+            ackedCodes[ackedCount] = inst.code;
+            ackedChannels[ackedCount] = inst.channel;
+            ackedCount++;
+            _ackInstanceLocked(inst);
+        }
+        releaseMutex(&_registryMutex);
+
+        for (uint32_t i = 0; i < ackedCount; i++) {
+            _logTransition("acked", false, ackedCodes[i], ackedChannels[i], "");
+        }
+        return ackedCount;
+    }
+
+    TaskInfo getTaskInfo()
+    {
+        return getTaskInfoSafely(_taskHandle, ISSUE_REGISTRY_TASK_STACK_SIZE, &_heartbeat);
+    }
+
+    // Task and evaluators
+    // =========================================================
+
+    static void _registryTask(void *parameter)
+    {
+        LOG_DEBUG("Issue registry task started");
+        _taskShouldRun = true;
+
+        while (_taskShouldRun) {
+            TASK_HEARTBEAT(_heartbeat);
+
+            _evaluateChannelCodes();
+            _evaluateGlobalCodes();
+            _firstTick = false;
+
+            if (ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(ISSUE_REGISTRY_TICK_INTERVAL)) > 0) {
+                _taskShouldRun = false;
+                break;
+            }
+        }
+
+        LOG_DEBUG("Issue registry task stopping");
+        _taskHandle = NULL;
+        vTaskDelete(NULL);
+    }
+
+    static void _evaluateChannelCodes()
+    {
+        char message[ISSUE_MESSAGE_BUFFER_SIZE];
+        char label[NAME_BUFFER_SIZE];
+
+        for (uint8_t ch = 0; ch < globalHwProfile->totalChannelCount; ch++) {
+            ChannelIssueFacts facts;
+            if (!Ade7953::getChannelIssueFacts(ch, facts)) continue;
+
+            if (!Ade7953::isChannelActive(ch)) {
+                // Channel disabled: clear streak and force condition false so any
+                // existing mismatch instance resolves on the next tick.
+                _mismatchStreak[ch] = 0;
+                _prevEvidenceReads[ch] = facts.evidenceReads;
+                _prevClampedReads[ch] = facts.clampedEvidenceReads;
+                _prevFlipCount[ch] = facts.polarityFlipCount;
+                _updateInstance(IssueLogic::Code::ChannelPolarityMismatch, ch, false, "");
+                _updateInstance(IssueLogic::Code::CtPolarityFlipped, ch, false, "");
+                continue;
+            }
+
+            // --- ct_polarity_flipped (event): pulse on a new flip, then the
+            // instance lands in cleared-unacked and lingers until acked. Flips
+            // that happened before the first tick (boot window) still pulse,
+            // since _prevFlipCount starts at 0.
+            bool flipPulse = (facts.polarityFlipCount != _prevFlipCount[ch]);
+            _prevFlipCount[ch] = facts.polarityFlipCount;
+            if (flipPulse) {
+                Ade7953::getChannelLabel(ch, label, sizeof(label));
+                snprintf(message, sizeof(message),
+                         "%s: CT orientation auto-corrected (%lu flip%s this boot)",
+                         label,
+                         (unsigned long)facts.polarityFlipCount,
+                         facts.polarityFlipCount == 1 ? "" : "s");
+            } else {
+                message[0] = '\0';
+            }
+            _updateInstance(IssueLogic::Code::CtPolarityFlipped, ch, flipPulse, message);
+
+            // --- channel_polarity_mismatch (condition): real readings persistently clamped
+            uint32_t evidenceDelta = (uint32_t)IssueLogic::counterDelta(_prevEvidenceReads[ch], facts.evidenceReads);
+            uint32_t clampedDelta = (uint32_t)IssueLogic::counterDelta(_prevClampedReads[ch], facts.clampedEvidenceReads);
+            _prevEvidenceReads[ch] = facts.evidenceReads;
+            _prevClampedReads[ch] = facts.clampedEvidenceReads;
+
+            IssueLogic::Evidence evidence = IssueLogic::channelMismatchEvidence(
+                evidenceDelta, clampedDelta,
+                ISSUE_MISMATCH_MIN_EVIDENCE_READS, ISSUE_MISMATCH_MIN_CLAMPED_FRACTION);
+            _mismatchStreak[ch] = IssueLogic::updateStreak(_mismatchStreak[ch], evidence);
+            bool mismatch = (_mismatchStreak[ch] >= ISSUE_STREAK_TO_RAISE);
+            if (mismatch) {
+                Ade7953::getChannelLabel(ch, label, sizeof(label));
+                snprintf(message, sizeof(message),
+                         "%s: readings persistently negative and clamped to 0 W. "
+                         "The reverse flag and the physical CT orientation disagree - fix either.",
+                         label);
+            } else {
+                message[0] = '\0';
+            }
+            _updateInstance(IssueLogic::Code::ChannelPolarityMismatch, ch, mismatch, message);
+        }
+    }
+
+    static void _evaluateGlobalCodes()
+    {
+        // Messages are only consumed on a raise edge, so each block formats its
+        // message only when its condition is true (same idiom as the channel codes).
+        char message[ISSUE_MESSAGE_BUFFER_SIZE];
+
+        // --- custom_mqtt_connect_failed: same connection fact + streak hysteresis
+        // as cloud MQTT, so both connectivity issues share one mechanism.
+        bool customMqttEnabled = CustomMqtt::isEnabled();
+        IssueLogic::Evidence customMqttEvidence = (!customMqttEnabled || CustomMqtt::isConnected())
+                                                      ? IssueLogic::Evidence::Good
+                                                      : IssueLogic::Evidence::Bad;
+        _customMqttStreak = IssueLogic::updateStreak(_customMqttStreak, customMqttEvidence);
+        bool customMqttDown = (_customMqttStreak >= ISSUE_CONNECTIVITY_STREAK_TO_RAISE);
+        message[0] = '\0';
+        if (customMqttDown) {
+            snprintf(message, sizeof(message), "Custom MQTT enabled but it has been disconnected for over %u s",
+                     (unsigned)(ISSUE_CONNECTIVITY_STREAK_TO_RAISE * ISSUE_REGISTRY_TICK_INTERVAL / 1000));
+        }
+        _updateInstance(IssueLogic::Code::CustomMqttConnectFailed, ISSUE_GLOBAL_SCOPE, customMqttDown, message);
+
+        // --- cloud_mqtt_disconnected
+        bool cloudEnabled = Mqtt::isCloudServicesEnabled();
+        IssueLogic::Evidence cloudEvidence = (!cloudEnabled || Mqtt::isConnected())
+                                                 ? IssueLogic::Evidence::Good
+                                                 : IssueLogic::Evidence::Bad;
+        _cloudMqttStreak = IssueLogic::updateStreak(_cloudMqttStreak, cloudEvidence);
+        bool cloudDown = (_cloudMqttStreak >= ISSUE_CONNECTIVITY_STREAK_TO_RAISE);
+        message[0] = '\0';
+        if (cloudDown) {
+            snprintf(message, sizeof(message), "Cloud services enabled but AWS MQTT has been disconnected for over %u s",
+                     (unsigned)(ISSUE_CONNECTIVITY_STREAK_TO_RAISE * ISSUE_REGISTRY_TICK_INTERVAL / 1000));
+        }
+        _updateInstance(IssueLogic::Code::CloudMqttDisconnected, ISSUE_GLOBAL_SCOPE, cloudDown, message);
+
+        // --- influxdb_upload_failing: windowed deltas of the global statistics counters
+        bool influxEnabled = InfluxDbClient::isEnabled();
+        uint64_t influxOkDelta = IssueLogic::counterDelta(_prevInfluxOk, statistics.influxdbUploadCount);
+        uint64_t influxErrorDelta = IssueLogic::counterDelta(_prevInfluxError, statistics.influxdbUploadCountError);
+        _prevInfluxOk = statistics.influxdbUploadCount;
+        _prevInfluxError = statistics.influxdbUploadCountError;
+        IssueLogic::Evidence influxEvidence = influxEnabled
+                                                  ? IssueLogic::rateEvidence(influxOkDelta, influxErrorDelta)
+                                                  : IssueLogic::Evidence::Good;
+        _influxStreak = IssueLogic::updateStreak(_influxStreak, influxEvidence);
+        bool influxFailing = (_influxStreak >= ISSUE_STREAK_TO_RAISE);
+        message[0] = '\0';
+        if (influxFailing) {
+            snprintf(message, sizeof(message), "InfluxDB enabled but uploads keep failing (%u consecutive bad windows)",
+                     (unsigned)_influxStreak);
+        }
+        _updateInstance(IssueLogic::Code::InfluxDbUploadFailing, ISSUE_GLOBAL_SCOPE, influxFailing, message);
+
+        // --- ntp_not_synced (boot grace so a normal cold boot never alarms)
+        bool ntpNotSynced = (millis64() > ISSUE_NTP_BOOT_GRACE_MS) && !CustomTime::isTimeSynched();
+        _updateInstance(IssueLogic::Code::NtpNotSynced, ISSUE_GLOBAL_SCOPE, ntpNotSynced,
+                        "Time never synced via NTP - timestamps are unreliable");
+
+        // --- panic_reboot (event): pulse once on the first tick after a crash reboot
+        bool panicPulse = _firstTick && (CrashMonitor::isLastResetDueToCrash() || CrashMonitor::getConsecutiveCrashCount() > 0);
+        if (panicPulse) {
+            snprintf(message, sizeof(message),
+                     "Device rebooted after a crash (%s, %lu crash%s total, %lu consecutive)",
+                     getResetReasonString(esp_reset_reason()),
+                     (unsigned long)CrashMonitor::getCrashCount(),
+                     CrashMonitor::getCrashCount() == 1 ? "" : "es",
+                     (unsigned long)CrashMonitor::getConsecutiveCrashCount());
+        } else {
+            message[0] = '\0';
+        }
+        _updateInstance(IssueLogic::Code::PanicReboot, ISSUE_GLOBAL_SCOPE, panicPulse, message);
+
+        // --- safe_mode_active
+        bool safeMode = CrashMonitor::isInSafeMode();
+        _updateInstance(IssueLogic::Code::SafeModeActive, ISSUE_GLOBAL_SCOPE, safeMode,
+                        "Safe mode active - restart protection engaged after rapid restarts");
+
+        // --- heap_low
+        uint32_t freeHeap = ESP.getFreeHeap();
+        IssueLogic::Evidence heapEvidence = (freeHeap < ISSUE_HEAP_LOW_THRESHOLD_BYTES)
+                                                ? IssueLogic::Evidence::Bad
+                                                : IssueLogic::Evidence::Good;
+        _heapStreak = IssueLogic::updateStreak(_heapStreak, heapEvidence);
+        bool heapLow = (_heapStreak >= ISSUE_STREAK_TO_RAISE);
+        message[0] = '\0';
+        if (heapLow) {
+            snprintf(message, sizeof(message), "Free internal heap low (%lu bytes, threshold %u)",
+                     (unsigned long)freeHeap, (unsigned)ISSUE_HEAP_LOW_THRESHOLD_BYTES);
+        }
+        _updateInstance(IssueLogic::Code::HeapLow, ISSUE_GLOBAL_SCOPE, heapLow, message);
+
+        // --- littlefs_near_full (raise/clear thresholds differ: simple hysteresis)
+        size_t fsTotal = LittleFS.totalBytes();
+        size_t fsUsed = LittleFS.usedBytes();
+        float fsFraction = (fsTotal > 0) ? ((float)fsUsed / (float)fsTotal) : 0.0f;
+        if (fsFraction > ISSUE_LITTLEFS_USED_FRACTION_RAISE) _littleFsCondition = true;
+        else if (fsFraction < ISSUE_LITTLEFS_USED_FRACTION_CLEAR) _littleFsCondition = false;
+        message[0] = '\0';
+        if (_littleFsCondition) {
+            snprintf(message, sizeof(message), "LittleFS %.0f%% full (%u of %u KB)",
+                     fsFraction * 100.0f, (unsigned)(fsUsed / 1024), (unsigned)(fsTotal / 1024));
+        }
+        _updateInstance(IssueLogic::Code::LittleFsNearFull, ISSUE_GLOBAL_SCOPE, _littleFsCondition, message);
+
+        // --- voltage_out_of_range (channel 0 carries the only voltage measurement)
+        MeterValues meterValues;
+        float voltage = 0.0f;
+        if (Ade7953::getMeterValues(meterValues, 0)) voltage = meterValues.voltage;
+        IssueLogic::Evidence voltageEv = IssueLogic::voltageEvidence(voltage, ISSUE_VOLTAGE_TOLERANCE_FRACTION);
+        _voltageStreak = IssueLogic::updateStreak(_voltageStreak, voltageEv);
+        bool voltageBad = (_voltageStreak >= ISSUE_STREAK_TO_RAISE);
+        message[0] = '\0';
+        if (voltageBad) {
+            snprintf(message, sizeof(message), "Mains voltage %.1f V is over %.0f%% away from nominal %.0f V",
+                     voltage, ISSUE_VOLTAGE_TOLERANCE_FRACTION * 100.0f, IssueLogic::nearestNominalVoltage(voltage));
+        }
+        _updateInstance(IssueLogic::Code::VoltageOutOfRange, ISSUE_GLOBAL_SCOPE, voltageBad, message);
+
+        // --- grid_frequency_out_of_range
+        float gridFrequency = Ade7953::getGridFrequency();
+        IssueLogic::Evidence frequencyEv = IssueLogic::frequencyEvidence(gridFrequency, ISSUE_FREQUENCY_TOLERANCE_HZ);
+        _frequencyStreak = IssueLogic::updateStreak(_frequencyStreak, frequencyEv);
+        bool frequencyBad = (_frequencyStreak >= ISSUE_STREAK_TO_RAISE);
+        message[0] = '\0';
+        if (frequencyBad) {
+            snprintf(message, sizeof(message), "Grid frequency %.2f Hz is over %.1f Hz away from nominal %.0f Hz",
+                     gridFrequency, ISSUE_FREQUENCY_TOLERANCE_HZ, IssueLogic::nearestNominalFrequency(gridFrequency));
+        }
+        _updateInstance(IssueLogic::Code::GridFrequencyOutOfRange, ISSUE_GLOBAL_SCOPE, frequencyBad, message);
+
+        // --- ade7953_read_failures
+        uint64_t failureDelta = IssueLogic::counterDelta(_prevAde7953Failures, statistics.ade7953ReadingCountFailure);
+        _prevAde7953Failures = statistics.ade7953ReadingCountFailure;
+        IssueLogic::Evidence failureEvidence = IssueLogic::readFailureEvidence(failureDelta, ISSUE_ADE7953_FAILURES_PER_WINDOW);
+        _readFailureStreak = IssueLogic::updateStreak(_readFailureStreak, failureEvidence);
+        bool readsFailing = (_readFailureStreak >= ISSUE_STREAK_TO_RAISE);
+        message[0] = '\0';
+        if (readsFailing) {
+            snprintf(message, sizeof(message), "Sustained ADE7953 reading failures (%llu in the last window)",
+                     failureDelta);
+        }
+        _updateInstance(IssueLogic::Code::Ade7953ReadFailures, ISSUE_GLOBAL_SCOPE, readsFailing, message);
+    }
+
+    // Instance table management
+    // =========================================================
+
+    static void _updateInstance(IssueLogic::Code code, uint8_t channel, bool conditionTrue, const char *message)
+    {
+        bool raised = false;
+        bool cleared = false;
+        char logMessage[ISSUE_MESSAGE_BUFFER_SIZE] = {0};
+
+        if (!acquireMutex(&_registryMutex)) {
+            LOG_ERROR("Failed to acquire registry mutex for update");
+            return;
+        }
+
+        IssueInstance *inst = _findInstance(code, channel);
+        if (inst == nullptr) {
+            if (!conditionTrue) { // Nothing exists and nothing to raise
+                releaseMutex(&_registryMutex);
+                return;
+            }
+            inst = _allocateInstance();
+            if (inst == nullptr) { // Table full - log outside the mutex
+                releaseMutex(&_registryMutex);
+                LOG_WARNING("Issue instance table full, dropping raise of %s", IssueLogic::codeToString(code));
+                return;
+            }
+            inst->code = code;
+            inst->channel = channel;
+            inst->state = IssueLogic::State::Inactive;
+            inst->occurrences = 0;
+            inst->firstSeenUnix = (uint32_t)CustomTime::getUnixTime();
+            inst->message[0] = '\0';
+        }
+
+        IssueLogic::Transition transition = IssueLogic::step(inst->state, conditionTrue);
+        if (transition.state != inst->state) {
+            inst->state = transition.state;
+            inst->lastChangeUnix = (uint32_t)CustomTime::getUnixTime();
+        }
+        if (transition.raised) {
+            inst->occurrences++;
+            if (message != nullptr && message[0] != '\0') {
+                snprintf(inst->message, sizeof(inst->message), "%s", message);
+            }
+            raised = true;
+        }
+        if (transition.cleared) cleared = true;
+        if (raised || cleared) snprintf(logMessage, sizeof(logMessage), "%s", inst->message);
+        if (inst->state == IssueLogic::State::Inactive) memset(inst, 0, sizeof(*inst));
+
+        releaseMutex(&_registryMutex);
+
+        if (raised) _logTransition("raised", true, code, channel, logMessage);
+        if (cleared) _logTransition("cleared", false, code, channel, logMessage);
+    }
+
+    static IssueInstance* _findInstance(IssueLogic::Code code, uint8_t channel)
+    {
+        for (uint8_t i = 0; i < ISSUE_MAX_INSTANCES; i++) {
+            if (!IssueLogic::isVisible(_instances[i].state)) continue;
+            if (_instances[i].code == code && _instances[i].channel == channel) return &_instances[i];
+        }
+        return nullptr;
+    }
+
+    static IssueInstance* _allocateInstance()
+    {
+        for (uint8_t i = 0; i < ISSUE_MAX_INSTANCES; i++) {
+            if (!IssueLogic::isVisible(_instances[i].state)) return &_instances[i];
+        }
+        return nullptr;
+    }
+
+    // Apply an acknowledgement to one instance. Caller must hold _registryMutex.
+    static void _ackInstanceLocked(IssueInstance &inst)
+    {
+        inst.state = IssueLogic::applyAck(inst.state);
+        inst.lastChangeUnix = (uint32_t)CustomTime::getUnixTime();
+        if (inst.state == IssueLogic::State::Inactive) memset(&inst, 0, sizeof(inst));
+    }
+
+    static const char* _stateToString(IssueLogic::State state)
+    {
+        switch (state) {
+            case IssueLogic::State::ActiveUnacked:  return "active_unacked";
+            case IssueLogic::State::ActiveAcked:    return "active_acked";
+            case IssueLogic::State::ClearedUnacked: return "cleared_unacked";
+            default:                                return "inactive";
+        }
+    }
+
+    static bool _codeFromString(const char *codeStr, IssueLogic::Code &code)
+    {
+        if (codeStr == nullptr) return false;
+        for (uint8_t i = 0; i < (uint8_t)IssueLogic::Code::Count; i++) {
+            if (strcmp(codeStr, IssueLogic::codeToString((IssueLogic::Code)i)) == 0) {
+                code = (IssueLogic::Code)i;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Uniform transition log line: the firmware log is the forensic record, so
+    // every raise / clear / ack is grep-able as "issue <verb>: code=".
+    static void _logTransition(const char *verb, bool raise, IssueLogic::Code code, uint8_t channel, const char *message)
+    {
+        char channelStr[8];
+        if (channel == ISSUE_GLOBAL_SCOPE) snprintf(channelStr, sizeof(channelStr), "none");
+        else snprintf(channelStr, sizeof(channelStr), "%u", channel);
+
+        IssueLogic::Severity severity = IssueLogic::codeSeverity(code);
+        char line[ISSUE_MESSAGE_BUFFER_SIZE + 96];
+        snprintf(line, sizeof(line), "Issue %s: code=%s channel=%s severity=%s details=\"%s\"",
+                 verb, IssueLogic::codeToString(code), channelStr,
+                 IssueLogic::severityToString(severity), message);
+
+        // Raise logs at the issue's own severity; clear/ack are informational
+        if (raise && severity == IssueLogic::Severity::Error) LOG_ERROR("%s", line);
+        else if (raise && severity == IssueLogic::Severity::Warning) LOG_WARNING("%s", line);
+        else LOG_INFO("%s", line);
+    }
+}

--- a/source/src/main.cpp
+++ b/source/src/main.cpp
@@ -22,6 +22,7 @@
 #include "mqtt.h"
 #include "custommqtt.h"
 #include "influxdbclient.h"
+#include "issueregistry.h"
 #include "multiplexer.h"
 #include "customlog.h"
 #include "taskprofiler.h"
@@ -183,6 +184,10 @@ void setup()
   LOG_DEBUG("Setting up InfluxDB client...");
   InfluxDbClient::begin();
   LOG_INFO("InfluxDB client setup done");
+
+  LOG_DEBUG("Setting up issue registry...");
+  IssueRegistry::begin();
+  LOG_INFO("Issue registry setup done");
 
   LOG_DEBUG("Starting maintenance task...");
   startMaintenanceTask();

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -2069,7 +2069,9 @@ namespace Mqtt
 
         // Monitor for stability period (here we just wait, rollback will occur automatically on failure)
         while (millis64() - validationStartTime < OTA_VALIDATION_TIMEOUT) {
-            LOG_DEBUG("OTA validation in progress - %llu ms remaining", OTA_VALIDATION_TIMEOUT + validationStartTime - millis64());
+            char otaRemainingHuman[24];
+            DurationFormat::humanizeDuration(OTA_VALIDATION_TIMEOUT + validationStartTime - millis64(), otaRemainingHuman, sizeof(otaRemainingHuman));
+            LOG_DEBUG("OTA validation in progress - %s remaining", otaRemainingHuman);
             delay(OTA_VALIDATION_CHECK_INTERVAL);
         }
 

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -3,6 +3,7 @@
 
 #include "mqtt.h"
 #include "taskprofiler.h"
+#include "duration_format.h"
 
 namespace Mqtt
 {
@@ -1514,7 +1515,9 @@ namespace Mqtt
 
             uint64_t backoffDelay = calculateExponentialBackoff(_mqttConnectionAttempt, MQTT_INITIAL_RETRY_INTERVAL, MQTT_MAX_RETRY_INTERVAL, MQTT_RETRY_MULTIPLIER);
             _nextMqttConnectionAttemptMillis = millis64() + backoffDelay;
-            LOG_WARNING("Failed to connect to MQTT (attempt %lu). Reason: %s. Next attempt in %llu ms", _mqttConnectionAttempt, _getMqttStateReason(currentState), backoffDelay);
+            char backoffHuman[24];
+            DurationFormat::humanizeDuration(backoffDelay, backoffHuman, sizeof(backoffHuman));
+            LOG_WARNING("Failed to connect to MQTT (attempt %lu). Reason: %s. Next attempt in %s", _mqttConnectionAttempt, _getMqttStateReason(currentState), backoffHuman);
 
             return false;
         }

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -31,6 +31,10 @@ namespace Mqtt
     static uint32_t _mqttConnectionAttempt = 0;
     static uint64_t _nextMqttConnectionAttemptMillis = 0;
 
+    // Connection state fact for the issue registry, updated once per task loop
+    // (the registry tick must not call _clientMqtt.connected() cross-task)
+    static volatile bool _lastConnectedState = false;
+
     // Last publish timestamps
     static uint64_t _lastMillisMeterPublished = 0;
     static uint64_t _lastMillisSystemDynamicPublished = 0;
@@ -330,6 +334,8 @@ namespace Mqtt
     }
 
     bool isCloudServicesEnabled() { return _cloudServicesEnabled; }
+
+    bool isConnected() { return _lastConnectedState; }
 
     // Public methods for requesting MQTT publications
     // ===============================================
@@ -647,13 +653,16 @@ namespace Mqtt
         {
             TASK_HEARTBEAT(_mqttHeartbeat);
 
+            bool connectedNow = false;
             if (CustomWifi::isFullyConnected()) {
                 if (_clientMqtt.connected()) {
+                    connectedNow = true;
                     _handleConnectedState();
                 } else {
                     _handleConnecting();
                 }
             }
+            _lastConnectedState = connectedNow;
 
             // If we receive a signal to stop the task, we try to publish all the data and flushing the queues so we avoid losing data
             if (_lastLoopToPublishData) {
@@ -669,6 +678,7 @@ namespace Mqtt
         }
 
         _clientMqtt.disconnect();
+        _lastConnectedState = false;
         LOG_DEBUG("MQTT task stopping");
         _taskHandle = nullptr;
         vTaskDelete(nullptr);

--- a/source/src/utils.cpp
+++ b/source/src/utils.cpp
@@ -202,6 +202,7 @@ void populateSystemDynamicInfo(SystemDynamicInfo& info) {
     info.ade7953EnergySaveTaskInfo = Ade7953::getEnergySaveTaskInfo();
     info.ade7953HourlyCsvTaskInfo = Ade7953::getHourlyCsvTaskInfo();
     info.maintenanceTaskInfo = getMaintenanceTaskInfo();
+    info.issueRegistryTaskInfo = IssueRegistry::getTaskInfo();
 
     LOG_DEBUG("Dynamic system info populated");
 }
@@ -360,6 +361,7 @@ void systemDynamicInfoToJson(SystemDynamicInfo& info, JsonDocument &doc) {
     addTask("ade7953EnergySave", info.ade7953EnergySaveTaskInfo);
     addTask("ade7953HourlyCsv", info.ade7953HourlyCsvTaskInfo);
     addTask("maintenance", info.maintenanceTaskInfo);
+    addTask("issueRegistry", info.issueRegistryTaskInfo);
 
     LOG_DEBUG("Dynamic system info converted to JSON");
 }
@@ -571,6 +573,7 @@ static void _restartTask(void* parameter) {
 
     // 2. Stop all services (best effort, don't wait forever for each)
     LOG_DEBUG("Stopping services before restart...");
+    IssueRegistry::stop();
     CustomServer::stop();
     Ade7953::stop();
     ModbusTcp::stop();

--- a/source/src/utils.cpp
+++ b/source/src/utils.cpp
@@ -253,6 +253,11 @@ void systemStaticInfoToJson(SystemStaticInfo& info, JsonDocument &doc) {
     
     // Device
     doc["device"]["id"] = info.deviceId;
+#ifdef ENV_DEV
+    doc["device"]["devBuild"] = true;
+#else
+    doc["device"]["devBuild"] = false;
+#endif
 
     // Factory provisioning (Unknown / 0 when the device was not factory-provisioned)
     doc["factory"]["serialNumber"] = info.serialNumber;

--- a/source/src/utils.cpp
+++ b/source/src/utils.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2025 Jibril Sharafi
 
 #include "utils.h"
+#include "duration_format.h"
 
 #include "taskprofiler.h"
 
@@ -560,7 +561,9 @@ static void _startFailsafeTimer() {
     };
     if (esp_timer_create(&timerArgs, &_failsafeTimer) == ESP_OK) {
         esp_timer_start_once(_failsafeTimer, SYSTEM_RESTART_FAILSAFE_TIMEOUT * 1000ULL); // Convert ms to us
-        LOG_DEBUG("Failsafe restart timer started (%d ms)", SYSTEM_RESTART_FAILSAFE_TIMEOUT);
+        char failsafeHuman[24];
+        DurationFormat::humanizeDuration((uint64_t)SYSTEM_RESTART_FAILSAFE_TIMEOUT, failsafeHuman, sizeof(failsafeHuman));
+        LOG_DEBUG("Failsafe restart timer started (%s)", failsafeHuman);
     } else {
         LOG_WARNING("Failed to create failsafe timer - restart may hang if blocked");
     }
@@ -688,9 +691,11 @@ void printDeviceStatusDynamic()
     populateSystemDynamicInfo(*info);
 
     LOG_DEBUG("--- Dynamic System Info ---");
+    char uptimeHuman[24];
+    DurationFormat::humanizeDuration(info->uptimeMilliseconds, uptimeHuman, sizeof(uptimeHuman));
     LOG_DEBUG(
-        "Uptime: %llu s (%llu ms) | Timestamp: %s | Temperature: %.2f C", 
-        info->uptimeSeconds, info->uptimeMilliseconds, info->currentTimestampIso, info->temperatureCelsius
+        "Uptime: %s | Timestamp: %s | Temperature: %.2f C",
+        uptimeHuman, info->currentTimestampIso, info->temperatureCelsius
     );
 
     LOG_DEBUG("Heap: %lu total, %lu free (%.1f%%), %lu used (%.1f%%), %lu min free, %lu max alloc",  

--- a/source/test/test_duration_format/test_duration_format.cpp
+++ b/source/test/test_duration_format/test_duration_format.cpp
@@ -45,34 +45,34 @@ void test_999_ms(void) {
 // Seconds range  (1000 ms .. 59999 ms)
 // ============================================================================
 
-void test_1000_ms_is_1_0_s(void) {
+void test_1000_ms_is_1_s(void) {
     char buf[32];
     humanizeDuration(1000, buf, sizeof(buf));
-    TEST_ASSERT_EQUAL_STRING("1.0 s", buf);
+    TEST_ASSERT_EQUAL_STRING("1 s", buf);
 }
 
-void test_1500_ms_is_1_5_s(void) {
+void test_1500_ms_is_1_s(void) {
     char buf[32];
     humanizeDuration(1500, buf, sizeof(buf));
-    TEST_ASSERT_EQUAL_STRING("1.5 s", buf);
+    TEST_ASSERT_EQUAL_STRING("1 s", buf);
 }
 
-void test_2400_ms_is_2_4_s(void) {
+void test_2400_ms_is_2_s(void) {
     char buf[32];
     humanizeDuration(2400, buf, sizeof(buf));
-    TEST_ASSERT_EQUAL_STRING("2.4 s", buf);
+    TEST_ASSERT_EQUAL_STRING("2 s", buf);
 }
 
-void test_10000_ms_is_10_0_s(void) {
+void test_10000_ms_is_10_s(void) {
     char buf[32];
     humanizeDuration(10000, buf, sizeof(buf));
-    TEST_ASSERT_EQUAL_STRING("10.0 s", buf);
+    TEST_ASSERT_EQUAL_STRING("10 s", buf);
 }
 
-void test_59999_ms_is_60_0_s(void) {
+void test_59999_ms_is_59_s(void) {
     char buf[32];
     humanizeDuration(59999, buf, sizeof(buf));
-    TEST_ASSERT_EQUAL_STRING("60.0 s", buf);
+    TEST_ASSERT_EQUAL_STRING("59 s", buf);
 }
 
 // ============================================================================
@@ -179,11 +179,11 @@ int main(int argc, char **argv) {
     RUN_TEST(test_850_ms);
     RUN_TEST(test_999_ms);
 
-    RUN_TEST(test_1000_ms_is_1_0_s);
-    RUN_TEST(test_1500_ms_is_1_5_s);
-    RUN_TEST(test_2400_ms_is_2_4_s);
-    RUN_TEST(test_10000_ms_is_10_0_s);
-    RUN_TEST(test_59999_ms_is_60_0_s);
+    RUN_TEST(test_1000_ms_is_1_s);
+    RUN_TEST(test_1500_ms_is_1_s);
+    RUN_TEST(test_2400_ms_is_2_s);
+    RUN_TEST(test_10000_ms_is_10_s);
+    RUN_TEST(test_59999_ms_is_59_s);
 
     RUN_TEST(test_60000_ms_is_1_min);
     RUN_TEST(test_3_min);

--- a/source/test/test_duration_format/test_duration_format.cpp
+++ b/source/test/test_duration_format/test_duration_format.cpp
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+//
+// Host unit tests for DurationFormat::humanizeDuration. Run with:
+//   pio test -e native          (from WSL - Windows native toolchain is unreliable)
+
+#include <unity.h>
+#include <cstring>
+#include "duration_format.h"
+
+using namespace DurationFormat;
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ============================================================================
+// Milliseconds range  (< 1000)
+// ============================================================================
+
+void test_zero_ms(void) {
+    char buf[32];
+    humanizeDuration(0, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("0 ms", buf);
+}
+
+void test_1_ms(void) {
+    char buf[32];
+    humanizeDuration(1, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("1 ms", buf);
+}
+
+void test_850_ms(void) {
+    char buf[32];
+    humanizeDuration(850, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("850 ms", buf);
+}
+
+void test_999_ms(void) {
+    char buf[32];
+    humanizeDuration(999, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("999 ms", buf);
+}
+
+// ============================================================================
+// Seconds range  (1000 ms .. 59999 ms)
+// ============================================================================
+
+void test_1000_ms_is_1_0_s(void) {
+    char buf[32];
+    humanizeDuration(1000, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("1.0 s", buf);
+}
+
+void test_1500_ms_is_1_5_s(void) {
+    char buf[32];
+    humanizeDuration(1500, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("1.5 s", buf);
+}
+
+void test_2400_ms_is_2_4_s(void) {
+    char buf[32];
+    humanizeDuration(2400, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("2.4 s", buf);
+}
+
+void test_10000_ms_is_10_0_s(void) {
+    char buf[32];
+    humanizeDuration(10000, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("10.0 s", buf);
+}
+
+void test_59999_ms_is_60_0_s(void) {
+    char buf[32];
+    humanizeDuration(59999, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("60.0 s", buf);
+}
+
+// ============================================================================
+// Minutes range  (60000 ms .. 3599999 ms)
+// ============================================================================
+
+void test_60000_ms_is_1_min(void) {
+    char buf[32];
+    humanizeDuration(60000, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("1 min", buf);
+}
+
+void test_3_min(void) {
+    char buf[32];
+    humanizeDuration(3 * 60000ULL, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("3 min", buf);
+}
+
+void test_59_min(void) {
+    char buf[32];
+    humanizeDuration(59 * 60000ULL, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("59 min", buf);
+}
+
+void test_3599999_ms_is_59_min(void) {
+    char buf[32];
+    humanizeDuration(3599999, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("59 min", buf);
+}
+
+// ============================================================================
+// Hours range  (3600000 ms .. 86399999 ms)
+// ============================================================================
+
+void test_3600000_ms_is_1_h(void) {
+    char buf[32];
+    humanizeDuration(3600000, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("1 h", buf);
+}
+
+void test_5_h(void) {
+    char buf[32];
+    humanizeDuration(5 * 3600000ULL, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("5 h", buf);
+}
+
+void test_23_h(void) {
+    char buf[32];
+    humanizeDuration(23 * 3600000ULL, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("23 h", buf);
+}
+
+void test_86399999_ms_is_23_h(void) {
+    char buf[32];
+    humanizeDuration(86399999, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("23 h", buf);
+}
+
+// ============================================================================
+// Days range  (>= 86400000 ms)
+// ============================================================================
+
+void test_86400000_ms_is_1_d(void) {
+    char buf[32];
+    humanizeDuration(86400000, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("1 d", buf);
+}
+
+void test_2_d(void) {
+    char buf[32];
+    humanizeDuration(2 * 86400000ULL, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("2 d", buf);
+}
+
+void test_large_duration(void) {
+    char buf[32];
+    humanizeDuration(30 * 86400000ULL, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("30 d", buf);
+}
+
+// ============================================================================
+// Safety: null/zero-size buffer
+// ============================================================================
+
+void test_null_buffer_is_safe(void) {
+    humanizeDuration(1000, nullptr, 32);  // must not crash
+}
+
+void test_zero_size_is_safe(void) {
+    char buf[32] = "sentinel";
+    humanizeDuration(1000, buf, 0);  // must not write anything
+    TEST_ASSERT_EQUAL_STRING("sentinel", buf);
+}
+
+// ============================================================================
+// Runner
+// ============================================================================
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_zero_ms);
+    RUN_TEST(test_1_ms);
+    RUN_TEST(test_850_ms);
+    RUN_TEST(test_999_ms);
+
+    RUN_TEST(test_1000_ms_is_1_0_s);
+    RUN_TEST(test_1500_ms_is_1_5_s);
+    RUN_TEST(test_2400_ms_is_2_4_s);
+    RUN_TEST(test_10000_ms_is_10_0_s);
+    RUN_TEST(test_59999_ms_is_60_0_s);
+
+    RUN_TEST(test_60000_ms_is_1_min);
+    RUN_TEST(test_3_min);
+    RUN_TEST(test_59_min);
+    RUN_TEST(test_3599999_ms_is_59_min);
+
+    RUN_TEST(test_3600000_ms_is_1_h);
+    RUN_TEST(test_5_h);
+    RUN_TEST(test_23_h);
+    RUN_TEST(test_86399999_ms_is_23_h);
+
+    RUN_TEST(test_86400000_ms_is_1_d);
+    RUN_TEST(test_2_d);
+    RUN_TEST(test_large_duration);
+
+    RUN_TEST(test_null_buffer_is_safe);
+    RUN_TEST(test_zero_size_is_safe);
+
+    return UNITY_END();
+}

--- a/source/test/test_issue_logic/test_issue_logic.cpp
+++ b/source/test/test_issue_logic/test_issue_logic.cpp
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+//
+// Host unit tests for the pure issue-registry logic. Run with:  pio test -e native
+// (On Windows the native toolchain is unreliable - run it from WSL.)
+//
+// These exercise the ISA-18.2-lite lifecycle (active/cleared x unacked/acked),
+// the window-evidence helpers and every per-code predicate entirely in memory.
+// The scenario tests at the bottom replay the design discussions for issue #145:
+// a correct auto-flip (info event, lingers until ack), a wrong manual reverse
+// (ongoing error that only a real fix clears), and a transient outage that
+// self-heals overnight (stays visible greyed until acked).
+
+#include <unity.h>
+#include <cstring>
+#include "issue_logic.h"
+
+using namespace IssueLogic;
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ============================================================================
+// Catalog
+// ============================================================================
+
+void test_code_strings_are_unique_and_stable(void) {
+    // Every code has a non-"unknown" string; spot-check the documented ones.
+    for (uint8_t i = 0; i < (uint8_t)Code::Count; i++) {
+        TEST_ASSERT_NOT_EQUAL(0, strcmp(codeToString((Code)i), "unknown"));
+    }
+    TEST_ASSERT_EQUAL_STRING("ct_polarity_flipped", codeToString(Code::CtPolarityFlipped));
+    TEST_ASSERT_EQUAL_STRING("channel_polarity_mismatch", codeToString(Code::ChannelPolarityMismatch));
+    TEST_ASSERT_EQUAL_STRING("panic_reboot", codeToString(Code::PanicReboot));
+}
+
+void test_severity_mapping(void) {
+    TEST_ASSERT_EQUAL(Severity::Info, codeSeverity(Code::CtPolarityFlipped));
+    TEST_ASSERT_EQUAL(Severity::Error, codeSeverity(Code::ChannelPolarityMismatch));
+    TEST_ASSERT_EQUAL(Severity::Warning, codeSeverity(Code::CustomMqttConnectFailed));
+    TEST_ASSERT_EQUAL(Severity::Warning, codeSeverity(Code::CloudMqttDisconnected));
+    TEST_ASSERT_EQUAL(Severity::Warning, codeSeverity(Code::InfluxDbUploadFailing));
+    TEST_ASSERT_EQUAL(Severity::Error, codeSeverity(Code::SafeModeActive));
+    TEST_ASSERT_EQUAL(Severity::Warning, codeSeverity(Code::HeapLow));
+}
+
+// ============================================================================
+// Lifecycle state machine
+// ============================================================================
+
+void test_step_raise_from_inactive(void) {
+    Transition t = step(State::Inactive, true);
+    TEST_ASSERT_EQUAL(State::ActiveUnacked, t.state);
+    TEST_ASSERT_TRUE(t.raised);
+    TEST_ASSERT_FALSE(t.cleared);
+}
+
+void test_step_inactive_stays_inactive(void) {
+    Transition t = step(State::Inactive, false);
+    TEST_ASSERT_EQUAL(State::Inactive, t.state);
+    TEST_ASSERT_FALSE(t.raised);
+    TEST_ASSERT_FALSE(t.cleared);
+}
+
+void test_step_active_unacked_clears_to_cleared_unacked(void) {
+    // Condition resolves before anyone saw it: must NOT vanish.
+    Transition t = step(State::ActiveUnacked, false);
+    TEST_ASSERT_EQUAL(State::ClearedUnacked, t.state);
+    TEST_ASSERT_TRUE(t.cleared);
+}
+
+void test_step_active_acked_clears_to_inactive(void) {
+    // Seen and resolved: gone.
+    Transition t = step(State::ActiveAcked, false);
+    TEST_ASSERT_EQUAL(State::Inactive, t.state);
+    TEST_ASSERT_TRUE(t.cleared);
+}
+
+void test_step_cleared_unacked_lingers(void) {
+    Transition t = step(State::ClearedUnacked, false);
+    TEST_ASSERT_EQUAL(State::ClearedUnacked, t.state);
+    TEST_ASSERT_FALSE(t.raised);
+    TEST_ASSERT_FALSE(t.cleared);
+}
+
+void test_step_cleared_unacked_reraises(void) {
+    Transition t = step(State::ClearedUnacked, true);
+    TEST_ASSERT_EQUAL(State::ActiveUnacked, t.state);
+    TEST_ASSERT_TRUE(t.raised);
+}
+
+void test_ack_active_unacked_becomes_acked_not_removed(void) {
+    // Acking a live problem must NOT hide it.
+    TEST_ASSERT_EQUAL(State::ActiveAcked, applyAck(State::ActiveUnacked));
+}
+
+void test_ack_cleared_unacked_removes(void) {
+    TEST_ASSERT_EQUAL(State::Inactive, applyAck(State::ClearedUnacked));
+}
+
+void test_ack_is_idempotent(void) {
+    TEST_ASSERT_EQUAL(State::ActiveAcked, applyAck(State::ActiveAcked));
+    TEST_ASSERT_EQUAL(State::Inactive, applyAck(State::Inactive));
+}
+
+void test_state_predicates(void) {
+    TEST_ASSERT_FALSE(isVisible(State::Inactive));
+    TEST_ASSERT_TRUE(isVisible(State::ClearedUnacked));
+    TEST_ASSERT_TRUE(isActive(State::ActiveAcked));
+    TEST_ASSERT_FALSE(isActive(State::ClearedUnacked));
+    TEST_ASSERT_TRUE(isUnacked(State::ActiveUnacked));
+    TEST_ASSERT_TRUE(isUnacked(State::ClearedUnacked));
+    TEST_ASSERT_FALSE(isUnacked(State::ActiveAcked));
+}
+
+// ============================================================================
+// Window evidence helpers
+// ============================================================================
+
+void test_counter_delta_normal(void) {
+    TEST_ASSERT_EQUAL_UINT64(5, counterDelta(10, 15));
+    TEST_ASSERT_EQUAL_UINT64(0, counterDelta(10, 10));
+}
+
+void test_counter_delta_backwards_is_zero(void) {
+    // Counter reset (module restart) must not produce a giant bogus delta.
+    TEST_ASSERT_EQUAL_UINT64(0, counterDelta(100, 3));
+}
+
+void test_rate_evidence(void) {
+    TEST_ASSERT_EQUAL(Evidence::Good, rateEvidence(5, 2));  // any success wins
+    TEST_ASSERT_EQUAL(Evidence::Bad, rateEvidence(0, 3));
+    TEST_ASSERT_EQUAL(Evidence::None, rateEvidence(0, 0)); // idle window: no evidence
+}
+
+void test_streak_accumulates_and_resets(void) {
+    uint16_t s = 0;
+    s = updateStreak(s, Evidence::Bad);
+    s = updateStreak(s, Evidence::Bad);
+    TEST_ASSERT_EQUAL_UINT16(2, s);
+    s = updateStreak(s, Evidence::None); // freeze, not reset
+    TEST_ASSERT_EQUAL_UINT16(2, s);
+    s = updateStreak(s, Evidence::Good);
+    TEST_ASSERT_EQUAL_UINT16(0, s);
+}
+
+void test_streak_saturates(void) {
+    uint16_t s = UINT16_MAX;
+    TEST_ASSERT_EQUAL_UINT16(UINT16_MAX, updateStreak(s, Evidence::Bad));
+}
+
+// ============================================================================
+// Per-code predicates
+// ============================================================================
+
+void test_channel_mismatch_requires_minimum_reads(void) {
+    // 3 evidence reads with min 5: window carries no evidence either way.
+    TEST_ASSERT_EQUAL(Evidence::None, channelMismatchEvidence(3, 3, 5, 0.9f));
+}
+
+void test_channel_mismatch_bad_when_mostly_clamped(void) {
+    TEST_ASSERT_EQUAL(Evidence::Bad, channelMismatchEvidence(20, 19, 5, 0.9f));
+    TEST_ASSERT_EQUAL(Evidence::Bad, channelMismatchEvidence(20, 20, 5, 0.9f));
+}
+
+void test_channel_mismatch_good_when_readings_flow(void) {
+    // Normal operation: evidence reads with zero (or few) clamps.
+    TEST_ASSERT_EQUAL(Evidence::Good, channelMismatchEvidence(20, 0, 5, 0.9f));
+    TEST_ASSERT_EQUAL(Evidence::Good, channelMismatchEvidence(20, 10, 5, 0.9f));
+}
+
+void test_read_failure_evidence(void) {
+    TEST_ASSERT_EQUAL(Evidence::Bad, readFailureEvidence(30, 30));
+    TEST_ASSERT_EQUAL(Evidence::Good, readFailureEvidence(29, 30));
+    TEST_ASSERT_EQUAL(Evidence::Good, readFailureEvidence(0, 30));
+}
+
+void test_nominal_voltage_selection(void) {
+    TEST_ASSERT_EQUAL_FLOAT(230.0f, nearestNominalVoltage(235.0f));
+    TEST_ASSERT_EQUAL_FLOAT(120.0f, nearestNominalVoltage(118.0f));
+    TEST_ASSERT_EQUAL_FLOAT(120.0f, nearestNominalVoltage(110.0f));
+}
+
+void test_nominal_frequency_selection(void) {
+    TEST_ASSERT_EQUAL_FLOAT(50.0f, nearestNominalFrequency(49.8f));
+    TEST_ASSERT_EQUAL_FLOAT(60.0f, nearestNominalFrequency(59.2f));
+}
+
+void test_voltage_evidence(void) {
+    TEST_ASSERT_EQUAL(Evidence::Good, voltageEvidence(230.0f, 0.10f));
+    TEST_ASSERT_EQUAL(Evidence::Good, voltageEvidence(215.0f, 0.10f));
+    TEST_ASSERT_EQUAL(Evidence::Bad, voltageEvidence(195.0f, 0.10f));  // -15% on 230
+    TEST_ASSERT_EQUAL(Evidence::Bad, voltageEvidence(140.0f, 0.10f));  // +17% on 120
+    TEST_ASSERT_EQUAL(Evidence::None, voltageEvidence(0.0f, 0.10f));   // no reading
+    TEST_ASSERT_EQUAL(Evidence::None, voltageEvidence(-5.0f, 0.10f));
+}
+
+void test_frequency_evidence(void) {
+    TEST_ASSERT_EQUAL(Evidence::Good, frequencyEvidence(50.05f, 1.0f));
+    TEST_ASSERT_EQUAL(Evidence::Bad, frequencyEvidence(48.5f, 1.0f));
+    TEST_ASSERT_EQUAL(Evidence::Good, frequencyEvidence(60.4f, 1.0f));
+    TEST_ASSERT_EQUAL(Evidence::None, frequencyEvidence(0.0f, 1.0f));
+}
+
+// ============================================================================
+// Scenario walkthroughs (from the #145 design discussion)
+// ============================================================================
+
+// Case 1: CT auto-flip on first load. The registry pulses the condition true
+// for exactly one tick (flip counter advanced); the notice must land in
+// ClearedUnacked and linger until the user acks it.
+void test_scenario_auto_flip_event_lingers_until_ack(void) {
+    State s = State::Inactive;
+
+    Transition t = step(s, true); // tick sees a new flip record
+    TEST_ASSERT_TRUE(t.raised);
+    s = t.state;
+
+    t = step(s, false); // next tick: event over
+    s = t.state;
+    TEST_ASSERT_EQUAL(State::ClearedUnacked, s);
+
+    // Days pass: it lingers, never silently disappears.
+    for (int i = 0; i < 1000; i++) s = step(s, false).state;
+    TEST_ASSERT_EQUAL(State::ClearedUnacked, s);
+
+    s = applyAck(s);
+    TEST_ASSERT_EQUAL(State::Inactive, s);
+}
+
+// Case 2: wrong manual reverse override. The mismatch condition stays active
+// through an ack (cannot be dismissed) and resolves only when the user fixes
+// either the flag or the physical CT - both collapse the clamped fraction.
+void test_scenario_manual_reverse_mismatch_until_fixed(void) {
+    uint16_t streak = 0;
+    State s = State::Inactive;
+    const uint16_t raiseThreshold = 3;
+
+    // Wrong reverse: every window mostly clamped while carrying evidence.
+    for (int tick = 0; tick < 5; tick++) {
+        Evidence e = channelMismatchEvidence(30, 30, 5, 0.9f);
+        streak = updateStreak(streak, e);
+        s = step(s, streak >= raiseThreshold).state;
+    }
+    TEST_ASSERT_EQUAL(State::ActiveUnacked, s);
+
+    // User acks but does not fix: stays listed, calm, NOT removed.
+    s = applyAck(s);
+    TEST_ASSERT_EQUAL(State::ActiveAcked, s);
+    Evidence e = channelMismatchEvidence(30, 30, 5, 0.9f);
+    streak = updateStreak(streak, e);
+    s = step(s, streak >= raiseThreshold).state;
+    TEST_ASSERT_EQUAL(State::ActiveAcked, s);
+
+    // Fix (either unchecking reverse or physically flipping the CT): clamps stop.
+    e = channelMismatchEvidence(30, 0, 5, 0.9f);
+    streak = updateStreak(streak, e);
+    s = step(s, streak >= raiseThreshold).state;
+    TEST_ASSERT_EQUAL(State::Inactive, s); // was acked -> removed on clear
+}
+
+// Case 3: InfluxDB outage at night that self-heals before morning. The user
+// must still find the trace (ClearedUnacked) and remove it with one ack.
+void test_scenario_overnight_outage_leaves_trace(void) {
+    uint16_t streak = 0;
+    State s = State::Inactive;
+    const uint16_t raiseThreshold = 3;
+
+    // Outage: errors, no successes.
+    for (int tick = 0; tick < 4; tick++) {
+        streak = updateStreak(streak, rateEvidence(0, 5));
+        s = step(s, streak >= raiseThreshold).state;
+    }
+    TEST_ASSERT_EQUAL(State::ActiveUnacked, s);
+
+    // Server back: one good window clears immediately.
+    streak = updateStreak(streak, rateEvidence(7, 0));
+    s = step(s, streak >= raiseThreshold).state;
+    TEST_ASSERT_EQUAL(State::ClearedUnacked, s);
+
+    // Morning: user acks the trace away.
+    s = applyAck(s);
+    TEST_ASSERT_EQUAL(State::Inactive, s);
+}
+
+// A flapping condition must re-raise (and would re-log) on each recurrence.
+void test_scenario_flapping_reraises(void) {
+    State s = State::Inactive;
+    s = step(s, true).state;
+    s = step(s, false).state;
+    TEST_ASSERT_EQUAL(State::ClearedUnacked, s);
+    Transition t = step(s, true);
+    TEST_ASSERT_TRUE(t.raised);
+    TEST_ASSERT_EQUAL(State::ActiveUnacked, t.state);
+}
+
+// ============================================================================
+
+int main(int argc, char **argv) {
+    (void)argc;
+    (void)argv;
+    UNITY_BEGIN();
+
+    RUN_TEST(test_code_strings_are_unique_and_stable);
+    RUN_TEST(test_severity_mapping);
+
+    RUN_TEST(test_step_raise_from_inactive);
+    RUN_TEST(test_step_inactive_stays_inactive);
+    RUN_TEST(test_step_active_unacked_clears_to_cleared_unacked);
+    RUN_TEST(test_step_active_acked_clears_to_inactive);
+    RUN_TEST(test_step_cleared_unacked_lingers);
+    RUN_TEST(test_step_cleared_unacked_reraises);
+    RUN_TEST(test_ack_active_unacked_becomes_acked_not_removed);
+    RUN_TEST(test_ack_cleared_unacked_removes);
+    RUN_TEST(test_ack_is_idempotent);
+    RUN_TEST(test_state_predicates);
+
+    RUN_TEST(test_counter_delta_normal);
+    RUN_TEST(test_counter_delta_backwards_is_zero);
+    RUN_TEST(test_rate_evidence);
+    RUN_TEST(test_streak_accumulates_and_resets);
+    RUN_TEST(test_streak_saturates);
+
+    RUN_TEST(test_channel_mismatch_requires_minimum_reads);
+    RUN_TEST(test_channel_mismatch_bad_when_mostly_clamped);
+    RUN_TEST(test_channel_mismatch_good_when_readings_flow);
+    RUN_TEST(test_read_failure_evidence);
+    RUN_TEST(test_nominal_voltage_selection);
+    RUN_TEST(test_nominal_frequency_selection);
+    RUN_TEST(test_voltage_evidence);
+    RUN_TEST(test_frequency_evidence);
+
+    RUN_TEST(test_scenario_auto_flip_event_lingers_until_ack);
+    RUN_TEST(test_scenario_manual_reverse_mismatch_until_fixed);
+    RUN_TEST(test_scenario_overnight_outage_leaves_trace);
+    RUN_TEST(test_scenario_flapping_reraises);
+
+    return UNITY_END();
+}

--- a/source/test/test_meter_logic/test_meter_logic.cpp
+++ b/source/test/test_meter_logic/test_meter_logic.cpp
@@ -20,7 +20,7 @@ void tearDown(void) {}
 
 // Config values mirror the firmware defaults so the tests track real behaviour.
 static const WeightConfig WCFG = {0.4f, 0.4f, 0.1f, 1.5f, 2.0f};
-static const float MIN_A = 0.02f;              // MINIMUM_CURRENT_FOR_VALIDATION
+static const float MIN_A = 0.02f;              // validation threshold (firmware: CT rating * MINIMUM_CURRENT_RATIO_VALIDATION, e.g. 20 A * 0.001)
 static const PolarityConfig PCFG = {5, 50, MIN_A};
 static const float COND_A = 1.0f;              // a nominal "real load" current (>= MIN_A)
 

--- a/source/test/test_meter_logic/test_meter_logic.cpp
+++ b/source/test/test_meter_logic/test_meter_logic.cpp
@@ -1,0 +1,998 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+//
+// Host unit tests for the pure meter logic. Run with:  pio test -e native
+// (On Windows the native toolchain is unreliable - run it from WSL.)
+//
+// These need no hardware: they exercise the CT-polarity detector, the negative
+// clamp, the WDRR weighting and the scheduler core entirely in memory. The
+// integration simulations at the bottom reproduce the dev-bench starvation
+// regression and prove the conduction-gated boost fixes it without breaking
+// reversed-CT detection on circuits that are idle at install time.
+
+#include <unity.h>
+#include "meter_logic.h"
+
+using namespace MeterLogic;
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// Config values mirror the firmware defaults so the tests track real behaviour.
+static const WeightConfig WCFG = {0.4f, 0.4f, 0.1f, 1.5f, 2.0f};
+static const float MIN_A = 0.02f;              // MINIMUM_CURRENT_FOR_VALIDATION
+static const PolarityConfig PCFG = {5, 50, MIN_A};
+static const float COND_A = 1.0f;              // a nominal "real load" current (>= MIN_A)
+
+// ============================================================================
+// updatePolarity
+// ============================================================================
+
+void test_polarity_not_armed_is_noop(void) {
+    PolarityState s{false, 0, 0};
+    PolarityResult r = updatePolarity(s, -100.0f, COND_A, PCFG);
+    TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
+    TEST_ASSERT_FALSE(r.state.armed);
+    TEST_ASSERT_EQUAL_INT8(0, r.state.voteCount);
+    TEST_ASSERT_EQUAL_UINT16(0, r.state.conductingReads);
+}
+
+void test_polarity_steady_reverse_flips_at_threshold(void) {
+    PolarityState s{true, 0, 0};
+    PolarityAction action = PolarityAction::Continue;
+    int reads = 0;
+    for (int i = 0; i < 10; i++) {
+        PolarityResult r = updatePolarity(s, -230.0f, COND_A, PCFG);
+        s = r.state;
+        action = r.action;
+        reads++;
+        if (action != PolarityAction::Continue) break;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Flip, action);
+    TEST_ASSERT_EQUAL_INT(5, reads);   // flips on exactly the 5th reversed vote
+    TEST_ASSERT_FALSE(s.armed);        // disarms after deciding
+}
+
+void test_polarity_steady_forward_confirms_without_flip(void) {
+    PolarityState s{true, 0, 0};
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 10; i++) {
+        PolarityResult r = updatePolarity(s, 1500.0f, COND_A, PCFG);
+        s = r.state;
+        action = r.action;
+        if (action != PolarityAction::Continue) break;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Disarm, action); // confirmed correct, no flip
+    TEST_ASSERT_FALSE(s.armed);
+}
+
+void test_polarity_is_magnitude_independent(void) {
+    // A tiny steady reversed load must flip exactly like a huge one.
+    PolarityState s{true, 0, 0};
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 10; i++) {
+        PolarityResult r = updatePolarity(s, -0.3f, COND_A, PCFG);
+        s = r.state;
+        action = r.action;
+        if (action != PolarityAction::Continue) break;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Flip, action);
+}
+
+void test_polarity_idle_is_noop_and_stays_armed(void) {
+    // No load: a non-conducting reading must not vote, must not count toward the
+    // bound, and must leave the channel armed (waiting for load).
+    PolarityState s{true, 0, 0};
+    for (int i = 0; i < 500; i++) {
+        PolarityResult r = updatePolarity(s, 0.0f, 0.0f, PCFG);
+        s = r.state;
+        TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
+    }
+    TEST_ASSERT_TRUE(s.armed);
+    TEST_ASSERT_EQUAL_INT8(0, s.voteCount);
+    TEST_ASSERT_EQUAL_UINT16(0, s.conductingReads);
+}
+
+void test_polarity_nan_is_noop(void) {
+    PolarityState s{true, 0, 0};
+    PolarityResult r = updatePolarity(s, NAN, COND_A, PCFG);
+    TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
+    TEST_ASSERT_TRUE(r.state.armed);
+    TEST_ASSERT_EQUAL_INT8(0, r.state.voteCount);
+    TEST_ASSERT_EQUAL_UINT16(0, r.state.conductingReads);
+}
+
+void test_polarity_delayed_load_still_detects(void) {
+    // THE KEY CORRECTNESS CASE: a CT clipped on a circuit that is off at install
+    // time. The channel stays armed through a long idle period, then a reversed
+    // load finally appears - and it must still be detected and flipped.
+    PolarityState s{true, 0, 0};
+    for (int i = 0; i < 200; i++) {
+        s = updatePolarity(s, 0.0f, 0.0f, PCFG).state; // idle: no load yet
+    }
+    TEST_ASSERT_TRUE(s.armed); // still armed after a long wait
+
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 10; i++) {
+        PolarityResult r = updatePolarity(s, -230.0f, COND_A, PCFG); // load finally flows, reversed
+        s = r.state;
+        action = r.action;
+        if (action != PolarityAction::Continue) break;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Flip, action);
+}
+
+void test_polarity_oscillating_conducting_disarms_via_bound(void) {
+    // A channel that keeps conducting but whose sign oscillates can never decide;
+    // the conducting-read bound makes it give up (no flip) so it cannot stay
+    // armed-and-boosted forever.
+    PolarityState s{true, 0, 0};
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 200; i++) {
+        float p = (i % 2 == 0) ? -50.0f : 50.0f;
+        PolarityResult r = updatePolarity(s, p, COND_A, PCFG);
+        s = r.state;
+        action = r.action;
+        if (!s.armed) break;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Disarm, action); // gave up, did not flip
+    TEST_ASSERT_FALSE(s.armed);
+}
+
+void test_polarity_unbounded_oscillation_never_disarms(void) {
+    // Documents why the bound exists: with maxConductingReads == 0 an oscillating
+    // conducting channel never decides and never disarms.
+    PolarityState s{true, 0, 0};
+    PolarityConfig unbounded{5, 0, MIN_A};
+    for (int i = 0; i < 1000; i++) {
+        float p = (i % 2 == 0) ? -50.0f : 50.0f;
+        s = updatePolarity(s, p, COND_A, unbounded).state;
+    }
+    TEST_ASSERT_TRUE(s.armed);
+}
+
+// ============================================================================
+// isConductingReading  (the current gate that stops offset-noise false flips)
+// ============================================================================
+
+void test_conducting_true_for_real_load(void) {
+    TEST_ASSERT_TRUE(isConductingReading(100.0f, 5.0f, MIN_A)); // forward load
+    TEST_ASSERT_TRUE(isConductingReading(1.0f, MIN_A, MIN_A));  // exactly at the threshold
+}
+
+void test_conducting_true_for_reversed_load_with_current(void) {
+    // CRITICAL for the load/PV priority work: a reversed load reads NEGATIVE power
+    // but with REAL current, so it must still count as conducting - that is what lets
+    // a reversed CT both vote (to flip) and earn the armed boost (to resolve fast).
+    TEST_ASSERT_TRUE(isConductingReading(-100.0f, 5.0f, MIN_A));
+    TEST_ASSERT_TRUE(isConductingReading(-0.3f, 5.0f, MIN_A)); // tiny reversed power, real current
+}
+
+void test_conducting_false_for_offset_noise(void) {
+    // THE BUG: ADE7953 offset noise is a small, steady, signed power at ~0 current.
+    // On an unclamped role it must NOT conduct, or it votes a false reversal and hogs.
+    TEST_ASSERT_FALSE(isConductingReading(1.2f, 0.004f, MIN_A));  // the observed bench value
+    TEST_ASSERT_FALSE(isConductingReading(-3.5f, 0.0f, MIN_A));
+    TEST_ASSERT_FALSE(isConductingReading(1.0f, 0.0199f, MIN_A)); // just below the threshold
+}
+
+void test_conducting_false_for_zero_power_or_nan(void) {
+    TEST_ASSERT_FALSE(isConductingReading(0.0f, 5.0f, MIN_A));  // no power, current irrelevant
+    TEST_ASSERT_FALSE(isConductingReading(NAN, 5.0f, MIN_A));   // bad power read
+    TEST_ASSERT_FALSE(isConductingReading(100.0f, NAN, MIN_A)); // bad current read
+}
+
+void test_conducting_zero_threshold_degrades_to_power_only(void) {
+    // minCurrent == 0 disables the gate: any non-zero power conducts (old behaviour).
+    TEST_ASSERT_TRUE(isConductingReading(1.0f, 0.0f, 0.0f));
+    TEST_ASSERT_FALSE(isConductingReading(0.0f, 0.0f, 0.0f));
+}
+
+// ============================================================================
+// shouldClampNegative
+// ============================================================================
+
+void test_clamp_load_and_pv_negatives(void) {
+    TEST_ASSERT_TRUE(shouldClampNegative(-5.0f, CHANNEL_ROLE_LOAD));
+    TEST_ASSERT_TRUE(shouldClampNegative(-5.0f, CHANNEL_ROLE_PV));
+}
+
+void test_clamp_allows_grid_battery_inverter_negatives(void) {
+    TEST_ASSERT_FALSE(shouldClampNegative(-5.0f, CHANNEL_ROLE_GRID));
+    TEST_ASSERT_FALSE(shouldClampNegative(-5.0f, CHANNEL_ROLE_BATTERY));
+    TEST_ASSERT_FALSE(shouldClampNegative(-5.0f, CHANNEL_ROLE_INVERTER));
+}
+
+void test_clamp_never_touches_positive(void) {
+    TEST_ASSERT_FALSE(shouldClampNegative(5.0f, CHANNEL_ROLE_LOAD));
+    TEST_ASSERT_FALSE(shouldClampNegative(0.0f, CHANNEL_ROLE_PV));
+    TEST_ASSERT_FALSE(shouldClampNegative(0.0f, CHANNEL_ROLE_LOAD)); // exact zero is not negative
+    TEST_ASSERT_FALSE(shouldClampNegative(NAN, CHANNEL_ROLE_LOAD));  // NaN < 0 is false in IEEE-754
+}
+
+// ============================================================================
+// weighting
+// ============================================================================
+
+void test_role_priority_grid_battery_only(void) {
+    TEST_ASSERT_TRUE(roleHasSchedulingPriority(CHANNEL_ROLE_GRID));
+    TEST_ASSERT_TRUE(roleHasSchedulingPriority(CHANNEL_ROLE_BATTERY));
+    TEST_ASSERT_FALSE(roleHasSchedulingPriority(CHANNEL_ROLE_LOAD));
+    TEST_ASSERT_FALSE(roleHasSchedulingPriority(CHANNEL_ROLE_PV));
+    TEST_ASSERT_FALSE(roleHasSchedulingPriority(CHANNEL_ROLE_INVERTER));
+}
+
+void test_weight_inactive_is_zero(void) {
+    ChannelWeightInput in{false, 100.0f, 1.0f, false, CHANNEL_ROLE_LOAD};
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, computeChannelWeight(in, 0.5f, 0.5f, WCFG));
+}
+
+void test_weight_idle_load_is_min_base(void) {
+    ChannelWeightInput in{true, 0.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    TEST_ASSERT_EQUAL_FLOAT(WCFG.minBase, computeChannelWeight(in, 0.0f, 0.0f, WCFG));
+}
+
+void test_weight_grid_gets_multiplier(void) {
+    ChannelWeightInput load{true, 0.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    ChannelWeightInput grid{true, 0.0f, 0.0f, false, CHANNEL_ROLE_GRID};
+    float wLoad = computeChannelWeight(load, 0.0f, 0.0f, WCFG);
+    float wGrid = computeChannelWeight(grid, 0.0f, 0.0f, WCFG);
+    TEST_ASSERT_EQUAL_FLOAT(wLoad * WCFG.rolePriorityMult, wGrid);
+}
+
+void test_weight_armed_boost_only_when_conducting(void) {
+    // Armed but NOT conducting (no current): NO boost - this is what stops a no-load
+    // armed channel from hogging the scheduler.
+    ChannelWeightInput idleArmed{true, 0.0f, 0.0f, true, CHANNEL_ROLE_LOAD, false};
+    TEST_ASSERT_EQUAL_FLOAT(WCFG.minBase, computeChannelWeight(idleArmed, 0.0f, 0.0f, WCFG));
+
+    // Armed AND conducting: boost added on top of the normal weight.
+    ChannelWeightInput condArmed{true, 500.0f, 0.0f, true, CHANNEL_ROLE_LOAD, true};
+    ChannelWeightInput condUnarmed{true, 500.0f, 0.0f, false, CHANNEL_ROLE_LOAD, true};
+    float wArmed = computeChannelWeight(condArmed, 1.0f, 0.0f, WCFG);
+    float wUnarmed = computeChannelWeight(condUnarmed, 1.0f, 0.0f, WCFG);
+    TEST_ASSERT_EQUAL_FLOAT(wUnarmed + WCFG.armedBoost, wArmed);
+}
+
+void test_weight_clamped_reversed_load_still_boosted(void) {
+    // The load/PV priority fix: a reversed LOAD is stored clamped to 0, but it IS
+    // conducting - so it must still earn the armed boost (driven by `conducting`,
+    // not the clamped stored power). Without this, reversed loads resolved slowly.
+    ChannelWeightInput in{true, 0.0f /*clamped*/, 0.0f, true, CHANNEL_ROLE_LOAD, true /*conducting*/};
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, WCFG.minBase + WCFG.armedBoost,
+                             computeChannelWeight(in, 0.0f, 0.0f, WCFG));
+    // And a clamped reversed PV likewise.
+    ChannelWeightInput pv{true, 0.0f, 0.0f, true, CHANNEL_ROLE_PV, true};
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, WCFG.minBase + WCFG.armedBoost,
+                             computeChannelWeight(pv, 0.0f, 0.0f, WCFG));
+}
+
+void test_weight_shares_contribute(void) {
+    ChannelWeightInput in{true, 500.0f, 2.0f, false, CHANNEL_ROLE_LOAD};
+    // full power share + full variability share + base
+    float expected = WCFG.powerShare * 1.0f + WCFG.variability * 1.0f + WCFG.minBase;
+    TEST_ASSERT_EQUAL_FLOAT(expected, computeChannelWeight(in, 1.0f, 1.0f, WCFG));
+}
+
+void test_computeWeights_zeroes_channel_zero_and_handles_nan(void) {
+    const uint8_t N = 4;
+    ChannelWeightInput in[N];
+    in[0] = {true, 1000.0f, 0.0f, false, CHANNEL_ROLE_GRID}; // ch0 - excluded
+    in[1] = {true, NAN, NAN, false, CHANNEL_ROLE_LOAD};      // bad reading
+    in[2] = {true, 100.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    in[3] = {false, 0.0f, 0.0f, false, CHANNEL_ROLE_LOAD};   // inactive
+    float w[N] = {9, 9, 9, 9};
+
+    computeWeights(in, N, 1, WCFG, w);
+
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, w[0]); // channel 0 not scheduled
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, w[3]); // inactive
+    // NaN channel does not crash and gets a finite (base) weight; ch2 carries the share.
+    TEST_ASSERT_TRUE(w[1] >= WCFG.minBase);
+    TEST_ASSERT_TRUE(w[2] > w[1]);
+}
+
+// ============================================================================
+// scheduler core
+// ============================================================================
+
+void test_find_starved_channel(void) {
+    const uint8_t N = 4;
+    bool active[N] = {true, true, true, false};
+    uint64_t last[N] = {0, 19000, 1000, 0};
+    uint64_t now = 20000;
+    uint8_t s = findStarvedChannel(last, active, N, 1, now, 15000);
+    TEST_ASSERT_EQUAL_UINT8(2, s); // ch2 gap 19000 > 15000 (ch1 gap 1000 is fine)
+}
+
+void test_find_starved_skips_unbaselined_and_inactive(void) {
+    const uint8_t N = 4;
+    bool active[N] = {true, false, true, true};
+    uint64_t last[N] = {0, 1, 0, 1}; // ch1 inactive, ch2 never baselined (0), ch3 baselined
+    uint64_t now = 100000;
+    uint8_t s = findStarvedChannel(last, active, N, 1, now, 15000);
+    TEST_ASSERT_EQUAL_UINT8(3, s); // only ch3 qualifies
+}
+
+void test_find_starved_none(void) {
+    const uint8_t N = 3;
+    bool active[N] = {true, true, true};
+    uint64_t last[N] = {0, 99000, 99500};
+    uint64_t now = 100000;
+    TEST_ASSERT_EQUAL_UINT8(NO_CHANNEL, findStarvedChannel(last, active, N, 1, now, 15000));
+}
+
+void test_wdrr_accumulate_gains_zeroes_and_clamps(void) {
+    const uint8_t N = 4;
+    float weights[N] = {0, 1.0f, 0.1f, 99.0f};
+    bool active[N] = {true, true, true, false};
+    float deficits[N] = {0, 4.9f, 0.0f, 7.0f};
+    wdrrAccumulate(weights, deficits, active, N, 1, 5.0f);
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, 5.0f, deficits[1]); // 4.9 + 1.0 -> clamped to 5.0
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, 0.1f, deficits[2]); // 0 + 0.1
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, deficits[3]);        // inactive -> zeroed
+}
+
+void test_wdrr_pick_highest_deficit(void) {
+    const uint8_t N = 4;
+    float deficits[N] = {0, 0.2f, 0.9f, 0.5f};
+    bool active[N] = {true, true, true, true};
+    uint8_t cursor = 0;
+    uint8_t pick = wdrrPick(deficits, active, N, 1, &cursor);
+    TEST_ASSERT_EQUAL_UINT8(2, pick);
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, -0.1f, deficits[2]); // decremented by 1.0
+    TEST_ASSERT_EQUAL_UINT8(2, cursor);
+}
+
+void test_wdrr_pick_all_inactive_returns_invalid(void) {
+    const uint8_t N = 3;
+    float deficits[N] = {0, 1.0f, 2.0f};
+    bool active[N] = {true, false, false};
+    uint8_t cursor = 0;
+    TEST_ASSERT_EQUAL_UINT8(NO_CHANNEL, wdrrPick(deficits, active, N, 1, &cursor));
+}
+
+void test_wdrr_tie_break_rotates_no_monopoly(void) {
+    // Equal-deficit idle channels must rotate, not let the lowest index win every
+    // time. Run many rounds and assert service counts are balanced.
+    const uint8_t N = 6; // ch0 + 5 schedulable
+    bool active[N] = {true, true, true, true, true, true};
+    float weights[N] = {0, 0.1f, 0.1f, 0.1f, 0.1f, 0.1f};
+    float deficits[N] = {0, 0, 0, 0, 0, 0};
+    uint8_t cursor = 0;
+    int picks[N] = {0};
+    for (int r = 0; r < 500; r++) {
+        wdrrAccumulate(weights, deficits, active, N, 1, 5.0f);
+        uint8_t p = wdrrPick(deficits, active, N, 1, &cursor);
+        TEST_ASSERT_NOT_EQUAL(NO_CHANNEL, p);
+        picks[p]++;
+    }
+    for (uint8_t i = 1; i < N; i++) {
+        TEST_ASSERT_TRUE(picks[i] > 50); // none starved
+    }
+}
+
+// ============================================================================
+// Integration simulations
+// ============================================================================
+//
+// A small driver that runs the full per-round pipeline (weights -> accumulate ->
+// pick -> detector) so the pieces are exercised together exactly as the firmware
+// composes them.
+
+void test_armed_no_load_channel_does_not_starve_peers(void) {
+    // ch0 + 6 active LOAD channels, none carrying any load. ch1 is armed (the
+    // installer just toggled it). The conduction-gated boost means ch1 is NEVER
+    // boosted while idle, so peers are serviced fairly from the very first round,
+    // and ch1 simply stays armed waiting for load.
+    const uint8_t N = 7;
+    const uint8_t START = 1;
+    ChannelWeightInput in[N];
+    bool active[N];
+    float deficits[N];
+    float weights[N];
+    PolarityState pol[N];
+    for (uint8_t i = 0; i < N; i++) {
+        in[i] = {i >= START, 0.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+        active[i] = (i >= START);
+        deficits[i] = 0.0f;
+        weights[i] = 0.0f;
+        pol[i] = {false, 0, 0};
+    }
+    pol[1].armed = true;
+    in[1].armed = true;
+
+    uint8_t cursor = 0;
+    int gap[N] = {0};
+    int maxGap[N] = {0};
+    const int ROUNDS = 600;
+
+    for (int r = 0; r < ROUNDS; r++) {
+        for (uint8_t i = START; i < N; i++) {
+            in[i].armed = pol[i].armed;
+            in[i].conducting = (in[i].activePower != 0.0f); // pre-clamp conduction signal
+        }
+        computeWeights(in, N, START, WCFG, weights);
+        wdrrAccumulate(weights, deficits, active, N, START, 5.0f);
+        uint8_t pick = wdrrPick(deficits, active, N, START, &cursor);
+        TEST_ASSERT_NOT_EQUAL(NO_CHANNEL, pick);
+
+        PolarityResult pr = updatePolarity(pol[pick], in[pick].activePower, COND_A, PCFG);
+        pol[pick] = pr.state;
+
+        for (uint8_t i = START; i < N; i++) {
+            if (i == pick) gap[i] = 0;
+            else {
+                gap[i]++;
+                if (gap[i] > maxGap[i]) maxGap[i] = gap[i];
+            }
+        }
+    }
+
+    // ch1 stays armed (no load ever arrived) - it must keep waiting, not give up.
+    TEST_ASSERT_TRUE(pol[1].armed);
+    // No starvation at any point: with 6 equal channels, fair service is ~6 rounds.
+    for (uint8_t i = START; i < N; i++) {
+        TEST_ASSERT_TRUE(maxGap[i] > 0);
+        TEST_ASSERT_TRUE(maxGap[i] < 12);
+    }
+}
+
+void test_armed_conducting_channel_resolves_quickly(void) {
+    // ch1 armed AND carrying a steady reversed load: the conduction-gated boost
+    // makes it win most slots and resolve (flip) within a handful of rounds.
+    const uint8_t N = 7;
+    const uint8_t START = 1;
+    ChannelWeightInput in[N];
+    bool active[N];
+    float deficits[N];
+    float weights[N];
+    PolarityState pol[N];
+    for (uint8_t i = 0; i < N; i++) {
+        in[i] = {i >= START, 0.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+        active[i] = (i >= START);
+        deficits[i] = 0.0f;
+        weights[i] = 0.0f;
+        pol[i] = {false, 0, 0};
+    }
+    pol[1].armed = true;
+    in[1].activePower = -500.0f; // reversed load conducting
+
+    uint8_t cursor = 0;
+    int flipRound = -1;
+    for (int r = 0; r < 200; r++) {
+        for (uint8_t i = START; i < N; i++) {
+            in[i].armed = pol[i].armed;
+            in[i].conducting = (in[i].activePower != 0.0f); // pre-clamp conduction signal
+        }
+        computeWeights(in, N, START, WCFG, weights);
+        wdrrAccumulate(weights, deficits, active, N, START, 5.0f);
+        uint8_t pick = wdrrPick(deficits, active, N, START, &cursor);
+
+        PolarityResult pr = updatePolarity(pol[pick], in[pick].activePower, COND_A, PCFG);
+        if (pr.action == PolarityAction::Flip && flipRound < 0) flipRound = r;
+        pol[pick] = pr.state;
+    }
+
+    TEST_ASSERT_TRUE(flipRound >= 0);
+    TEST_ASSERT_TRUE(flipRound < 20); // boosted -> resolves fast
+    TEST_ASSERT_FALSE(pol[1].armed);  // disarmed after the flip
+}
+
+void test_grid_sampled_more_often_than_load(void) {
+    // A grid channel and load channels, all idle: grid should be picked clearly
+    // more often thanks to the role multiplier (which is NOT gated on conduction).
+    const uint8_t N = 5; // ch0 + ch1 grid + ch2..4 load
+    ChannelWeightInput in[N];
+    bool active[N];
+    float deficits[N];
+    float weights[N];
+    for (uint8_t i = 0; i < N; i++) {
+        ChannelRole role = (i == 1) ? CHANNEL_ROLE_GRID : CHANNEL_ROLE_LOAD;
+        in[i] = {i >= 1, 0.0f, 0.0f, false, role};
+        active[i] = (i >= 1);
+        deficits[i] = 0.0f;
+        weights[i] = 0.0f;
+    }
+    uint8_t cursor = 0;
+    int picks[N] = {0};
+    for (int r = 0; r < 1000; r++) {
+        computeWeights(in, N, 1, WCFG, weights);
+        wdrrAccumulate(weights, deficits, active, N, 1, 5.0f);
+        uint8_t p = wdrrPick(deficits, active, N, 1, &cursor);
+        picks[p]++;
+    }
+    TEST_ASSERT_TRUE(picks[1] > picks[2]);
+    TEST_ASSERT_TRUE(picks[1] > picks[3]);
+    TEST_ASSERT_TRUE(picks[1] > picks[4]);
+}
+
+// ============================================================================
+// Additional coverage (boundaries, precedence, multi-channel, full-size)
+// ============================================================================
+
+void test_polarity_nonpositive_threshold_is_noop(void) {
+    // Misconfigured threshold must be a safe no-op, not decide on the first read.
+    PolarityState s{true, 0, 0};
+    PolarityConfig zero{0, 50, MIN_A};
+    PolarityResult r = updatePolarity(s, -230.0f, COND_A, zero);
+    TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
+    TEST_ASSERT_TRUE(r.state.armed);
+    TEST_ASSERT_EQUAL_INT8(0, r.state.voteCount);
+}
+
+void test_polarity_threshold_one_decides_immediately(void) {
+    PolarityState s{true, 0, 0};
+    PolarityConfig one{1, 50, MIN_A};
+    TEST_ASSERT_EQUAL(PolarityAction::Flip, updatePolarity(s, -100.0f, COND_A, one).action);
+    TEST_ASSERT_EQUAL(PolarityAction::Disarm, updatePolarity(s, 100.0f, COND_A, one).action);
+}
+
+void test_polarity_one_below_threshold_stays_armed(void) {
+    PolarityState s{true, 0, 0};
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 4; i++) { // threshold is 5
+        PolarityResult r = updatePolarity(s, -230.0f, COND_A, PCFG);
+        s = r.state;
+        action = r.action;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Continue, action);
+    TEST_ASSERT_TRUE(s.armed);
+    TEST_ASSERT_EQUAL_INT8(-4, s.voteCount);
+    TEST_ASSERT_EQUAL_UINT16(4, s.conductingReads);
+}
+
+void test_polarity_flip_takes_precedence_over_bound(void) {
+    // bound == threshold: a genuinely reversed CT must Flip, not Disarm, on the
+    // read where both conditions are first satisfiable.
+    PolarityState s{true, 0, 0};
+    PolarityConfig cfg{5, 5, MIN_A};
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 5; i++) {
+        PolarityResult r = updatePolarity(s, -230.0f, COND_A, cfg);
+        s = r.state;
+        action = r.action;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Flip, action);
+    TEST_ASSERT_FALSE(s.armed);
+}
+
+void test_polarity_bound_disarms_without_flip(void) {
+    PolarityState s{true, 0, 0};
+    PolarityConfig cfg{5, 4, MIN_A};
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 4; i++) {
+        float p = (i % 2 == 0) ? -50.0f : 50.0f; // net stays near 0, never reaches 5
+        PolarityResult r = updatePolarity(s, p, COND_A, cfg);
+        s = r.state;
+        action = r.action;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Disarm, action);
+    TEST_ASSERT_FALSE(s.armed);
+}
+
+void test_polarity_vote_recovers_and_confirms(void) {
+    // Goes to -4, then a run of forward votes recovers it to +5 -> confirm (no flip).
+    PolarityState s{true, 0, 0};
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 4; i++) s = updatePolarity(s, -100.0f, COND_A, PCFG).state; // vote -4
+    TEST_ASSERT_EQUAL_INT8(-4, s.voteCount);
+    for (int i = 0; i < 9; i++) {
+        PolarityResult r = updatePolarity(s, 100.0f, COND_A, PCFG); // -3,-2,-1,0,1,2,3,4,5
+        s = r.state;
+        action = r.action;
+        if (action != PolarityAction::Continue) break;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Disarm, action); // confirmed forward, no flip
+}
+
+void test_polarity_vote_recovers_and_flips(void) {
+    // Mirror: +4 then a run of reversed votes -> reaches -5 -> flip.
+    PolarityState s{true, 0, 0};
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 4; i++) s = updatePolarity(s, 100.0f, COND_A, PCFG).state; // vote +4
+    for (int i = 0; i < 9; i++) {
+        PolarityResult r = updatePolarity(s, -100.0f, COND_A, PCFG);
+        s = r.state;
+        action = r.action;
+        if (action != PolarityAction::Continue) break;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Flip, action);
+}
+
+void test_polarity_disarmed_mid_sequence_is_noop(void) {
+    PolarityState s{false, -3, 3}; // disarmed but with residual counters
+    PolarityResult r = updatePolarity(s, -230.0f, COND_A, PCFG);
+    TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
+    TEST_ASSERT_FALSE(r.state.armed);
+    TEST_ASSERT_EQUAL_INT8(-3, r.state.voteCount);     // unchanged
+    TEST_ASSERT_EQUAL_UINT16(3, r.state.conductingReads);
+}
+
+void test_weight_grid_armed_conducting_all_bumps_stack(void) {
+    // grid (x2) + armed + conducting + full power share: pins the arithmetic order
+    // (role multiply on the base, THEN add the flat armed boost).
+    ChannelWeightInput in{true, -500.0f, 0.0f, true, CHANNEL_ROLE_GRID, true};
+    // base = 0.4*1 + 0.4*0 + 0.1 = 0.5; *2.0 = 1.0; + 1.5 = 2.5
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, 2.5f, computeChannelWeight(in, 1.0f, 0.0f, WCFG));
+    // same but not conducting -> no boost: 0.5*2.0 = 1.0
+    ChannelWeightInput idle{true, 0.0f, 0.0f, true, CHANNEL_ROLE_GRID, false};
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, 1.0f, computeChannelWeight(idle, 1.0f, 0.0f, WCFG));
+}
+
+void test_computeWeights_battery_gets_multiplier(void) {
+    const uint8_t N = 3;
+    ChannelWeightInput in[N];
+    in[0] = {false, 0.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    in[1] = {true, 100.0f, 0.0f, false, CHANNEL_ROLE_BATTERY};
+    in[2] = {true, 100.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    float w[N] = {};
+    computeWeights(in, N, 1, WCFG, w);
+    TEST_ASSERT_TRUE(w[1] > w[2]);
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, w[2] * WCFG.rolePriorityMult, w[1]);
+}
+
+void test_computeWeights_tiny_channel_gets_min_base(void) {
+    const uint8_t N = 3;
+    ChannelWeightInput in[N];
+    in[0] = {false, 0.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    in[1] = {true, 10000.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    in[2] = {true, 1.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    float w[N] = {};
+    computeWeights(in, N, 1, WCFG, w);
+    TEST_ASSERT_TRUE(w[2] >= WCFG.minBase); // anti-starvation floor holds under skew
+    TEST_ASSERT_TRUE(w[1] > w[2]);
+}
+
+void test_computeWeights_all_inactive_all_zeros(void) {
+    const uint8_t N = 4;
+    ChannelWeightInput in[N];
+    for (uint8_t i = 0; i < N; i++) in[i] = {false, 0.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    float w[N] = {9, 9, 9, 9};
+    computeWeights(in, N, 1, WCFG, w);
+    for (uint8_t i = 0; i < N; i++) TEST_ASSERT_EQUAL_FLOAT(0.0f, w[i]);
+}
+
+void test_computeWeights_variability_differentiates_equal_power(void) {
+    const uint8_t N = 3;
+    ChannelWeightInput in[N];
+    in[0] = {false, 0.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+    in[1] = {true, 100.0f, 0.1f, false, CHANNEL_ROLE_LOAD};
+    in[2] = {true, 100.0f, 0.9f, false, CHANNEL_ROLE_LOAD};
+    float w[N] = {};
+    computeWeights(in, N, 1, WCFG, w);
+    TEST_ASSERT_TRUE(w[2] > w[1]); // higher variability -> more weight
+}
+
+void test_find_starved_returns_lowest_index_when_multiple(void) {
+    const uint8_t N = 5;
+    bool active[N] = {true, true, true, true, true};
+    uint64_t last[N] = {0, 1000, 2000, 1000, 2000}; // all past gap at now=30000
+    TEST_ASSERT_EQUAL_UINT8(1, findStarvedChannel(last, active, N, 1, 30000, 5000));
+}
+
+void test_find_starved_exactly_at_gap_is_not_starved(void) {
+    const uint8_t N = 3;
+    bool active[N] = {true, true, true};
+    uint64_t last[N] = {0, 5000, 4999}; // ch1 gap=15000 (==), ch2 gap=15001 (>)
+    TEST_ASSERT_EQUAL_UINT8(2, findStarvedChannel(last, active, N, 1, 20000, 15000));
+    uint64_t last2[N] = {0, 4999, 5000}; // ch1 gap=15001 (>), ch2 gap=15000 (==)
+    TEST_ASSERT_EQUAL_UINT8(1, findStarvedChannel(last2, active, N, 1, 20000, 15000));
+}
+
+void test_find_starved_now_before_lastMillis_returns_channel(void) {
+    // Defensive: if lastMillis > now (clock skew / torn read), the unsigned gap
+    // underflows to a huge value and the channel is force-picked. This matches the
+    // original firmware and is the intended (force-read rather than defer) behavior.
+    const uint8_t N = 3;
+    bool active[N] = {true, true, true};
+    uint64_t last[N] = {0, 5000, 5000};
+    TEST_ASSERT_EQUAL_UINT8(1, findStarvedChannel(last, active, N, 1, 1000, 5000));
+}
+
+void test_wdrr_accumulate_nan_weight_is_zeroed(void) {
+    const uint8_t N = 3;
+    float weights[N] = {0, NAN, 0.5f};
+    bool active[N] = {false, true, true};
+    float deficits[N] = {0, 2.0f, 2.0f};
+    wdrrAccumulate(weights, deficits, active, N, 1, 5.0f);
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, deficits[1]); // NaN poisoned then reset
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, 2.5f, deficits[2]);
+}
+
+void test_wdrr_accumulate_clamps_negative(void) {
+    const uint8_t N = 2;
+    float weights[N] = {0, 0.0f};
+    bool active[N] = {false, true};
+    float deficits[N] = {0, -5.5f};
+    wdrrAccumulate(weights, deficits, active, N, 1, 5.0f);
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, -5.0f, deficits[1]); // clamped to -bound
+}
+
+void test_wdrr_pick_single_channel_always_wins(void) {
+    const uint8_t N = 4;
+    float deficits[N] = {0, 0.0f, 0.0f, 0.5f};
+    bool active[N] = {true, false, false, true}; // only ch3 schedulable
+    uint8_t cursor = 3;
+    TEST_ASSERT_EQUAL_UINT8(3, wdrrPick(deficits, active, N, 1, &cursor));
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, -0.5f, deficits[3]);
+    cursor = 1; // even starting elsewhere, the wrap finds ch3
+    deficits[3] = 0.5f;
+    TEST_ASSERT_EQUAL_UINT8(3, wdrrPick(deficits, active, N, 1, &cursor));
+}
+
+void test_wdrr_pick_cursor_wraps_at_end(void) {
+    // cursor at the last index must wrap to startIndex on the next pick.
+    const uint8_t N = 4;
+    float deficits[N] = {0, 0.1f, 0.1f, 0.1f};
+    bool active[N] = {true, true, true, true};
+    uint8_t cursor = 3; // last index -> next starts at ch1
+    TEST_ASSERT_EQUAL_UINT8(1, wdrrPick(deficits, active, N, 1, &cursor));
+    TEST_ASSERT_EQUAL_UINT8(1, cursor);
+    // next pick starts one past ch1 -> ch2 (deficits ch2,ch3 still 0.1, ch1 now -0.9)
+    TEST_ASSERT_EQUAL_UINT8(2, wdrrPick(deficits, active, N, 1, &cursor));
+}
+
+void test_wdrr_pick_tie_goes_to_channel_after_cursor(void) {
+    const uint8_t N = 4;
+    float deficits[N] = {0, 1.0f, 1.0f, 0.0f};
+    bool active[N] = {true, true, true, false};
+    uint8_t cursor = 1; // iteration starts at ch2
+    TEST_ASSERT_EQUAL_UINT8(2, wdrrPick(deficits, active, N, 1, &cursor));
+}
+
+void test_wdrr_pick_all_negative_deficits_picks_max(void) {
+    // Validates the no-sentinel picker: all deficits negative, highest still wins.
+    const uint8_t N = 4;
+    float deficits[N] = {0, -3.0f, -1.0f, -2.0f};
+    bool active[N] = {true, true, true, true};
+    uint8_t cursor = 0;
+    TEST_ASSERT_EQUAL_UINT8(2, wdrrPick(deficits, active, N, 1, &cursor));
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, -2.0f, deficits[2]);
+}
+
+void test_multiple_armed_channels_both_resolve(void) {
+    // Two reversed CTs armed at once (panel with several reversed clips): both must
+    // flip, neither starving the other.
+    const uint8_t N = 5;
+    const uint8_t START = 1;
+    ChannelWeightInput in[N];
+    bool active[N];
+    float deficits[N];
+    float weights[N];
+    PolarityState pol[N];
+    float power[N] = {0, -500.0f, -300.0f, 200.0f, 100.0f};
+    for (uint8_t i = 0; i < N; i++) {
+        in[i] = {i >= START, power[i], 0.0f, false, CHANNEL_ROLE_LOAD};
+        active[i] = (i >= START);
+        deficits[i] = 0.0f;
+        weights[i] = 0.0f;
+        pol[i] = {false, 0, 0};
+    }
+    pol[1].armed = true;
+    pol[2].armed = true;
+
+    uint8_t cursor = 0;
+    bool flipped1 = false, flipped2 = false;
+    for (int r = 0; r < 200; r++) {
+        for (uint8_t i = START; i < N; i++) {
+            in[i].armed = pol[i].armed;
+            in[i].conducting = (in[i].activePower != 0.0f); // pre-clamp conduction signal
+        }
+        computeWeights(in, N, START, WCFG, weights);
+        wdrrAccumulate(weights, deficits, active, N, START, 5.0f);
+        uint8_t pick = wdrrPick(deficits, active, N, START, &cursor);
+        PolarityResult pr = updatePolarity(pol[pick], in[pick].activePower, COND_A, PCFG);
+        if (pr.action == PolarityAction::Flip && pick == 1) flipped1 = true;
+        if (pr.action == PolarityAction::Flip && pick == 2) flipped2 = true;
+        pol[pick] = pr.state;
+    }
+    TEST_ASSERT_TRUE(flipped1);
+    TEST_ASSERT_TRUE(flipped2);
+    TEST_ASSERT_FALSE(pol[1].armed);
+    TEST_ASSERT_FALSE(pol[2].armed);
+}
+
+void test_full_17_channel_no_starvation(void) {
+    // Production array size: 17 channels (ch0 + 16 mux), all active LOAD, equal load.
+    // Every schedulable channel must be serviced and none may monopolise.
+    const uint8_t N = 17;
+    const uint8_t START = 1;
+    ChannelWeightInput in[N];
+    bool active[N];
+    float deficits[N];
+    float weights[N];
+    for (uint8_t i = 0; i < N; i++) {
+        in[i] = {i >= START, 100.0f, 0.0f, false, CHANNEL_ROLE_LOAD};
+        active[i] = (i >= START);
+        deficits[i] = 0.0f;
+        weights[i] = 0.0f;
+    }
+    uint8_t cursor = 0;
+    int picks[N] = {0};
+    for (int r = 0; r < 1600; r++) {
+        computeWeights(in, N, START, WCFG, weights);
+        wdrrAccumulate(weights, deficits, active, N, START, 5.0f);
+        uint8_t p = wdrrPick(deficits, active, N, START, &cursor);
+        TEST_ASSERT_NOT_EQUAL(NO_CHANNEL, p);
+        picks[p]++;
+    }
+    // 16 equal channels over 1600 rounds -> ~100 each. Assert balanced, none starved.
+    for (uint8_t i = START; i < N; i++) {
+        TEST_ASSERT_TRUE(picks[i] > 50);
+        TEST_ASSERT_TRUE(picks[i] < 200);
+    }
+}
+
+void test_mixed_fleet_grid_battery_sampled_more(void) {
+    // grid + battery (priority roles) vs load + PV: priority roles sampled clearly
+    // more often, and nothing is starved.
+    const uint8_t N = 6;
+    const uint8_t START = 1;
+    ChannelWeightInput in[N];
+    bool active[N];
+    float deficits[N];
+    float weights[N];
+    ChannelRole roles[N] = {CHANNEL_ROLE_LOAD, CHANNEL_ROLE_GRID, CHANNEL_ROLE_BATTERY,
+                            CHANNEL_ROLE_LOAD, CHANNEL_ROLE_LOAD, CHANNEL_ROLE_PV};
+    float power[N] = {0, 1000.0f, 500.0f, 300.0f, 200.0f, 400.0f};
+    for (uint8_t i = 0; i < N; i++) {
+        in[i] = {i >= START, power[i], 0.0f, false, roles[i]};
+        active[i] = (i >= START);
+        deficits[i] = 0.0f;
+        weights[i] = 0.0f;
+    }
+    uint8_t cursor = 0;
+    int picks[N] = {0};
+    for (int r = 0; r < 2000; r++) {
+        computeWeights(in, N, START, WCFG, weights);
+        wdrrAccumulate(weights, deficits, active, N, START, 5.0f);
+        uint8_t p = wdrrPick(deficits, active, N, START, &cursor);
+        picks[p]++;
+    }
+    TEST_ASSERT_TRUE(picks[1] > picks[3]); // grid > load
+    TEST_ASSERT_TRUE(picks[2] > picks[3]); // battery > load
+    TEST_ASSERT_TRUE(picks[1] > picks[5]); // grid > PV
+    for (uint8_t i = START; i < N; i++) TEST_ASSERT_TRUE(picks[i] > 50); // none starved
+}
+
+// ============================================================================
+// Current-gate integration (reproduces the bench false-flip and proves the fix)
+// ============================================================================
+
+void test_offset_noise_never_false_flips_unclamped_role(void) {
+    // THE HARDWARE REGRESSION, end to end: a grid channel (unclamped role) armed with
+    // no real load. The ADE7953 reports a small steady offset (+1.2 W) at ~0.004 A.
+    // Current-gated, every such read is non-conducting: updatePolarity no-ops, the
+    // channel never votes and stays armed - no false "CT reversal detected".
+    PolarityState s{true, 0, 0};
+    for (int i = 0; i < 1000; i++) {
+        PolarityResult r = updatePolarity(s, 1.2f, 0.004f, PCFG);
+        s = r.state;
+        TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
+    }
+    TEST_ASSERT_TRUE(s.armed);
+    TEST_ASSERT_EQUAL_INT8(0, s.voteCount);
+    TEST_ASSERT_EQUAL_UINT16(0, s.conductingReads);
+
+    // A genuine reversed load finally flows (-2000 W at 8.7 A): now it must flip.
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 10; i++) {
+        PolarityResult r = updatePolarity(s, -2000.0f, 8.7f, PCFG);
+        s = r.state;
+        action = r.action;
+        if (action != PolarityAction::Continue) break;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Flip, action);
+}
+
+void test_offset_noise_earns_no_boost(void) {
+    // The other half of the regression: offset noise must not earn the armed boost,
+    // or the noisy channel hogs the scheduler. The caller derives `conducting` from
+    // isConductingReading, so an armed grid channel on offset noise gets only its
+    // normal (role-multiplied) weight - no boost.
+    bool conducting = isConductingReading(1.2f, 0.004f, MIN_A);
+    TEST_ASSERT_FALSE(conducting);
+    ChannelWeightInput in{true, 1.2f, 0.0f, true /*armed*/, CHANNEL_ROLE_GRID, conducting};
+    // base 0.1 * rolePriorityMult 2.0 = 0.2; NO armed boost.
+    TEST_ASSERT_FLOAT_WITHIN(1e-5, WCFG.minBase * WCFG.rolePriorityMult,
+                             computeChannelWeight(in, 0.0f, 0.0f, WCFG));
+}
+
+void test_low_current_noise_does_not_burn_the_bound(void) {
+    // A noisy unclamped channel that oscillates sign at ~0 current must NOT burn its
+    // conducting-read bound: it stays armed indefinitely (waiting for real load),
+    // exactly like an idle channel, rather than disarming on noise.
+    PolarityState s{true, 0, 0};
+    for (int i = 0; i < 500; i++) {
+        float p = (i % 2 == 0) ? -2.0f : 2.0f; // offset noise, both signs
+        s = updatePolarity(s, p, 0.004f, PCFG).state;
+    }
+    TEST_ASSERT_TRUE(s.armed);
+    TEST_ASSERT_EQUAL_UINT16(0, s.conductingReads);
+}
+
+// ============================================================================
+// runner
+// ============================================================================
+
+int main(int, char **) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_polarity_not_armed_is_noop);
+    RUN_TEST(test_polarity_steady_reverse_flips_at_threshold);
+    RUN_TEST(test_polarity_steady_forward_confirms_without_flip);
+    RUN_TEST(test_polarity_is_magnitude_independent);
+    RUN_TEST(test_polarity_idle_is_noop_and_stays_armed);
+    RUN_TEST(test_polarity_nan_is_noop);
+    RUN_TEST(test_polarity_delayed_load_still_detects);
+    RUN_TEST(test_polarity_oscillating_conducting_disarms_via_bound);
+    RUN_TEST(test_polarity_unbounded_oscillation_never_disarms);
+
+    RUN_TEST(test_conducting_true_for_real_load);
+    RUN_TEST(test_conducting_true_for_reversed_load_with_current);
+    RUN_TEST(test_conducting_false_for_offset_noise);
+    RUN_TEST(test_conducting_false_for_zero_power_or_nan);
+    RUN_TEST(test_conducting_zero_threshold_degrades_to_power_only);
+
+    RUN_TEST(test_clamp_load_and_pv_negatives);
+    RUN_TEST(test_clamp_allows_grid_battery_inverter_negatives);
+    RUN_TEST(test_clamp_never_touches_positive);
+
+    RUN_TEST(test_role_priority_grid_battery_only);
+    RUN_TEST(test_weight_inactive_is_zero);
+    RUN_TEST(test_weight_idle_load_is_min_base);
+    RUN_TEST(test_weight_grid_gets_multiplier);
+    RUN_TEST(test_weight_armed_boost_only_when_conducting);
+    RUN_TEST(test_weight_shares_contribute);
+    RUN_TEST(test_computeWeights_zeroes_channel_zero_and_handles_nan);
+
+    RUN_TEST(test_find_starved_channel);
+    RUN_TEST(test_find_starved_skips_unbaselined_and_inactive);
+    RUN_TEST(test_find_starved_none);
+    RUN_TEST(test_wdrr_accumulate_gains_zeroes_and_clamps);
+    RUN_TEST(test_wdrr_pick_highest_deficit);
+    RUN_TEST(test_wdrr_pick_all_inactive_returns_invalid);
+    RUN_TEST(test_wdrr_tie_break_rotates_no_monopoly);
+
+    RUN_TEST(test_armed_no_load_channel_does_not_starve_peers);
+    RUN_TEST(test_armed_conducting_channel_resolves_quickly);
+    RUN_TEST(test_grid_sampled_more_often_than_load);
+
+    // Additional coverage
+    RUN_TEST(test_polarity_nonpositive_threshold_is_noop);
+    RUN_TEST(test_polarity_threshold_one_decides_immediately);
+    RUN_TEST(test_polarity_one_below_threshold_stays_armed);
+    RUN_TEST(test_polarity_flip_takes_precedence_over_bound);
+    RUN_TEST(test_polarity_bound_disarms_without_flip);
+    RUN_TEST(test_polarity_vote_recovers_and_confirms);
+    RUN_TEST(test_polarity_vote_recovers_and_flips);
+    RUN_TEST(test_polarity_disarmed_mid_sequence_is_noop);
+
+    RUN_TEST(test_weight_grid_armed_conducting_all_bumps_stack);
+    RUN_TEST(test_weight_clamped_reversed_load_still_boosted);
+    RUN_TEST(test_computeWeights_battery_gets_multiplier);
+    RUN_TEST(test_computeWeights_tiny_channel_gets_min_base);
+    RUN_TEST(test_computeWeights_all_inactive_all_zeros);
+    RUN_TEST(test_computeWeights_variability_differentiates_equal_power);
+
+    RUN_TEST(test_find_starved_returns_lowest_index_when_multiple);
+    RUN_TEST(test_find_starved_exactly_at_gap_is_not_starved);
+    RUN_TEST(test_find_starved_now_before_lastMillis_returns_channel);
+    RUN_TEST(test_wdrr_accumulate_nan_weight_is_zeroed);
+    RUN_TEST(test_wdrr_accumulate_clamps_negative);
+    RUN_TEST(test_wdrr_pick_single_channel_always_wins);
+    RUN_TEST(test_wdrr_pick_cursor_wraps_at_end);
+    RUN_TEST(test_wdrr_pick_tie_goes_to_channel_after_cursor);
+    RUN_TEST(test_wdrr_pick_all_negative_deficits_picks_max);
+
+    RUN_TEST(test_multiple_armed_channels_both_resolve);
+    RUN_TEST(test_full_17_channel_no_starvation);
+    RUN_TEST(test_mixed_fleet_grid_battery_sampled_more);
+
+    RUN_TEST(test_offset_noise_never_false_flips_unclamped_role);
+    RUN_TEST(test_offset_noise_earns_no_boost);
+    RUN_TEST(test_low_current_noise_does_not_burn_the_bound);
+
+    return UNITY_END();
+}

--- a/source/test/test_meter_logic/test_meter_logic.cpp
+++ b/source/test/test_meter_logic/test_meter_logic.cpp
@@ -21,8 +21,12 @@ void tearDown(void) {}
 // Config values mirror the firmware defaults so the tests track real behaviour.
 static const WeightConfig WCFG = {0.4f, 0.4f, 0.1f, 1.5f, 2.0f};
 static const float MIN_A = 0.02f;              // validation threshold (firmware: CT rating * MINIMUM_CURRENT_RATIO_VALIDATION, e.g. 20 A * 0.001)
+static const float COND_MIN_A = 0.006f;        // conducting gate (firmware: CT rating * MINIMUM_CURRENT_RATIO_CONDUCTING, e.g. 20 A * 0.0003)
 static const PolarityConfig PCFG = {5, 50, MIN_A};
+static const PolarityConfig PCFG_SMALL = {5, 50, COND_MIN_A}; // mirrors firmware cfg after the small-load-polarity fix
 static const float COND_A = 1.0f;              // a nominal "real load" current (>= MIN_A)
+static const float SMALL_LOAD_A = 0.009f;      // between COND_MIN_A and MIN_A: a real small load that should now vote
+static const float NOISE_A = 0.004f;           // below COND_MIN_A: offset noise that must never vote
 
 // ============================================================================
 // updatePolarity
@@ -913,6 +917,67 @@ void test_low_current_noise_does_not_burn_the_bound(void) {
 }
 
 // ============================================================================
+// Small-load conducting gate (#180: MINIMUM_CURRENT_RATIO_CONDUCTING)
+// ============================================================================
+
+void test_small_reversed_load_flips_with_conducting_gate(void) {
+    // THE REGRESSION from #180: a ~2.5 W reversed load on a 30 A CT sits below
+    // MINIMUM_CURRENT_RATIO_VALIDATION (~7 W) but above MINIMUM_CURRENT_RATIO_CONDUCTING
+    // (~2 W). With the old PCFG it was non-conducting and read a constant 0 forever.
+    // With PCFG_SMALL (the firmware's new cfg) it must vote and flip within threshold reads.
+    PolarityState s{true, 0, 0};
+    // SMALL_LOAD_A (0.009) > COND_MIN_A (0.006) but < MIN_A (0.02)
+    PolarityAction action = PolarityAction::Continue;
+    for (int i = 0; i < 10; i++) {
+        PolarityResult r = updatePolarity(s, -2.5f, SMALL_LOAD_A, PCFG_SMALL);
+        s = r.state;
+        action = r.action;
+        if (action != PolarityAction::Continue) break;
+    }
+    TEST_ASSERT_EQUAL(PolarityAction::Flip, action);
+
+    // Same load is non-conducting (and therefore never votes) with the old strict gate.
+    PolarityState s2{true, 0, 0};
+    for (int i = 0; i < 100; i++) {
+        PolarityResult r = updatePolarity(s2, -2.5f, SMALL_LOAD_A, PCFG);
+        s2 = r.state;
+        TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
+    }
+    TEST_ASSERT_TRUE(s2.armed);
+    TEST_ASSERT_EQUAL_INT8(0, s2.voteCount);
+}
+
+void test_noise_below_conducting_gate_does_not_vote(void) {
+    // Offset noise at NOISE_A (0.004 A) is below both gates. With PCFG_SMALL it must
+    // still produce no votes (the lower gate still excludes it).
+    PolarityState s{true, 0, 0};
+    for (int i = 0; i < 1000; i++) {
+        PolarityResult r = updatePolarity(s, 1.2f, NOISE_A, PCFG_SMALL);
+        s = r.state;
+        TEST_ASSERT_EQUAL(PolarityAction::Continue, r.action);
+    }
+    TEST_ASSERT_TRUE(s.armed);
+    TEST_ASSERT_EQUAL_INT8(0, s.voteCount);
+    TEST_ASSERT_EQUAL_UINT16(0, s.conductingReads);
+}
+
+void test_small_reversed_load_earns_armed_boost(void) {
+    // isConductingReading with the new lower gate must return true for SMALL_LOAD_A,
+    // so the WDRR armed boost fires and the channel resolves quickly.
+    bool conducting = isConductingReading(-2.5f, SMALL_LOAD_A, COND_MIN_A);
+    TEST_ASSERT_TRUE(conducting);
+
+    // The same reading is non-conducting under the old strict gate.
+    bool notConductingOld = isConductingReading(-2.5f, SMALL_LOAD_A, MIN_A);
+    TEST_ASSERT_FALSE(notConductingOld);
+
+    // Verify the boost is awarded when conducting=true under the new gate.
+    ChannelWeightInput in{true, 0.0f /*clamped*/, 0.0f, true /*armed*/, CHANNEL_ROLE_LOAD, conducting};
+    float w = computeChannelWeight(in, 0.0f, 0.0f, WCFG);
+    TEST_ASSERT_FLOAT_WITHIN(1e-5f, WCFG.minBase + WCFG.armedBoost, w);
+}
+
+// ============================================================================
 // runner
 // ============================================================================
 
@@ -993,6 +1058,10 @@ int main(int, char **) {
     RUN_TEST(test_offset_noise_never_false_flips_unclamped_role);
     RUN_TEST(test_offset_noise_earns_no_boost);
     RUN_TEST(test_low_current_noise_does_not_burn_the_bound);
+
+    RUN_TEST(test_small_reversed_load_flips_with_conducting_gate);
+    RUN_TEST(test_noise_below_conducting_gate_does_not_vote);
+    RUN_TEST(test_small_reversed_load_earns_armed_boost);
 
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

- Adds `DurationFormat::humanizeDuration(uint64_t ms, char *out, size_t outSize)` in `lib/duration_format/` - pure C++, no Arduino/FreeRTOS deps, compiles on host
- 22 Unity tests covering all range boundaries (ms/s/min/h/d), threshold edges, and null/zero-size buffer safety
- Migrates user-visible status string in `custommqtt.cpp` and log lines in `mqtt.cpp` / `influxdbclient.cpp` from raw `%llu ms` to humanized output

## Format

| Input | Output |
|-------|--------|
| < 1 s | `850 ms` |
| 1 s to < 60 s | `2.4 s` (one decimal) |
| 60 s to < 1 h | `3 min` |
| 1 h to < 24 h | `5 h` |
| >= 24 h | `2 d` |

## Test plan

- [x] `pio test -e native --filter test_duration_format` - 22/22 passed
- [x] Hardware verify: trigger a custom MQTT connection failure and confirm status box shows e.g. "Retrying in 5.0 s" instead of "Retrying in 5000 ms"

Closes #179