### PR TITLE
feat(utils): add DurationFormat::humanizeDuration helper

### DIFF
--- a/source/lib/duration_format/duration_format.cpp
+++ b/source/lib/duration_format/duration_format.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#include "duration_format.h"
+#include <cstdio>
+
+namespace DurationFormat {
+
+static constexpr uint64_t MS_PER_S   =     1000ULL;
+static constexpr uint64_t MS_PER_MIN =    60000ULL;
+static constexpr uint64_t MS_PER_H   =  3600000ULL;
+static constexpr uint64_t MS_PER_D   = 86400000ULL;
+
+void humanizeDuration(uint64_t ms, char *out, size_t outSize) {
+    if (!out || outSize == 0) return;
+
+    if (ms < MS_PER_S) {
+        snprintf(out, outSize, "%llu ms", (unsigned long long)ms);
+    } else if (ms < MS_PER_MIN) {
+        snprintf(out, outSize, "%.1f s", (double)ms / MS_PER_S);
+    } else if (ms < MS_PER_H) {
+        snprintf(out, outSize, "%llu min", (unsigned long long)(ms / MS_PER_MIN));
+    } else if (ms < MS_PER_D) {
+        snprintf(out, outSize, "%llu h", (unsigned long long)(ms / MS_PER_H));
+    } else {
+        snprintf(out, outSize, "%llu d", (unsigned long long)(ms / MS_PER_D));
+    }
+}
+
+}  // namespace DurationFormat

--- a/source/lib/duration_format/duration_format.cpp
+++ b/source/lib/duration_format/duration_format.cpp
@@ -17,7 +17,7 @@ void humanizeDuration(uint64_t ms, char *out, size_t outSize) {
     if (ms < MS_PER_S) {
         snprintf(out, outSize, "%llu ms", (unsigned long long)ms);
     } else if (ms < MS_PER_MIN) {
-        snprintf(out, outSize, "%.1f s", (double)ms / MS_PER_S);
+        snprintf(out, outSize, "%llu s", (unsigned long long)(ms / MS_PER_S));
     } else if (ms < MS_PER_H) {
         snprintf(out, outSize, "%llu min", (unsigned long long)(ms / MS_PER_MIN));
     } else if (ms < MS_PER_D) {

--- a/source/lib/duration_format/duration_format.h
+++ b/source/lib/duration_format/duration_format.h
@@ -10,7 +10,7 @@
 //
 // Formats a millisecond count into the most readable unit:
 //   <1 s    ->  "850 ms"
-//   <60 s   ->  "2.4 s"   (one decimal)
+//   <60 s   ->  "2 s"
 //   <60 min ->  "3 min"
 //   <24 h   ->  "5 h"
 //   >=24 h  ->  "2 d"

--- a/source/lib/duration_format/duration_format.h
+++ b/source/lib/duration_format/duration_format.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// Pure, dependency-free duration formatter.
+//
+// Formats a millisecond count into the most readable unit:
+//   <1 s    ->  "850 ms"
+//   <60 s   ->  "2.4 s"   (one decimal)
+//   <60 min ->  "3 min"
+//   <24 h   ->  "5 h"
+//   >=24 h  ->  "2 d"
+//
+// Output is ASCII-only and null-terminated. If `outSize` is 0 the call
+// is a no-op. A minimum buffer of 16 bytes covers all representable values.
+namespace DurationFormat {
+
+void humanizeDuration(uint64_t ms, char *out, size_t outSize);
+
+}  // namespace DurationFormat

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -3,6 +3,7 @@
 
 #include "ade7953.h"
 #include "taskprofiler.h"
+#include "duration_format.h"
 
 namespace Ade7953
 {
@@ -1981,8 +1982,10 @@ namespace Ade7953
             
             // Safety timeout
             if (currentMicros - _captureStartMicros >= WAVEFORM_CAPTURE_MAX_DURATION_MICROS) {
-                LOG_WARNING("Waveform capture timeout after %llu ms, captured %u samples with %u zero crossings", 
-                    (currentMicros - _captureStartMicros) / 1000, _captureSampleCount, zeroCrossingCount);
+                char captureDurHuman[24];
+                DurationFormat::humanizeDuration((currentMicros - _captureStartMicros) / 1000, captureDurHuman, sizeof(captureDurHuman));
+                LOG_WARNING("Waveform capture timeout after %s, captured %u samples with %u zero crossings",
+                    captureDurHuman, _captureSampleCount, zeroCrossingCount);
                 break;
             }
             
@@ -2035,8 +2038,10 @@ namespace Ade7953
         uint64_t totalDurationMs = (micros64() - _captureStartMicros) / 1000;
         
         _captureState = CaptureState::COMPLETE;
-        LOG_INFO("Waveform capture complete for channel %u: %u samples in %llu ms with %u zero crossings", 
-            _captureChannel, _captureSampleCount, totalDurationMs, zeroCrossingCount);
+        char captureDurHuman[24];
+        DurationFormat::humanizeDuration(totalDurationMs, captureDurHuman, sizeof(captureDurHuman));
+        LOG_INFO("Waveform capture complete for channel %u: %u samples in %s with %u zero crossings",
+            _captureChannel, _captureSampleCount, captureDurHuman, zeroCrossingCount);
     }
 
     void _handleCrcChangeInterrupt() {
@@ -2368,7 +2373,9 @@ namespace Ade7953
 
             // Calculate milliseconds until next hour using CustomTime
             uint64_t msUntilNextHour = CustomTime::getMillisecondsUntilNextHour();
-            LOG_DEBUG("Waiting for %llu ms until next hour to save the hourly energy", msUntilNextHour);
+            char msUntilNextHourHuman[24];
+            DurationFormat::humanizeDuration(msUntilNextHour, msUntilNextHourHuman, sizeof(msUntilNextHourHuman));
+            LOG_DEBUG("Waiting for %s until next hour to save the hourly energy", msUntilNextHourHuman);
 
             // Wait for the calculated time or stop notification
             if (ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS((uint32_t)msUntilNextHour)) > 0) { // Needs to be casted to uint32_t otherwise it will crash
@@ -4258,7 +4265,9 @@ namespace Ade7953
         
         setSampleTime(sampleTime);
 
-        LOG_DEBUG("Loaded sample time %llu ms from preferences", sampleTime);
+        char sampleTimeHuman[24];
+        DurationFormat::humanizeDuration(sampleTime, sampleTimeHuman, sizeof(sampleTimeHuman));
+        LOG_DEBUG("Loaded sample time %s from preferences", sampleTimeHuman);
     }
 
     void _saveSampleTimeToPreferences() {
@@ -4270,7 +4279,9 @@ namespace Ade7953
         preferences.putULong64(CONFIG_SAMPLE_TIME_KEY, _sampleTime);
         preferences.end();
 
-        LOG_DEBUG("Saved sample time %llu ms to preferences", _sampleTime);
+        char sampleTimeHuman[24];
+        DurationFormat::humanizeDuration(_sampleTime, sampleTimeHuman, sizeof(sampleTimeHuman));
+        LOG_DEBUG("Saved sample time %s to preferences", sampleTimeHuman);
     }
 
     void _updateSampleTime() {
@@ -4287,7 +4298,9 @@ namespace Ade7953
         uint64_t calculatedLinecyc = _sampleTime * _lineFrequency * 2 / 1000;
         _setLinecyc((uint32_t)calculatedLinecyc);
 
-        LOG_DEBUG("Successfully updated sample time to %llu ms (%llu line cycles) with grid frequency %u Hz", _sampleTime, calculatedLinecyc, _lineFrequency);
+        char sampleTimeHuman[24];
+        DurationFormat::humanizeDuration(_sampleTime, sampleTimeHuman, sizeof(sampleTimeHuman));
+        LOG_DEBUG("Successfully updated sample time to %s (%llu line cycles) with grid frequency %u Hz", sampleTimeHuman, calculatedLinecyc, _lineFrequency);
     }
 
     // ADE7953 register reading functions
@@ -4362,7 +4375,9 @@ namespace Ade7953
     void _checkForTooManyFailures() {
         
         if (millis64() - _firstFailureTime > ADE7953_FAILURE_RESET_TIMEOUT_MS && _failureCount > 0) {
-            LOG_DEBUG("Failure timeout exceeded (%lu ms). Resetting failure count (reached %d)", millis64() - _firstFailureTime, _failureCount);
+            char failureDurHuman[24];
+            DurationFormat::humanizeDuration(millis64() - _firstFailureTime, failureDurHuman, sizeof(failureDurHuman));
+            LOG_DEBUG("Failure timeout exceeded (%s). Resetting failure count (reached %d)", failureDurHuman, _failureCount);
             
             _failureCount = 0;
             _firstFailureTime = 0;
@@ -4396,8 +4411,10 @@ namespace Ade7953
 
     void _checkForTooManyCriticalFailures() {
         if (millis64() - _firstCriticalFailureTime > ADE7953_CRITICAL_FAILURE_RESET_TIMEOUT_MS && _criticalFailureCount > 0) {
-            LOG_DEBUG("Critical failure timeout exceeded (%llu ms). Resetting critical failure count (reached %lu)", 
-                millis64() - _firstCriticalFailureTime, _criticalFailureCount);
+            char critFailDurHuman[24];
+            DurationFormat::humanizeDuration(millis64() - _firstCriticalFailureTime, critFailDurHuman, sizeof(critFailDurHuman));
+            LOG_DEBUG("Critical failure timeout exceeded (%s). Resetting critical failure count (reached %lu)",
+                critFailDurHuman, _criticalFailureCount);
             
             _criticalFailureCount = 0;
             _firstCriticalFailureTime = 0;
@@ -4621,9 +4638,11 @@ namespace Ade7953
         if (starvedChannel != INVALID_CHANNEL) {
             // Can happen with high-power channels alongside static 0 W ones, so it is
             // not an error per se (hence DEBUG level).
+            char starvedGapHuman[24];
+            DurationFormat::humanizeDuration(starvedGap, starvedGapHuman, sizeof(starvedGapHuman));
             LOG_DEBUG(
-                "%s (%u): scheduler starvation, %llu ms since last read; force-picking",
-                _channelData[starvedChannel].label, starvedChannel, starvedGap
+                "%s (%u): scheduler starvation, %s since last read; force-picking",
+                _channelData[starvedChannel].label, starvedChannel, starvedGapHuman
             );
             _channelDeficit[starvedChannel] = 0.0f;
             return starvedChannel;

--- a/source/src/buttonhandler.cpp
+++ b/source/src/buttonhandler.cpp
@@ -3,6 +3,7 @@
 
 #include "buttonhandler.h"
 #include "taskprofiler.h"
+#include "duration_format.h"
 
 namespace ButtonHandler
 {
@@ -142,7 +143,9 @@ namespace ButtonHandler
                 {
                     // Button was released - process the press
                     uint64_t pressDuration = millis64() - _buttonPressStartTime;
-                    LOG_DEBUG("Button released after %llu ms", pressDuration);
+                    char pressDurationHuman[24];
+                    DurationFormat::humanizeDuration(pressDuration, pressDurationHuman, sizeof(pressDurationHuman));
+                    LOG_DEBUG("Button released after %s", pressDurationHuman);
 
                     _processButtonPress(pressDuration);
                     _buttonPressStartTime = ZERO_START_TIME;
@@ -197,7 +200,9 @@ namespace ButtonHandler
         else
         {
             _currentPressType = ButtonPressType::NONE;
-            LOG_DEBUG("Button press duration %llu ms - no action", pressDuration);
+            char pressDurationHuman[24];
+            DurationFormat::humanizeDuration(pressDuration, pressDurationHuman, sizeof(pressDurationHuman));
+            LOG_DEBUG("Button press duration %s - no action", pressDurationHuman);
         }
     }
 

--- a/source/src/crashmonitor.cpp
+++ b/source/src/crashmonitor.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2025 Jibril Sharafi
 
 #include "crashmonitor.h"
+#include "duration_format.h"
 
 namespace CrashMonitor
 {
@@ -112,8 +113,11 @@ namespace CrashMonitor
         
         if (isQuickRestart) {
             _quickRestartCount++;
-            LOG_WARNING("Quick restart detected (#%lu): only %llu ms since last boot (threshold: %lu ms)", 
-                _quickRestartCount, timeSinceLastBoot, QUICK_RESTART_THRESHOLD);
+            char timeSinceLastBootHuman[24], thresholdHuman[24];
+            DurationFormat::humanizeDuration(timeSinceLastBoot, timeSinceLastBootHuman, sizeof(timeSinceLastBootHuman));
+            DurationFormat::humanizeDuration(QUICK_RESTART_THRESHOLD, thresholdHuman, sizeof(thresholdHuman));
+            LOG_WARNING("Quick restart detected (#%lu): only %s since last boot (threshold: %s)",
+                _quickRestartCount, timeSinceLastBootHuman, thresholdHuman);
             
             if (_quickRestartCount >= MAX_QUICK_RESTARTS) {
                 _safeModeActive = true;
@@ -126,8 +130,10 @@ namespace CrashMonitor
         } else {
             // Not a quick restart - reset quick restart counter (but keep crash/reset counters)
             if (_quickRestartCount > 0) {
-                LOG_DEBUG("Stable boot detected (%llu ms since last boot), resetting quick restart counter (was %lu)", 
-                    timeSinceLastBoot, _quickRestartCount);
+                char timeSinceLastBootHuman[24];
+                DurationFormat::humanizeDuration(timeSinceLastBoot, timeSinceLastBootHuman, sizeof(timeSinceLastBootHuman));
+                LOG_DEBUG("Stable boot detected (%s since last boot), resetting quick restart counter (was %lu)",
+                    timeSinceLastBootHuman, _quickRestartCount);
                 _quickRestartCount = 0;
                 // Note: We intentionally keep _consecutiveCrashCount and _consecutiveResetCount
                 // Those are reset by the separate _crashResetTask after COUNTERS_RESET_TIMEOUT
@@ -135,7 +141,9 @@ namespace CrashMonitor
             
             // Exit safe mode if we had a stable restart (user fixed the issue)
             if (_safeModeActive && timeSinceLastBoot >= SAFE_MODE_MIN_UPTIME) {
-                LOG_INFO("Exiting safe mode due to stable restart (%llu ms uptime)", timeSinceLastBoot);
+                char timeSinceLastBootHuman[24];
+                DurationFormat::humanizeDuration(timeSinceLastBoot, timeSinceLastBootHuman, sizeof(timeSinceLastBootHuman));
+                LOG_INFO("Exiting safe mode due to stable restart (%s uptime)", timeSinceLastBootHuman);
                 _safeModeActive = false;
             }
         }

--- a/source/src/custommqtt.cpp
+++ b/source/src/custommqtt.cpp
@@ -3,6 +3,7 @@
 
 #include "custommqtt.h"
 #include "taskprofiler.h"
+#include "duration_format.h"
 
 namespace CustomMqtt
 {
@@ -472,14 +473,16 @@ namespace CustomMqtt
             uint64_t _backoffDelay = calculateExponentialBackoff(_currentMqttConnectionAttempt, MQTT_CUSTOM_INITIAL_RECONNECT_INTERVAL, MQTT_CUSTOM_MAX_RECONNECT_INTERVAL, MQTT_CUSTOM_RECONNECT_MULTIPLIER);
             _nextMqttConnectionAttemptMillis = millis64() + _backoffDelay;
 
-            snprintf(_status, sizeof(_status), "Connection failed: %s (Attempt %lu). Retrying in %llu ms", _reason, _currentMqttConnectionAttempt, _backoffDelay);
+            char _backoffHuman[24];
+            DurationFormat::humanizeDuration(_backoffDelay, _backoffHuman, sizeof(_backoffHuman));
+            snprintf(_status, sizeof(_status), "Connection failed: %s (Attempt %lu). Retrying in %s", _reason, _currentMqttConnectionAttempt, _backoffHuman);
             _statusTimestampUnix = CustomTime::getUnixTime();
 
-            LOG_WARNING("Failed to connect to Custom MQTT (attempt %lu). Reason: %s (%ld). Retrying in %llu ms", 
+            LOG_WARNING("Failed to connect to Custom MQTT (attempt %lu). Reason: %s (%ld). Retrying in %s",
                            _currentMqttConnectionAttempt,
                            _reason,
                            currentState,
-                           _nextMqttConnectionAttemptMillis - millis64());
+                           _backoffHuman);
 
             return false;
         }

--- a/source/src/customserver.cpp
+++ b/source/src/customserver.cpp
@@ -3,6 +3,7 @@
 
 #include "customserver.h"
 #include "taskprofiler.h"
+#include "duration_format.h"
 
 namespace CustomServer
 {
@@ -2014,7 +2015,9 @@ namespace CustomServer
 
                 if (Ade7953::setSampleTime(sampleTime))
                 {
-                    LOG_INFO("ADE7953 sample time updated to %lu ms via API", sampleTime);
+                    char sampleTimeHuman[24];
+                    DurationFormat::humanizeDuration(sampleTime, sampleTimeHuman, sizeof(sampleTimeHuman));
+                    LOG_INFO("ADE7953 sample time updated to %s via API", sampleTimeHuman);
                     _sendSuccessResponse(request, "ADE7953 sample time updated successfully");
                 }
                 else

--- a/source/src/customtime.cpp
+++ b/source/src/customtime.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2025 Jibril Sharafi
 
 #include "customtime.h"
+#include "duration_format.h"
 
 namespace CustomTime {
     // Static variables to maintain state
@@ -39,14 +40,18 @@ namespace CustomTime {
         uint64_t millisUntilNextHour = 3600000ULL - millisSinceCurrentHour;
 
         // Check if we're close to either the current hour (just passed) or the next hour (approaching)
+        char toleranceHuman[24], sinceHourHuman[24], untilNextHuman[24];
+        DurationFormat::humanizeDuration(toleranceMillis, toleranceHuman, sizeof(toleranceHuman));
         if (millisSinceCurrentHour <= toleranceMillis) {
-            LOG_DEBUG("Current time is close to the current hour (within %llu ms since hour start)", toleranceMillis);
+            LOG_DEBUG("Current time is close to the current hour (within %s since hour start)", toleranceHuman);
             return true;
         } else if (millisUntilNextHour <= toleranceMillis) {
-            LOG_DEBUG("Current time is close to the next hour (within %llu ms)", toleranceMillis);
+            LOG_DEBUG("Current time is close to the next hour (within %s)", toleranceHuman);
             return true;
         } else {
-            LOG_DEBUG("Current time is not close to any hour (since hour: %llu ms, until next: %llu ms)", millisSinceCurrentHour, millisUntilNextHour);
+            DurationFormat::humanizeDuration(millisSinceCurrentHour, sinceHourHuman, sizeof(sinceHourHuman));
+            DurationFormat::humanizeDuration(millisUntilNextHour, untilNextHuman, sizeof(untilNextHuman));
+            LOG_DEBUG("Current time is not close to any hour (since hour: %s, until next: %s)", sinceHourHuman, untilNextHuman);
             return false;
         }
     }

--- a/source/src/influxdbclient.cpp
+++ b/source/src/influxdbclient.cpp
@@ -3,6 +3,7 @@
 
 #include "influxdbclient.h"
 #include "taskprofiler.h"
+#include "duration_format.h"
 
 namespace InfluxDbClient
 {
@@ -677,7 +678,9 @@ namespace InfluxDbClient
             snprintf(_status, sizeof(_status), "Failed to send data (HTTP %ld - %s) - Attempt %u", httpCode, httpStatus, _currentSendAttempt);
             _statusTimestampUnix = CustomTime::getUnixTime();
 
-            LOG_WARNING("Failed to send data to InfluxDB (HTTP %ld - %s). Next attempt in %llu ms", httpCode, httpStatus, _nextSendAttemptMillis - millis64());
+            char backoffHuman[24];
+            DurationFormat::humanizeDuration(backoffDelay, backoffHuman, sizeof(backoffHuman));
+            LOG_WARNING("Failed to send data to InfluxDB (HTTP %ld - %s). Next attempt in %s", httpCode, httpStatus, backoffHuman);
         }
         
         _statusTimestampUnix = CustomTime::getUnixTime();

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -2069,7 +2069,9 @@ namespace Mqtt
 
         // Monitor for stability period (here we just wait, rollback will occur automatically on failure)
         while (millis64() - validationStartTime < OTA_VALIDATION_TIMEOUT) {
-            LOG_DEBUG("OTA validation in progress - %llu ms remaining", OTA_VALIDATION_TIMEOUT + validationStartTime - millis64());
+            char otaRemainingHuman[24];
+            DurationFormat::humanizeDuration(OTA_VALIDATION_TIMEOUT + validationStartTime - millis64(), otaRemainingHuman, sizeof(otaRemainingHuman));
+            LOG_DEBUG("OTA validation in progress - %s remaining", otaRemainingHuman);
             delay(OTA_VALIDATION_CHECK_INTERVAL);
         }
 

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -3,6 +3,7 @@
 
 #include "mqtt.h"
 #include "taskprofiler.h"
+#include "duration_format.h"
 
 namespace Mqtt
 {
@@ -1514,7 +1515,9 @@ namespace Mqtt
 
             uint64_t backoffDelay = calculateExponentialBackoff(_mqttConnectionAttempt, MQTT_INITIAL_RETRY_INTERVAL, MQTT_MAX_RETRY_INTERVAL, MQTT_RETRY_MULTIPLIER);
             _nextMqttConnectionAttemptMillis = millis64() + backoffDelay;
-            LOG_WARNING("Failed to connect to MQTT (attempt %lu). Reason: %s. Next attempt in %llu ms", _mqttConnectionAttempt, _getMqttStateReason(currentState), backoffDelay);
+            char backoffHuman[24];
+            DurationFormat::humanizeDuration(backoffDelay, backoffHuman, sizeof(backoffHuman));
+            LOG_WARNING("Failed to connect to MQTT (attempt %lu). Reason: %s. Next attempt in %s", _mqttConnectionAttempt, _getMqttStateReason(currentState), backoffHuman);
 
             return false;
         }

--- a/source/src/utils.cpp
+++ b/source/src/utils.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2025 Jibril Sharafi
 
 #include "utils.h"
+#include "duration_format.h"
 
 #include "taskprofiler.h"
 
@@ -560,7 +561,9 @@ static void _startFailsafeTimer() {
     };
     if (esp_timer_create(&timerArgs, &_failsafeTimer) == ESP_OK) {
         esp_timer_start_once(_failsafeTimer, SYSTEM_RESTART_FAILSAFE_TIMEOUT * 1000ULL); // Convert ms to us
-        LOG_DEBUG("Failsafe restart timer started (%d ms)", SYSTEM_RESTART_FAILSAFE_TIMEOUT);
+        char failsafeHuman[24];
+        DurationFormat::humanizeDuration((uint64_t)SYSTEM_RESTART_FAILSAFE_TIMEOUT, failsafeHuman, sizeof(failsafeHuman));
+        LOG_DEBUG("Failsafe restart timer started (%s)", failsafeHuman);
     } else {
         LOG_WARNING("Failed to create failsafe timer - restart may hang if blocked");
     }
@@ -688,9 +691,11 @@ void printDeviceStatusDynamic()
     populateSystemDynamicInfo(*info);
 
     LOG_DEBUG("--- Dynamic System Info ---");
+    char uptimeHuman[24];
+    DurationFormat::humanizeDuration(info->uptimeMilliseconds, uptimeHuman, sizeof(uptimeHuman));
     LOG_DEBUG(
-        "Uptime: %llu s (%llu ms) | Timestamp: %s | Temperature: %.2f C", 
-        info->uptimeSeconds, info->uptimeMilliseconds, info->currentTimestampIso, info->temperatureCelsius
+        "Uptime: %s | Timestamp: %s | Temperature: %.2f C",
+        uptimeHuman, info->currentTimestampIso, info->temperatureCelsius
     );
 
     LOG_DEBUG("Heap: %lu total, %lu free (%.1f%%), %lu used (%.1f%%), %lu min free, %lu max alloc",  

--- a/source/test/test_duration_format/test_duration_format.cpp
+++ b/source/test/test_duration_format/test_duration_format.cpp
@@ -45,34 +45,34 @@ void test_999_ms(void) {
 // Seconds range  (1000 ms .. 59999 ms)
 // ============================================================================
 
-void test_1000_ms_is_1_0_s(void) {
+void test_1000_ms_is_1_s(void) {
     char buf[32];
     humanizeDuration(1000, buf, sizeof(buf));
-    TEST_ASSERT_EQUAL_STRING("1.0 s", buf);
+    TEST_ASSERT_EQUAL_STRING("1 s", buf);
 }
 
-void test_1500_ms_is_1_5_s(void) {
+void test_1500_ms_is_1_s(void) {
     char buf[32];
     humanizeDuration(1500, buf, sizeof(buf));
-    TEST_ASSERT_EQUAL_STRING("1.5 s", buf);
+    TEST_ASSERT_EQUAL_STRING("1 s", buf);
 }
 
-void test_2400_ms_is_2_4_s(void) {
+void test_2400_ms_is_2_s(void) {
     char buf[32];
     humanizeDuration(2400, buf, sizeof(buf));
-    TEST_ASSERT_EQUAL_STRING("2.4 s", buf);
+    TEST_ASSERT_EQUAL_STRING("2 s", buf);
 }
 
-void test_10000_ms_is_10_0_s(void) {
+void test_10000_ms_is_10_s(void) {
     char buf[32];
     humanizeDuration(10000, buf, sizeof(buf));
-    TEST_ASSERT_EQUAL_STRING("10.0 s", buf);
+    TEST_ASSERT_EQUAL_STRING("10 s", buf);
 }
 
-void test_59999_ms_is_60_0_s(void) {
+void test_59999_ms_is_59_s(void) {
     char buf[32];
     humanizeDuration(59999, buf, sizeof(buf));
-    TEST_ASSERT_EQUAL_STRING("60.0 s", buf);
+    TEST_ASSERT_EQUAL_STRING("59 s", buf);
 }
 
 // ============================================================================
@@ -179,11 +179,11 @@ int main(int argc, char **argv) {
     RUN_TEST(test_850_ms);
     RUN_TEST(test_999_ms);
 
-    RUN_TEST(test_1000_ms_is_1_0_s);
-    RUN_TEST(test_1500_ms_is_1_5_s);
-    RUN_TEST(test_2400_ms_is_2_4_s);
-    RUN_TEST(test_10000_ms_is_10_0_s);
-    RUN_TEST(test_59999_ms_is_60_0_s);
+    RUN_TEST(test_1000_ms_is_1_s);
+    RUN_TEST(test_1500_ms_is_1_s);
+    RUN_TEST(test_2400_ms_is_2_s);
+    RUN_TEST(test_10000_ms_is_10_s);
+    RUN_TEST(test_59999_ms_is_59_s);
 
     RUN_TEST(test_60000_ms_is_1_min);
     RUN_TEST(test_3_min);

--- a/source/test/test_duration_format/test_duration_format.cpp
+++ b/source/test/test_duration_format/test_duration_format.cpp
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+//
+// Host unit tests for DurationFormat::humanizeDuration. Run with:
+//   pio test -e native          (from WSL - Windows native toolchain is unreliable)
+
+#include <unity.h>
+#include <cstring>
+#include "duration_format.h"
+
+using namespace DurationFormat;
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ============================================================================
+// Milliseconds range  (< 1000)
+// ============================================================================
+
+void test_zero_ms(void) {
+    char buf[32];
+    humanizeDuration(0, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("0 ms", buf);
+}
+
+void test_1_ms(void) {
+    char buf[32];
+    humanizeDuration(1, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("1 ms", buf);
+}
+
+void test_850_ms(void) {
+    char buf[32];
+    humanizeDuration(850, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("850 ms", buf);
+}
+
+void test_999_ms(void) {
+    char buf[32];
+    humanizeDuration(999, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("999 ms", buf);
+}
+
+// ============================================================================
+// Seconds range  (1000 ms .. 59999 ms)
+// ============================================================================
+
+void test_1000_ms_is_1_0_s(void) {
+    char buf[32];
+    humanizeDuration(1000, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("1.0 s", buf);
+}
+
+void test_1500_ms_is_1_5_s(void) {
+    char buf[32];
+    humanizeDuration(1500, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("1.5 s", buf);
+}
+
+void test_2400_ms_is_2_4_s(void) {
+    char buf[32];
+    humanizeDuration(2400, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("2.4 s", buf);
+}
+
+void test_10000_ms_is_10_0_s(void) {
+    char buf[32];
+    humanizeDuration(10000, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("10.0 s", buf);
+}
+
+void test_59999_ms_is_60_0_s(void) {
+    char buf[32];
+    humanizeDuration(59999, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("60.0 s", buf);
+}
+
+// ============================================================================
+// Minutes range  (60000 ms .. 3599999 ms)
+// ============================================================================
+
+void test_60000_ms_is_1_min(void) {
+    char buf[32];
+    humanizeDuration(60000, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("1 min", buf);
+}
+
+void test_3_min(void) {
+    char buf[32];
+    humanizeDuration(3 * 60000ULL, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("3 min", buf);
+}
+
+void test_59_min(void) {
+    char buf[32];
+    humanizeDuration(59 * 60000ULL, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("59 min", buf);
+}
+
+void test_3599999_ms_is_59_min(void) {
+    char buf[32];
+    humanizeDuration(3599999, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("59 min", buf);
+}
+
+// ============================================================================
+// Hours range  (3600000 ms .. 86399999 ms)
+// ============================================================================
+
+void test_3600000_ms_is_1_h(void) {
+    char buf[32];
+    humanizeDuration(3600000, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("1 h", buf);
+}
+
+void test_5_h(void) {
+    char buf[32];
+    humanizeDuration(5 * 3600000ULL, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("5 h", buf);
+}
+
+void test_23_h(void) {
+    char buf[32];
+    humanizeDuration(23 * 3600000ULL, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("23 h", buf);
+}
+
+void test_86399999_ms_is_23_h(void) {
+    char buf[32];
+    humanizeDuration(86399999, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("23 h", buf);
+}
+
+// ============================================================================
+// Days range  (>= 86400000 ms)
+// ============================================================================
+
+void test_86400000_ms_is_1_d(void) {
+    char buf[32];
+    humanizeDuration(86400000, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("1 d", buf);
+}
+
+void test_2_d(void) {
+    char buf[32];
+    humanizeDuration(2 * 86400000ULL, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("2 d", buf);
+}
+
+void test_large_duration(void) {
+    char buf[32];
+    humanizeDuration(30 * 86400000ULL, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("30 d", buf);
+}
+
+// ============================================================================
+// Safety: null/zero-size buffer
+// ============================================================================
+
+void test_null_buffer_is_safe(void) {
+    humanizeDuration(1000, nullptr, 32);  // must not crash
+}
+
+void test_zero_size_is_safe(void) {
+    char buf[32] = "sentinel";
+    humanizeDuration(1000, buf, 0);  // must not write anything
+    TEST_ASSERT_EQUAL_STRING("sentinel", buf);
+}
+
+// ============================================================================
+// Runner
+// ============================================================================
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_zero_ms);
+    RUN_TEST(test_1_ms);
+    RUN_TEST(test_850_ms);
+    RUN_TEST(test_999_ms);
+
+    RUN_TEST(test_1000_ms_is_1_0_s);
+    RUN_TEST(test_1500_ms_is_1_5_s);
+    RUN_TEST(test_2400_ms_is_2_4_s);
+    RUN_TEST(test_10000_ms_is_10_0_s);
+    RUN_TEST(test_59999_ms_is_60_0_s);
+
+    RUN_TEST(test_60000_ms_is_1_min);
+    RUN_TEST(test_3_min);
+    RUN_TEST(test_59_min);
+    RUN_TEST(test_3599999_ms_is_59_min);
+
+    RUN_TEST(test_3600000_ms_is_1_h);
+    RUN_TEST(test_5_h);
+    RUN_TEST(test_23_h);
+    RUN_TEST(test_86399999_ms_is_23_h);
+
+    RUN_TEST(test_86400000_ms_is_1_d);
+    RUN_TEST(test_2_d);
+    RUN_TEST(test_large_duration);
+
+    RUN_TEST(test_null_buffer_is_safe);
+    RUN_TEST(test_zero_size_is_safe);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

- Adds `DurationFormat::humanizeDuration(uint64_t ms, char *out, size_t outSize)` in `lib/duration_format/` - pure C++, no Arduino/FreeRTOS deps, compiles on host
- 22 Unity tests covering all range boundaries (ms/s/min/h/d), threshold edges, and null/zero-size buffer safety
- Migrates all raw `%llu ms` / `%lu ms` strings across the entire codebase to humanized output (zero raw-ms strings remain in src/)

## Format

| Input | Output |
|-------|--------|
| < 1 s | `850 ms` |
| 1 s to < 60 s | `2 s` |
| 60 s to < 1 h | `3 min` |
| 1 h to < 24 h | `5 h` |
| >= 24 h | `2 d` |

## Test plan

- [x] `pio test -e native --filter test_duration_format` - 22/22 passed
- [x] Hardware verify: trigger a custom MQTT connection failure and confirm status box shows e.g. "Retrying in 5 s" instead of "Retrying in 5000 ms"

Closes #179