### PR TITLE
fix(ade7953): correct PHASE_2/PHASE_3 angle convention to IEC standard

### DIFF
--- a/source/html/channel.html
+++ b/source/html/channel.html
@@ -298,7 +298,7 @@
     // the installer picks the one that looks like a real load (PF near 1) instead of
     // guessing from the breaker panel. The power sign is omitted: it is always
     // flippable via the reverse flag, so it says nothing about the right phase.
-    const PHASE_ANGLES_DEG = { 1: 0, 2: 120, 3: -120 }; // same convention as firmware
+    const PHASE_ANGLES_DEG = { 1: 0, 2: -120, 3: 120 }; // IEC: PHASE_1=L1(0°), PHASE_2=L2(-120°), PHASE_3=L3(+120°)
 
     function isThreePhaseInstall() {
         const basePhase = channelData[0] ? channelData[0].phase : 1;

--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -312,12 +312,7 @@ enum class Ade7953InterruptType {
 };
 
 
-enum Phase : uint32_t { // Not a class so that we can directly use it in JSON serialization
-    PHASE_1 = 1,
-    PHASE_2 = 2,
-    PHASE_3 = 3,
-    PHASE_SPLIT_240 = 4,  // North America split-phase 240V circuit (L1-L2), auto-applies 2x multiplier
-};
+#include "phase_utils.h"  // Phase enum + PhaseUtils:: helpers (Arduino-free, host-testable)
 
 enum class Ade7953Channel{
     A,

--- a/source/lib/phase_utils/phase_utils.h
+++ b/source/lib/phase_utils/phase_utils.h
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#pragma once
+
+#include <cstdint>
+
+// Phase enum and pure phase-rotation helpers, deliberately free of any Arduino /
+// FreeRTOS dependency so the logic can be unit-tested on the host (see
+// test/test_phase_utils). ade7953.h includes this header for the Phase type.
+//
+// Convention (IEC positive sequence, European 3-phase):
+//   PHASE_1 = L1  0°      (reference)
+//   PHASE_2 = L2  -120°   (lags L1 by 120°)
+//   PHASE_3 = L3  +120°   (leads L1 by 120°)
+
+enum Phase : uint32_t { // plain enum so it serializes directly to/from JSON as an integer
+    PHASE_1       = 1,
+    PHASE_2       = 2,
+    PHASE_3       = 3,
+    PHASE_SPLIT_240 = 4, // North America split-phase 240 V (L1-L2), auto-applies 2x multiplier
+};
+
+namespace PhaseUtils {
+
+// Returns the phase 120° behind `phase` in IEC rotation (L1->L2->L3->L1).
+inline Phase getLaggingPhase(Phase phase) {
+    switch (phase) {
+        case PHASE_1: return PHASE_2;
+        case PHASE_2: return PHASE_3;
+        case PHASE_3: return PHASE_1;
+        case PHASE_SPLIT_240: return PHASE_SPLIT_240;
+        default: return PHASE_1;
+    }
+}
+
+// Returns the phase 120° ahead of `phase` in IEC rotation (L1->L3->L2->L1).
+inline Phase getLeadingPhase(Phase phase) {
+    switch (phase) {
+        case PHASE_1: return PHASE_3;
+        case PHASE_2: return PHASE_1;
+        case PHASE_3: return PHASE_2;
+        case PHASE_SPLIT_240: return PHASE_SPLIT_240;
+        default: return PHASE_1;
+    }
+}
+
+// Returns the degrees to shift the voltage waveform to align it with the current's
+// phase reference. Formula: currentAngle - voltageAngle.
+// Positive = current leads voltage reference; negative = current lags.
+inline float calculatePhaseShiftDeg(Phase voltagePhase, Phase currentPhase) {
+    auto toAngle = [](Phase p) -> float {
+        switch (p) {
+            case PHASE_1: return 0.0f;
+            case PHASE_2: return -120.0f;
+            case PHASE_3: return 120.0f;
+            case PHASE_SPLIT_240: return 0.0f;
+            default: return 0.0f;
+        }
+    };
+    return toAngle(currentPhase) - toAngle(voltagePhase);
+}
+
+} // namespace PhaseUtils

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -4683,67 +4683,11 @@ namespace Ade7953
     // Poor man's phase shift (doing with modulus didn't work properly,
     // and in any case the phases will always be at most 3)
 
-    Phase _getLaggingPhase(Phase phase) {
-        // Lagging means it is behind (yes it should be trivial but this costed me a lot of time..)
-        // So if it is phase 1, the lagging phase behind is phase 3
-        switch (phase) {
-            case PHASE_1:
-                return PHASE_3;
-            case PHASE_2:
-                return PHASE_1;
-            case PHASE_3:
-                return PHASE_2;
-            case PHASE_SPLIT_240:
-                return PHASE_SPLIT_240;  // Split-phase 240V doesn't rotate
-            default:
-                return PHASE_1;
-        }
-    }
-
-    Phase _getLeadingPhase(Phase phase) {
-        switch (phase) {
-            case PHASE_1:
-                return PHASE_2;
-            case PHASE_2:
-                return PHASE_3;
-            case PHASE_3:
-                return PHASE_1;
-            case PHASE_SPLIT_240:
-                return PHASE_SPLIT_240;  // Split-phase 240V doesn't rotate
-            default:
-                return PHASE_1;
-        }
-    }
+    Phase _getLaggingPhase(Phase phase) { return PhaseUtils::getLaggingPhase(phase); }
+    Phase _getLeadingPhase(Phase phase)  { return PhaseUtils::getLeadingPhase(phase); }
 
     float _calculatePhaseShift(Phase voltagePhase, Phase currentPhase) {
-        /**
-         * Calculate phase shift to align voltage waveform with current's phase reference.
-         * 
-         * Returns angle in degrees: positive = shift forward, negative = shift backward
-         * Formula: currentPhaseAngle - voltagePhaseAngle
-         */
-        
-        // Get phase angle for voltage
-        float voltageAngle = 0.0f;
-        switch (voltagePhase) {
-            case PHASE_1: voltageAngle = 0.0f; break;      // Phase A: 0°
-            case PHASE_2: voltageAngle = 120.0f; break;    // Phase B: 120°
-            case PHASE_3: voltageAngle = -120.0f; break;   // Phase C: -120°
-            case PHASE_SPLIT_240: voltageAngle = 0.0f; break;  // Split-phase 240V: 0° (same reference as Phase 1)
-            default: return 0.0f;  // Invalid phase
-        }
-        
-        // Get phase angle for current
-        float currentAngle = 0.0f;
-        switch (currentPhase) {
-            case PHASE_1: currentAngle = 0.0f; break;      // Phase A: 0°
-            case PHASE_2: currentAngle = 120.0f; break;    // Phase B: 120°
-            case PHASE_3: currentAngle = -120.0f; break;   // Phase C: -120°
-            case PHASE_SPLIT_240: currentAngle = 0.0f; break;  // Split-phase 240V: 0° (same reference as Phase 1)
-            default: return 0.0f;  // Invalid phase
-        }
-        
-        return currentAngle - voltageAngle;
+        return PhaseUtils::calculatePhaseShiftDeg(voltagePhase, currentPhase);
     }
 
     const char* _irqstataBitName(uint32_t bit) {

--- a/source/test/test_phase_utils/test_phase_utils.cpp
+++ b/source/test/test_phase_utils/test_phase_utils.cpp
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+//
+// Host unit tests for PhaseUtils phase-rotation helpers. Run with:  pio test -e native
+// (On Windows the native toolchain is unreliable - run it from WSL.)
+
+#include <unity.h>
+#include "phase_utils.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ============================================================================
+// getLaggingPhase - IEC rotation L1->L2->L3->L1
+// ============================================================================
+
+void test_lagging_from_L1_is_L2(void) {
+    TEST_ASSERT_EQUAL(PHASE_2, PhaseUtils::getLaggingPhase(PHASE_1));
+}
+
+void test_lagging_from_L2_is_L3(void) {
+    TEST_ASSERT_EQUAL(PHASE_3, PhaseUtils::getLaggingPhase(PHASE_2));
+}
+
+void test_lagging_from_L3_is_L1(void) {
+    TEST_ASSERT_EQUAL(PHASE_1, PhaseUtils::getLaggingPhase(PHASE_3));
+}
+
+void test_lagging_split240_is_identity(void) {
+    TEST_ASSERT_EQUAL(PHASE_SPLIT_240, PhaseUtils::getLaggingPhase(PHASE_SPLIT_240));
+}
+
+// ============================================================================
+// getLeadingPhase - IEC rotation L1->L3->L2->L1
+// ============================================================================
+
+void test_leading_from_L1_is_L3(void) {
+    TEST_ASSERT_EQUAL(PHASE_3, PhaseUtils::getLeadingPhase(PHASE_1));
+}
+
+void test_leading_from_L2_is_L1(void) {
+    TEST_ASSERT_EQUAL(PHASE_1, PhaseUtils::getLeadingPhase(PHASE_2));
+}
+
+void test_leading_from_L3_is_L2(void) {
+    TEST_ASSERT_EQUAL(PHASE_2, PhaseUtils::getLeadingPhase(PHASE_3));
+}
+
+void test_leading_split240_is_identity(void) {
+    TEST_ASSERT_EQUAL(PHASE_SPLIT_240, PhaseUtils::getLeadingPhase(PHASE_SPLIT_240));
+}
+
+void test_leading_and_lagging_are_inverses(void) {
+    // Leading and lagging must be exact inverses: leading(lagging(x)) == x
+    TEST_ASSERT_EQUAL(PHASE_1, PhaseUtils::getLeadingPhase(PhaseUtils::getLaggingPhase(PHASE_1)));
+    TEST_ASSERT_EQUAL(PHASE_2, PhaseUtils::getLeadingPhase(PhaseUtils::getLaggingPhase(PHASE_2)));
+    TEST_ASSERT_EQUAL(PHASE_3, PhaseUtils::getLeadingPhase(PhaseUtils::getLaggingPhase(PHASE_3)));
+}
+
+// ============================================================================
+// calculatePhaseShiftDeg
+// ============================================================================
+
+void test_shift_same_phase_is_zero(void) {
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, PhaseUtils::calculatePhaseShiftDeg(PHASE_1, PHASE_1));
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, PhaseUtils::calculatePhaseShiftDeg(PHASE_2, PHASE_2));
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, PhaseUtils::calculatePhaseShiftDeg(PHASE_3, PHASE_3));
+}
+
+void test_shift_L1_voltage_L2_current_is_minus_120(void) {
+    // L2 lags L1 by 120°: current zero-crossing comes 120° after voltage reference
+    TEST_ASSERT_EQUAL_FLOAT(-120.0f, PhaseUtils::calculatePhaseShiftDeg(PHASE_1, PHASE_2));
+}
+
+void test_shift_L1_voltage_L3_current_is_plus_120(void) {
+    // L3 leads L1 by 120°: current zero-crossing comes 120° before voltage reference
+    TEST_ASSERT_EQUAL_FLOAT(120.0f, PhaseUtils::calculatePhaseShiftDeg(PHASE_1, PHASE_3));
+}
+
+void test_shift_is_antisymmetric(void) {
+    // Swapping voltage and current must negate the shift
+    TEST_ASSERT_EQUAL_FLOAT(120.0f,  PhaseUtils::calculatePhaseShiftDeg(PHASE_1, PHASE_3));
+    TEST_ASSERT_EQUAL_FLOAT(-120.0f, PhaseUtils::calculatePhaseShiftDeg(PHASE_3, PHASE_1));
+    TEST_ASSERT_EQUAL_FLOAT(-120.0f, PhaseUtils::calculatePhaseShiftDeg(PHASE_1, PHASE_2));
+    TEST_ASSERT_EQUAL_FLOAT(120.0f,  PhaseUtils::calculatePhaseShiftDeg(PHASE_2, PHASE_1));
+}
+
+void test_shift_split240_reference_is_zero(void) {
+    // Split-phase 240V shares the L1 reference angle
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, PhaseUtils::calculatePhaseShiftDeg(PHASE_SPLIT_240, PHASE_1));
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, PhaseUtils::calculatePhaseShiftDeg(PHASE_1, PHASE_SPLIT_240));
+}
+
+// ============================================================================
+// Regression guard: old (wrong) convention would have flipped signs
+// These values must NOT change without a deliberate decision and release note.
+// ============================================================================
+
+void test_regression_L2_angle_is_negative(void) {
+    // Before the IEC fix, PHASE_2 was +120° (L3). Confirm it is now -120° (L2).
+    TEST_ASSERT_EQUAL_FLOAT(-120.0f, PhaseUtils::calculatePhaseShiftDeg(PHASE_1, PHASE_2));
+}
+
+void test_regression_L3_angle_is_positive(void) {
+    // Before the IEC fix, PHASE_3 was -120° (L2). Confirm it is now +120° (L3).
+    TEST_ASSERT_EQUAL_FLOAT(120.0f, PhaseUtils::calculatePhaseShiftDeg(PHASE_1, PHASE_3));
+}
+
+void test_regression_lagging_from_L1_is_L2_not_L3(void) {
+    // Before the fix: getLaggingPhase(PHASE_1) returned PHASE_3. Must now return PHASE_2.
+    TEST_ASSERT_EQUAL(PHASE_2, PhaseUtils::getLaggingPhase(PHASE_1));
+    TEST_ASSERT_NOT_EQUAL(PHASE_3, PhaseUtils::getLaggingPhase(PHASE_1));
+}
+
+void test_regression_leading_from_L1_is_L3_not_L2(void) {
+    // Before the fix: getLeadingPhase(PHASE_1) returned PHASE_2. Must now return PHASE_3.
+    TEST_ASSERT_EQUAL(PHASE_3, PhaseUtils::getLeadingPhase(PHASE_1));
+    TEST_ASSERT_NOT_EQUAL(PHASE_2, PhaseUtils::getLeadingPhase(PHASE_1));
+}
+
+// ============================================================================
+// runner
+// ============================================================================
+
+int main(int, char **) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_lagging_from_L1_is_L2);
+    RUN_TEST(test_lagging_from_L2_is_L3);
+    RUN_TEST(test_lagging_from_L3_is_L1);
+    RUN_TEST(test_lagging_split240_is_identity);
+
+    RUN_TEST(test_leading_from_L1_is_L3);
+    RUN_TEST(test_leading_from_L2_is_L1);
+    RUN_TEST(test_leading_from_L3_is_L2);
+    RUN_TEST(test_leading_split240_is_identity);
+    RUN_TEST(test_leading_and_lagging_are_inverses);
+
+    RUN_TEST(test_shift_same_phase_is_zero);
+    RUN_TEST(test_shift_L1_voltage_L2_current_is_minus_120);
+    RUN_TEST(test_shift_L1_voltage_L3_current_is_plus_120);
+    RUN_TEST(test_shift_is_antisymmetric);
+    RUN_TEST(test_shift_split240_reference_is_zero);
+
+    RUN_TEST(test_regression_L2_angle_is_negative);
+    RUN_TEST(test_regression_L3_angle_is_positive);
+    RUN_TEST(test_regression_lagging_from_L1_is_L2_not_L3);
+    RUN_TEST(test_regression_leading_from_L1_is_L3_not_L2);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

- **Root cause:** PHASE_2 was mapped to +120 deg and PHASE_3 to -120 deg - the inverse of IEC European positive sequence (L1=0 deg, L2=-120 deg, L3=+120 deg). This caused customers to configure channels as 1-3-2 instead of 1-2-3 for standard 3-phase installations.
- **Fix:** Swap the angles so PHASE_2=L2(-120 deg) and PHASE_3=L3(+120 deg). Affects `_getLaggingPhase`, `_getLeadingPhase`, `_calculatePhaseShift` in firmware and `PHASE_ANGLES_DEG` in the channel config UI.
- **Refactor:** Extract `Phase` enum and the three rotation helpers to `lib/phase_utils/phase_utils.h` (Arduino-free) so the convention is host-testable.
- **Tests:** 18 unit tests added in `test/test_phase_utils/` including 4 regression guards that will fail if the convention is accidentally reverted.

## Breaking change

NVS enum values are unchanged, but **existing 3-phase devices configured with the 1-3-2 workaround must reconfigure back to 1-2-3** after updating. Single-phase and split-phase installations are unaffected.

## Test plan

- [x] `pio test -e native` - 137/137 passed (all 4 suites)
- [x] `pio run -e esp32s3-dev` - build succeeded
- [x] OTA to dev device (192.168.2.174) - verified, MD5 matched
- [ ] Waveform reverse flag: capture with reverse=false vs reverse=true, confirm sign flip
- [ ] Phase shift direction: configure channel as PHASE_2 on single-phase bench, confirm waveform shifts voltage right (delayed) not left
- [ ] 3-phase power calculation: requires 3-phase supply - validate with field device after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)