### PR TITLE
fix(integrations): align status display, fix issue detection, and UX polish

### DIFF
--- a/source/html/configuration.html
+++ b/source/html/configuration.html
@@ -648,6 +648,7 @@
         let _deviceId = '';
         let _devBuild = false;
         let _cloudEnabled = false;
+        let _hasSecrets = false;
 
         async function loadDeviceInfo() {
             try {
@@ -665,7 +666,12 @@
             if (!_deviceId) { banner.style.display = 'none'; return; }
             banner.style.display = 'block';
             const link = document.getElementById('portalLink');
-            if (_cloudEnabled) {
+            if (!_hasSecrets) {
+                link.href = '#';
+                link.classList.add('portal-cta-disabled');
+                link.textContent = '🔒 Add to EnergyMe Portal ›';
+                document.getElementById('portalMsg').textContent = 'Cloud services are not available on this device (community build - no provisioning secrets).';
+            } else if (_cloudEnabled) {
                 const base = _devBuild
                     ? 'https://portal-dev.energyme.net'
                     : 'https://portal.energyme.net';
@@ -943,6 +949,8 @@
         function checkHasSecrets() {
             energyApi.getSystemSecrets()
                 .then(response => {
+                    _hasSecrets = response.hasSecrets;
+                    updatePortalLink();
                     // If no secrets available, disable cloud services option
                     if (!response.hasSecrets) {
                         var cloudServicesCheckbox = document.getElementById("cloudServices");

--- a/source/html/configuration.html
+++ b/source/html/configuration.html
@@ -649,6 +649,7 @@
         let _devBuild = false;
         let _cloudEnabled = false;
         let _hasSecrets = false;
+        let _secretsChecked = false;
 
         async function loadDeviceInfo() {
             try {
@@ -663,7 +664,7 @@
 
         function updatePortalLink() {
             const banner = document.getElementById('portalBanner');
-            if (!_deviceId) { banner.style.display = 'none'; return; }
+            if (!_deviceId || !_secretsChecked) { banner.style.display = 'none'; return; }
             banner.style.display = 'block';
             const link = document.getElementById('portalLink');
             if (!_hasSecrets) {
@@ -950,6 +951,7 @@
             energyApi.getSystemSecrets()
                 .then(response => {
                     _hasSecrets = response.hasSecrets;
+                    _secretsChecked = true;
                     updatePortalLink();
                     // If no secrets available, disable cloud services option
                     if (!response.hasSecrets) {

--- a/source/html/integrations.html
+++ b/source/html/integrations.html
@@ -20,7 +20,7 @@
     <style>
         /* Mobile-specific styles */
         @media screen and (max-width: 768px) {
-            #statusContainer,
+            #customMqttStatusContainer,
             #influxDbStatusContainer {
                 flex-direction: column;
                 align-items: flex-start;
@@ -231,9 +231,7 @@
             <ol style="margin-left: 20px;">
                 <li>Install the integration via <a href="https://hacs.xyz/" target="_blank">HACS</a> (recommended) or manually.
                     <ul style="margin-top: 8px;">
-                        <li><strong>HACS:</strong> HACS &rarr; Integrations &rarr; ⋮ &rarr; Custom repositories &rarr;
-                            add <code>https://github.com/jibrilsharafi/homeassistant-energyme</code> as an Integration,
-                            then install "EnergyMe".</li>
+                        <li><strong>HACS:</strong> HACS &rarr; Integrations &rarr; search for "EnergyMe" &rarr; install.</li>
                         <li><strong>Manual:</strong> download the latest release, extract the <code>energyme</code> folder
                             into your <code>custom_components</code> directory.</li>
                     </ul>
@@ -440,6 +438,16 @@
         var influxDbAutoReloadInterval = null;
         const AUTO_RELOAD_INTERVAL_MS = 5000;
 
+        function timeAgo(isoString) {
+            if (!isoString) return "";
+            const diffMs = Date.now() - new Date(isoString).getTime();
+            if (isNaN(diffMs) || diffMs < 0) return "";
+            if (diffMs < 60000) return " (" + Math.floor(diffMs / 1000) + " s ago)";
+            if (diffMs < 3600000) return " (" + Math.floor(diffMs / 60000) + " min ago)";
+            if (diffMs < 86400000) return " (" + Math.floor(diffMs / 3600000) + " h ago)";
+            return " (" + Math.floor(diffMs / 86400000) + " d ago)";
+        }
+
         // ============================================================================
         // CUSTOM MQTT FUNCTIONS
         // ============================================================================
@@ -527,7 +535,7 @@
             }
 
             statusElement.textContent = status || "N/A";
-            timestampElement.textContent = timestamp || "N/A";
+            timestampElement.textContent = (timestamp || "N/A") + timeAgo(timestamp);
 
             if (status === "Connected") {
                 timestampContainer.style.display = "none";
@@ -611,7 +619,7 @@
 
             // If enabled, proceed with normal status display
             statusElement.textContent = status || "N/A";
-            timestampElement.textContent = timestamp || "N/A";
+            timestampElement.textContent = (timestamp || "N/A") + timeAgo(timestamp);
 
             // Show/hide timestamp based on connection status
             if (status === "Data sent successfully") {

--- a/source/html/integrations.html
+++ b/source/html/integrations.html
@@ -439,13 +439,13 @@
         const AUTO_RELOAD_INTERVAL_MS = 5000;
 
         function timeAgo(isoString) {
-            if (!isoString) return "";
+            if (!isoString) return "N/A";
             const diffMs = Date.now() - new Date(isoString).getTime();
-            if (isNaN(diffMs) || diffMs < 0) return "";
-            if (diffMs < 60000) return " (" + Math.floor(diffMs / 1000) + " s ago)";
-            if (diffMs < 3600000) return " (" + Math.floor(diffMs / 60000) + " min ago)";
-            if (diffMs < 86400000) return " (" + Math.floor(diffMs / 3600000) + " h ago)";
-            return " (" + Math.floor(diffMs / 86400000) + " d ago)";
+            if (isNaN(diffMs) || diffMs < 0) return isoString;
+            if (diffMs < 60000) return Math.floor(diffMs / 1000) + " s ago";
+            if (diffMs < 3600000) return Math.floor(diffMs / 60000) + " min ago";
+            if (diffMs < 86400000) return Math.floor(diffMs / 3600000) + " h ago";
+            return Math.floor(diffMs / 86400000) + " d ago";
         }
 
         // ============================================================================
@@ -535,7 +535,7 @@
             }
 
             statusElement.textContent = status || "N/A";
-            timestampElement.textContent = (timestamp || "N/A") + timeAgo(timestamp);
+            timestampElement.textContent = timeAgo(timestamp);
 
             if (status === "Connected") {
                 timestampContainer.style.display = "none";
@@ -619,7 +619,7 @@
 
             // If enabled, proceed with normal status display
             statusElement.textContent = status || "N/A";
-            timestampElement.textContent = (timestamp || "N/A") + timeAgo(timestamp);
+            timestampElement.textContent = timeAgo(timestamp);
 
             // Show/hide timestamp based on connection status
             if (status === "Data sent successfully") {

--- a/source/html/integrations.html
+++ b/source/html/integrations.html
@@ -131,12 +131,12 @@
         </div>
         <div id="customMqttStatus"
             style="margin-top: 15px; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background-color: #f9f9f9;">
-            <div id="statusContainer" style="display: flex; align-items: center;">
-                <span id="statusIcon" class="status-icon" style="font-size: 1.5em; margin-right: 10px;">⚪</span>
+            <div id="customMqttStatusContainer" style="display: flex; align-items: center;">
+                <span id="customMqttStatusIcon" class="status-icon" style="font-size: 1.5em; margin-right: 10px;">⚪</span>
                 <div>
-                    <strong>Status: </strong><span id="lastConnectionStatus">Loading...</span><br>
-                    <span id="timestampContainer"><strong>Last Attempt: </strong><span
-                            id="lastConnectionAttemptTimestamp">Loading...</span></span>
+                    <strong>Status: </strong><span id="customMqttLastConnectionStatus">Loading...</span><br>
+                    <span id="customMqttTimestampContainer"><strong>Last Attempt: </strong><span
+                            id="customMqttLastConnectionAttemptTimestamp">Loading...</span></span>
                 </div>
             </div>
         </div>
@@ -508,46 +508,43 @@
         }
 
         function updateStatusDisplay(status, timestamp, isEnabled) {
-            const statusElement = document.getElementById("lastConnectionStatus");
-            const timestampElement = document.getElementById("lastConnectionAttemptTimestamp");
-            const timestampContainer = document.getElementById("timestampContainer");
-            const statusIcon = document.getElementById("statusIcon");
-            const statusContainer = document.getElementById("statusContainer");
+            const statusElement = document.getElementById("customMqttLastConnectionStatus");
+            const timestampElement = document.getElementById("customMqttLastConnectionAttemptTimestamp");
+            const timestampContainer = document.getElementById("customMqttTimestampContainer");
+            const statusIcon = document.getElementById("customMqttStatusIcon");
+            const statusContainer = document.getElementById("customMqttStatusContainer");
 
             // Reset styles
             statusContainer.style.color = "";
             statusElement.style.fontWeight = "";
 
-            // If MQTT is disabled, show disabled status
             if (!isEnabled) {
                 statusElement.textContent = "Disabled";
                 timestampContainer.style.display = "none";
-                statusIcon.innerHTML = "⚫"; // Black circle for disabled
-                statusElement.style.color = "#757575"; // Gray color
+                statusIcon.innerHTML = "⚫";
+                statusElement.style.color = "#757575";
                 return;
             }
 
-            // If enabled, proceed with normal status display
             statusElement.textContent = status || "N/A";
             timestampElement.textContent = timestamp || "N/A";
 
-            // Show/hide timestamp based on connection status
             if (status === "Connected") {
                 timestampContainer.style.display = "none";
-                statusIcon.innerHTML = "🟢"; // Green circle for connected
-                statusElement.style.color = "#2e7d32"; // Dark green
+                statusIcon.innerHTML = "🟢";
+                statusElement.style.color = "#2e7d32";
                 statusElement.style.fontWeight = "bold";
-            } else if (status === "Disconnected") {
+            } else if (status && status.toLowerCase().includes("failed")) {
                 timestampContainer.style.display = "block";
-                statusIcon.innerHTML = "🔴"; // Red circle for disconnected
-                statusElement.style.color = "#c62828"; // Dark red
-            } else if (status && status.startsWith("Error")) {
+                statusIcon.innerHTML = "🔴";
+                statusElement.style.color = "#c62828";
+            } else if (status && status.includes("Error")) {
                 timestampContainer.style.display = "block";
-                statusIcon.innerHTML = "⚠️"; // Warning for errors
-                statusElement.style.color = "#e65100"; // Orange
+                statusIcon.innerHTML = "⚠️";
+                statusElement.style.color = "#e65100";
             } else {
                 timestampContainer.style.display = "block";
-                statusIcon.innerHTML = "⚪"; // Default neutral circle
+                statusIcon.innerHTML = "⚪";
             }
         }
 
@@ -559,9 +556,6 @@
             try {
                 showStatus('Setting MQTT configuration...', 'info');
 
-                var currentStatus = customMqttConfig ? customMqttConfig.lastConnectionStatus : "Unknown";
-                var currentTimestamp = customMqttConfig ? customMqttConfig.lastConnectionAttemptTimestamp : "";
-
                 var newCustomMqttConfig = {
                     "enabled": document.getElementById("customMqttEnabled").checked,
                     "server": document.getElementById("customMqttServer").value,
@@ -571,9 +565,7 @@
                     "frequency": parseInt(document.getElementById("customMqttFrequency").value),
                     "useCredentials": document.getElementById("customMqttUseCredentials").checked,
                     "username": document.getElementById("customMqttUsername").value,
-                    "password": document.getElementById("customMqttPassword").value,
-                    "lastConnectionStatus": currentStatus,
-                    "lastConnectionAttemptTimestamp": currentTimestamp
+                    "password": document.getElementById("customMqttPassword").value
                 };
 
                 await energyApi.setCustomMqttConfig(newCustomMqttConfig);
@@ -622,7 +614,7 @@
             timestampElement.textContent = timestamp || "N/A";
 
             // Show/hide timestamp based on connection status
-            if (status === "Upload successful" || status === "Connection successful" || status === "Credentials valid" || status == "Data sent successfully") {
+            if (status === "Data sent successfully") {
                 timestampContainer.style.display = "none"; // Hide timestamp for successful connections
                 statusIcon.innerHTML = "🟢"; // Green circle for successful
                 statusElement.style.color = "#2e7d32"; // Dark green
@@ -731,9 +723,6 @@
             try {
                 showStatus('Setting InfluxDB configuration...', 'info');
 
-                var currentStatus = influxDbConfig ? influxDbConfig.lastConnectionStatus : "Unknown";
-                var currentTimestamp = influxDbConfig ? influxDbConfig.lastConnectionAttemptTimestamp : "";
-
                 var newInfluxDbConfig = {
                     "enabled": document.getElementById("influxDbEnabled").checked,
                     "server": document.getElementById("influxDbServer").value,
@@ -747,9 +736,7 @@
                     "token": document.getElementById("influxDbToken").value,
                     "measurement": document.getElementById("influxDbMeasurement").value,
                     "frequency": Math.max(1, Math.min(3600, parseInt(document.getElementById("influxDbFrequency").value))),
-                    "useSsl": document.getElementById("influxDbUseSsl").checked,
-                    "lastConnectionStatus": currentStatus,
-                    "lastConnectionAttemptTimestamp": currentTimestamp
+                    "useSsl": document.getElementById("influxDbUseSsl").checked
                 };
 
                 await energyApi.setInfluxDbConfig(newInfluxDbConfig);

--- a/source/include/issueregistry.h
+++ b/source/include/issueregistry.h
@@ -32,6 +32,9 @@
 // so they scale with the tick: the "over X s" messages derive from streak * tick.
 #define ISSUE_STREAK_TO_RAISE 12              // ~1 min of sustained bad evidence
 #define ISSUE_CONNECTIVITY_STREAK_TO_RAISE 24 // ~2 min: rides out boot/reconnect blips
+// InfluxDB uses sparse evidence (one window per attempt due to exponential backoff):
+// streak counts failed attempts, not 5s ticks. 3 consecutive failures = issue raised.
+#define ISSUE_INFLUXDB_STREAK_TO_RAISE 3
 
 // Per-code thresholds
 #define ISSUE_MISMATCH_MIN_EVIDENCE_READS 4

--- a/source/lib/duration_format/duration_format.h
+++ b/source/lib/duration_format/duration_format.h
@@ -15,8 +15,15 @@
 //   <24 h   ->  "5 h"
 //   >=24 h  ->  "2 d"
 //
-// Output is ASCII-only and null-terminated. If `outSize` is 0 the call
-// is a no-op. A minimum buffer of 16 bytes covers all representable values.
+// Output is ASCII-only and null-terminated. If `outSize` is 0 the call is a no-op.
+// Use DURATION_FORMAT_BUFFER_SIZE for the local char buffer at every call site.
+
+// "999 ms" is the widest sub-day output (6 chars + null = 7 bytes). The days branch
+// is unbounded for huge uint64_t values but no real firmware duration exceeds a few
+// hundred days ("999 d" = 6 bytes). 12 bytes gives comfortable headroom over the
+// 7-byte worst case without inflating every call-site buffer to 24.
+#define DURATION_FORMAT_BUFFER_SIZE 12
+
 namespace DurationFormat {
 
 void humanizeDuration(uint64_t ms, char *out, size_t outSize);

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -1982,7 +1982,7 @@ namespace Ade7953
             
             // Safety timeout
             if (currentMicros - _captureStartMicros >= WAVEFORM_CAPTURE_MAX_DURATION_MICROS) {
-                char captureDurHuman[24];
+                char captureDurHuman[DURATION_FORMAT_BUFFER_SIZE];
                 DurationFormat::humanizeDuration((currentMicros - _captureStartMicros) / 1000, captureDurHuman, sizeof(captureDurHuman));
                 LOG_WARNING("Waveform capture timeout after %s, captured %u samples with %u zero crossings",
                     captureDurHuman, _captureSampleCount, zeroCrossingCount);
@@ -2038,7 +2038,7 @@ namespace Ade7953
         uint64_t totalDurationMs = (micros64() - _captureStartMicros) / 1000;
         
         _captureState = CaptureState::COMPLETE;
-        char captureDurHuman[24];
+        char captureDurHuman[DURATION_FORMAT_BUFFER_SIZE];
         DurationFormat::humanizeDuration(totalDurationMs, captureDurHuman, sizeof(captureDurHuman));
         LOG_INFO("Waveform capture complete for channel %u: %u samples in %s with %u zero crossings",
             _captureChannel, _captureSampleCount, captureDurHuman, zeroCrossingCount);
@@ -2373,7 +2373,7 @@ namespace Ade7953
 
             // Calculate milliseconds until next hour using CustomTime
             uint64_t msUntilNextHour = CustomTime::getMillisecondsUntilNextHour();
-            char msUntilNextHourHuman[24];
+            char msUntilNextHourHuman[DURATION_FORMAT_BUFFER_SIZE];
             DurationFormat::humanizeDuration(msUntilNextHour, msUntilNextHourHuman, sizeof(msUntilNextHourHuman));
             LOG_DEBUG("Waiting for %s until next hour to save the hourly energy", msUntilNextHourHuman);
 
@@ -4265,7 +4265,7 @@ namespace Ade7953
         
         setSampleTime(sampleTime);
 
-        char sampleTimeHuman[24];
+        char sampleTimeHuman[DURATION_FORMAT_BUFFER_SIZE];
         DurationFormat::humanizeDuration(sampleTime, sampleTimeHuman, sizeof(sampleTimeHuman));
         LOG_DEBUG("Loaded sample time %s from preferences", sampleTimeHuman);
     }
@@ -4279,7 +4279,7 @@ namespace Ade7953
         preferences.putULong64(CONFIG_SAMPLE_TIME_KEY, _sampleTime);
         preferences.end();
 
-        char sampleTimeHuman[24];
+        char sampleTimeHuman[DURATION_FORMAT_BUFFER_SIZE];
         DurationFormat::humanizeDuration(_sampleTime, sampleTimeHuman, sizeof(sampleTimeHuman));
         LOG_DEBUG("Saved sample time %s to preferences", sampleTimeHuman);
     }
@@ -4298,7 +4298,7 @@ namespace Ade7953
         uint64_t calculatedLinecyc = _sampleTime * _lineFrequency * 2 / 1000;
         _setLinecyc((uint32_t)calculatedLinecyc);
 
-        char sampleTimeHuman[24];
+        char sampleTimeHuman[DURATION_FORMAT_BUFFER_SIZE];
         DurationFormat::humanizeDuration(_sampleTime, sampleTimeHuman, sizeof(sampleTimeHuman));
         LOG_DEBUG("Successfully updated sample time to %s (%llu line cycles) with grid frequency %u Hz", sampleTimeHuman, calculatedLinecyc, _lineFrequency);
     }
@@ -4375,7 +4375,7 @@ namespace Ade7953
     void _checkForTooManyFailures() {
         
         if (millis64() - _firstFailureTime > ADE7953_FAILURE_RESET_TIMEOUT_MS && _failureCount > 0) {
-            char failureDurHuman[24];
+            char failureDurHuman[DURATION_FORMAT_BUFFER_SIZE];
             DurationFormat::humanizeDuration(millis64() - _firstFailureTime, failureDurHuman, sizeof(failureDurHuman));
             LOG_DEBUG("Failure timeout exceeded (%s). Resetting failure count (reached %d)", failureDurHuman, _failureCount);
             
@@ -4411,7 +4411,7 @@ namespace Ade7953
 
     void _checkForTooManyCriticalFailures() {
         if (millis64() - _firstCriticalFailureTime > ADE7953_CRITICAL_FAILURE_RESET_TIMEOUT_MS && _criticalFailureCount > 0) {
-            char critFailDurHuman[24];
+            char critFailDurHuman[DURATION_FORMAT_BUFFER_SIZE];
             DurationFormat::humanizeDuration(millis64() - _firstCriticalFailureTime, critFailDurHuman, sizeof(critFailDurHuman));
             LOG_DEBUG("Critical failure timeout exceeded (%s). Resetting critical failure count (reached %lu)",
                 critFailDurHuman, _criticalFailureCount);
@@ -4638,7 +4638,7 @@ namespace Ade7953
         if (starvedChannel != INVALID_CHANNEL) {
             // Can happen with high-power channels alongside static 0 W ones, so it is
             // not an error per se (hence DEBUG level).
-            char starvedGapHuman[24];
+            char starvedGapHuman[DURATION_FORMAT_BUFFER_SIZE];
             DurationFormat::humanizeDuration(starvedGap, starvedGapHuman, sizeof(starvedGapHuman));
             LOG_DEBUG(
                 "%s (%u): scheduler starvation, %s since last read; force-picking",

--- a/source/src/buttonhandler.cpp
+++ b/source/src/buttonhandler.cpp
@@ -143,7 +143,7 @@ namespace ButtonHandler
                 {
                     // Button was released - process the press
                     uint64_t pressDuration = millis64() - _buttonPressStartTime;
-                    char pressDurationHuman[24];
+                    char pressDurationHuman[DURATION_FORMAT_BUFFER_SIZE];
                     DurationFormat::humanizeDuration(pressDuration, pressDurationHuman, sizeof(pressDurationHuman));
                     LOG_DEBUG("Button released after %s", pressDurationHuman);
 
@@ -200,7 +200,7 @@ namespace ButtonHandler
         else
         {
             _currentPressType = ButtonPressType::NONE;
-            char pressDurationHuman[24];
+            char pressDurationHuman[DURATION_FORMAT_BUFFER_SIZE];
             DurationFormat::humanizeDuration(pressDuration, pressDurationHuman, sizeof(pressDurationHuman));
             LOG_DEBUG("Button press duration %s - no action", pressDurationHuman);
         }

--- a/source/src/crashmonitor.cpp
+++ b/source/src/crashmonitor.cpp
@@ -113,7 +113,7 @@ namespace CrashMonitor
         
         if (isQuickRestart) {
             _quickRestartCount++;
-            char timeSinceLastBootHuman[24], thresholdHuman[24];
+            char timeSinceLastBootHuman[DURATION_FORMAT_BUFFER_SIZE], thresholdHuman[DURATION_FORMAT_BUFFER_SIZE];
             DurationFormat::humanizeDuration(timeSinceLastBoot, timeSinceLastBootHuman, sizeof(timeSinceLastBootHuman));
             DurationFormat::humanizeDuration(QUICK_RESTART_THRESHOLD, thresholdHuman, sizeof(thresholdHuman));
             LOG_WARNING("Quick restart detected (#%lu): only %s since last boot (threshold: %s)",
@@ -130,7 +130,7 @@ namespace CrashMonitor
         } else {
             // Not a quick restart - reset quick restart counter (but keep crash/reset counters)
             if (_quickRestartCount > 0) {
-                char timeSinceLastBootHuman[24];
+                char timeSinceLastBootHuman[DURATION_FORMAT_BUFFER_SIZE];
                 DurationFormat::humanizeDuration(timeSinceLastBoot, timeSinceLastBootHuman, sizeof(timeSinceLastBootHuman));
                 LOG_DEBUG("Stable boot detected (%s since last boot), resetting quick restart counter (was %lu)",
                     timeSinceLastBootHuman, _quickRestartCount);
@@ -141,7 +141,7 @@ namespace CrashMonitor
             
             // Exit safe mode if we had a stable restart (user fixed the issue)
             if (_safeModeActive && timeSinceLastBoot >= SAFE_MODE_MIN_UPTIME) {
-                char timeSinceLastBootHuman[24];
+                char timeSinceLastBootHuman[DURATION_FORMAT_BUFFER_SIZE];
                 DurationFormat::humanizeDuration(timeSinceLastBoot, timeSinceLastBootHuman, sizeof(timeSinceLastBootHuman));
                 LOG_INFO("Exiting safe mode due to stable restart (%s uptime)", timeSinceLastBootHuman);
                 _safeModeActive = false;

--- a/source/src/custommqtt.cpp
+++ b/source/src/custommqtt.cpp
@@ -473,7 +473,7 @@ namespace CustomMqtt
             uint64_t _backoffDelay = calculateExponentialBackoff(_currentMqttConnectionAttempt, MQTT_CUSTOM_INITIAL_RECONNECT_INTERVAL, MQTT_CUSTOM_MAX_RECONNECT_INTERVAL, MQTT_CUSTOM_RECONNECT_MULTIPLIER);
             _nextMqttConnectionAttemptMillis = millis64() + _backoffDelay;
 
-            char _backoffHuman[24];
+            char _backoffHuman[DURATION_FORMAT_BUFFER_SIZE];
             DurationFormat::humanizeDuration(_backoffDelay, _backoffHuman, sizeof(_backoffHuman));
             snprintf(_status, sizeof(_status), "Connection failed: %s (Attempt %lu). Retrying in %s", _reason, _currentMqttConnectionAttempt, _backoffHuman);
             _statusTimestampUnix = CustomTime::getUnixTime();

--- a/source/src/customserver.cpp
+++ b/source/src/customserver.cpp
@@ -2015,7 +2015,7 @@ namespace CustomServer
 
                 if (Ade7953::setSampleTime(sampleTime))
                 {
-                    char sampleTimeHuman[24];
+                    char sampleTimeHuman[DURATION_FORMAT_BUFFER_SIZE];
                     DurationFormat::humanizeDuration(sampleTime, sampleTimeHuman, sizeof(sampleTimeHuman));
                     LOG_INFO("ADE7953 sample time updated to %s via API", sampleTimeHuman);
                     _sendSuccessResponse(request, "ADE7953 sample time updated successfully");

--- a/source/src/customtime.cpp
+++ b/source/src/customtime.cpp
@@ -40,7 +40,7 @@ namespace CustomTime {
         uint64_t millisUntilNextHour = 3600000ULL - millisSinceCurrentHour;
 
         // Check if we're close to either the current hour (just passed) or the next hour (approaching)
-        char toleranceHuman[24], sinceHourHuman[24], untilNextHuman[24];
+        char toleranceHuman[DURATION_FORMAT_BUFFER_SIZE], sinceHourHuman[DURATION_FORMAT_BUFFER_SIZE], untilNextHuman[DURATION_FORMAT_BUFFER_SIZE];
         DurationFormat::humanizeDuration(toleranceMillis, toleranceHuman, sizeof(toleranceHuman));
         if (millisSinceCurrentHour <= toleranceMillis) {
             LOG_DEBUG("Current time is close to the current hour (within %s since hour start)", toleranceHuman);

--- a/source/src/influxdbclient.cpp
+++ b/source/src/influxdbclient.cpp
@@ -677,7 +677,7 @@ namespace InfluxDbClient
 
             char backoffHuman[24];
             DurationFormat::humanizeDuration(backoffDelay, backoffHuman, sizeof(backoffHuman));
-            snprintf(_status, sizeof(_status), "Failed to send data (HTTP %ld - %s) - Attempt %u. Retrying in %s", httpCode, httpStatus, _currentSendAttempt, backoffHuman);
+            snprintf(_status, sizeof(_status), "Failed to send data (HTTP %ld - %s) (Attempt %u). Retrying in %s", httpCode, httpStatus, _currentSendAttempt, backoffHuman);
             _statusTimestampUnix = CustomTime::getUnixTime();
 
             LOG_WARNING("Failed to send data to InfluxDB (HTTP %ld - %s). Next attempt in %s", httpCode, httpStatus, backoffHuman);

--- a/source/src/influxdbclient.cpp
+++ b/source/src/influxdbclient.cpp
@@ -677,7 +677,7 @@ namespace InfluxDbClient
 
             char backoffHuman[24];
             DurationFormat::humanizeDuration(backoffDelay, backoffHuman, sizeof(backoffHuman));
-            snprintf(_status, sizeof(_status), "Failed to send data (HTTP %ld - %s) (Attempt %u). Retrying in %s", httpCode, httpStatus, _currentSendAttempt, backoffHuman);
+            snprintf(_status, sizeof(_status), "Failed to send data: HTTP %ld - %s (Attempt %u). Retrying in %s", httpCode, httpStatus, _currentSendAttempt, backoffHuman);
             _statusTimestampUnix = CustomTime::getUnixTime();
 
             LOG_WARNING("Failed to send data to InfluxDB (HTTP %ld - %s). Next attempt in %s", httpCode, httpStatus, backoffHuman);

--- a/source/src/influxdbclient.cpp
+++ b/source/src/influxdbclient.cpp
@@ -675,7 +675,7 @@ namespace InfluxDbClient
             uint64_t backoffDelay = calculateExponentialBackoff(_currentSendAttempt, INFLUXDB_INITIAL_RETRY_INTERVAL, INFLUXDB_MAX_RETRY_INTERVAL, INFLUXDB_RETRY_MULTIPLIER);
             _nextSendAttemptMillis = millis64() + backoffDelay;
 
-            char backoffHuman[24];
+            char backoffHuman[DURATION_FORMAT_BUFFER_SIZE];
             DurationFormat::humanizeDuration(backoffDelay, backoffHuman, sizeof(backoffHuman));
             snprintf(_status, sizeof(_status), "Failed to send data: HTTP %ld - %s (Attempt %u). Retrying in %s", httpCode, httpStatus, _currentSendAttempt, backoffHuman);
             _statusTimestampUnix = CustomTime::getUnixTime();

--- a/source/src/influxdbclient.cpp
+++ b/source/src/influxdbclient.cpp
@@ -675,11 +675,11 @@ namespace InfluxDbClient
             uint64_t backoffDelay = calculateExponentialBackoff(_currentSendAttempt, INFLUXDB_INITIAL_RETRY_INTERVAL, INFLUXDB_MAX_RETRY_INTERVAL, INFLUXDB_RETRY_MULTIPLIER);
             _nextSendAttemptMillis = millis64() + backoffDelay;
 
-            snprintf(_status, sizeof(_status), "Failed to send data (HTTP %ld - %s) - Attempt %u", httpCode, httpStatus, _currentSendAttempt);
-            _statusTimestampUnix = CustomTime::getUnixTime();
-
             char backoffHuman[24];
             DurationFormat::humanizeDuration(backoffDelay, backoffHuman, sizeof(backoffHuman));
+            snprintf(_status, sizeof(_status), "Failed to send data (HTTP %ld - %s) - Attempt %u. Retrying in %s", httpCode, httpStatus, _currentSendAttempt, backoffHuman);
+            _statusTimestampUnix = CustomTime::getUnixTime();
+
             LOG_WARNING("Failed to send data to InfluxDB (HTTP %ld - %s). Next attempt in %s", httpCode, httpStatus, backoffHuman);
         }
         

--- a/source/src/issueregistry.cpp
+++ b/source/src/issueregistry.cpp
@@ -337,10 +337,10 @@ namespace IssueRegistry
                                                   ? IssueLogic::rateEvidence(influxOkDelta, influxErrorDelta)
                                                   : IssueLogic::Evidence::Good;
         _influxStreak = IssueLogic::updateStreak(_influxStreak, influxEvidence);
-        bool influxFailing = (_influxStreak >= ISSUE_STREAK_TO_RAISE);
+        bool influxFailing = (_influxStreak >= ISSUE_INFLUXDB_STREAK_TO_RAISE);
         message[0] = '\0';
         if (influxFailing) {
-            snprintf(message, sizeof(message), "InfluxDB enabled but uploads keep failing (%u consecutive bad windows)",
+            snprintf(message, sizeof(message), "InfluxDB enabled but uploads keep failing (%u consecutive failed attempts)",
                      (unsigned)_influxStreak);
         }
         _updateInstance(IssueLogic::Code::InfluxDbUploadFailing, ISSUE_GLOBAL_SCOPE, influxFailing, message);

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -1515,7 +1515,7 @@ namespace Mqtt
 
             uint64_t backoffDelay = calculateExponentialBackoff(_mqttConnectionAttempt, MQTT_INITIAL_RETRY_INTERVAL, MQTT_MAX_RETRY_INTERVAL, MQTT_RETRY_MULTIPLIER);
             _nextMqttConnectionAttemptMillis = millis64() + backoffDelay;
-            char backoffHuman[24];
+            char backoffHuman[DURATION_FORMAT_BUFFER_SIZE];
             DurationFormat::humanizeDuration(backoffDelay, backoffHuman, sizeof(backoffHuman));
             LOG_WARNING("Failed to connect to MQTT (attempt %lu). Reason: %s. Next attempt in %s", _mqttConnectionAttempt, _getMqttStateReason(currentState), backoffHuman);
 
@@ -2069,7 +2069,7 @@ namespace Mqtt
 
         // Monitor for stability period (here we just wait, rollback will occur automatically on failure)
         while (millis64() - validationStartTime < OTA_VALIDATION_TIMEOUT) {
-            char otaRemainingHuman[24];
+            char otaRemainingHuman[DURATION_FORMAT_BUFFER_SIZE];
             DurationFormat::humanizeDuration(OTA_VALIDATION_TIMEOUT + validationStartTime - millis64(), otaRemainingHuman, sizeof(otaRemainingHuman));
             LOG_DEBUG("OTA validation in progress - %s remaining", otaRemainingHuman);
             delay(OTA_VALIDATION_CHECK_INTERVAL);

--- a/source/src/utils.cpp
+++ b/source/src/utils.cpp
@@ -561,7 +561,7 @@ static void _startFailsafeTimer() {
     };
     if (esp_timer_create(&timerArgs, &_failsafeTimer) == ESP_OK) {
         esp_timer_start_once(_failsafeTimer, SYSTEM_RESTART_FAILSAFE_TIMEOUT * 1000ULL); // Convert ms to us
-        char failsafeHuman[24];
+        char failsafeHuman[DURATION_FORMAT_BUFFER_SIZE];
         DurationFormat::humanizeDuration((uint64_t)SYSTEM_RESTART_FAILSAFE_TIMEOUT, failsafeHuman, sizeof(failsafeHuman));
         LOG_DEBUG("Failsafe restart timer started (%s)", failsafeHuman);
     } else {
@@ -691,7 +691,7 @@ void printDeviceStatusDynamic()
     populateSystemDynamicInfo(*info);
 
     LOG_DEBUG("--- Dynamic System Info ---");
-    char uptimeHuman[24];
+    char uptimeHuman[DURATION_FORMAT_BUFFER_SIZE];
     DurationFormat::humanizeDuration(info->uptimeMilliseconds, uptimeHuman, sizeof(uptimeHuman));
     LOG_DEBUG(
         "Uptime: %s | Timestamp: %s | Temperature: %.2f C",

--- a/source/test/test_duration_format/test_duration_format.cpp
+++ b/source/test/test_duration_format/test_duration_format.cpp
@@ -168,6 +168,23 @@ void test_zero_size_is_safe(void) {
 }
 
 // ============================================================================
+// DURATION_FORMAT_BUFFER_SIZE adequacy
+// "999 ms" is the widest realistic output; verify the constant fits it.
+// ============================================================================
+
+void test_buffer_size_fits_999_ms(void) {
+    char buf[DURATION_FORMAT_BUFFER_SIZE];
+    humanizeDuration(999, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("999 ms", buf);
+}
+
+void test_buffer_size_fits_59_min(void) {
+    char buf[DURATION_FORMAT_BUFFER_SIZE];
+    humanizeDuration(59 * 60000ULL, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_STRING("59 min", buf);
+}
+
+// ============================================================================
 // Runner
 // ============================================================================
 
@@ -201,6 +218,9 @@ int main(int argc, char **argv) {
 
     RUN_TEST(test_null_buffer_is_safe);
     RUN_TEST(test_zero_size_is_safe);
+
+    RUN_TEST(test_buffer_size_fits_999_ms);
+    RUN_TEST(test_buffer_size_fits_59_min);
 
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

- **Status display symmetry**: both custom MQTT and InfluxDB now show `(Attempt N). Retrying in X` in the same format
- **Relative timestamps**: Last Attempt shows `30 s ago` instead of raw UTC ISO string
- **InfluxDB issue detection fix**: `InfluxDbUploadFailing` was using `ISSUE_STREAK_TO_RAISE=12` which assumed evidence every 5s tick; with exponential backoff the issue would take ~5h to raise. New `ISSUE_INFLUXDB_STREAK_TO_RAISE=3` counts consecutive failed attempts instead
- **HACS instructions**: EnergyMe is in the default store now - updated from custom repository URL to search flow
- **CSS fix**: stale `#statusContainer` selector corrected to `#customMqttStatusContainer`
- **Portal banner**: third state for devices with no provisioning secrets (community builds); banner hidden until secrets check resolves to avoid lock-icon flash on load
- **`DURATION_FORMAT_BUFFER_SIZE`**: centralized constant replacing all hardcoded `[24]` buffers at `humanizeDuration` call sites (22 locations across 9 files); sized at 12 with reasoning in header comment

Closes #179 (tracked separately via #185)

## Test plan

- [ ] Custom MQTT and InfluxDB status sections show identical text structure on failure
- [ ] Last Attempt shows relative time only (e.g. `2 min ago`)
- [ ] InfluxDB issue raises after ~3 failed upload attempts
- [ ] Portal banner does not flash the lock icon on page load
- [ ] Portal banner shows correct state: no-secrets / cloud-disabled / cloud-enabled
- [ ] All 24 unit tests pass (`pio test -e native --filter test_duration_format`)