### PR TITLE
feat(shadow): AWS IoT Named Shadows + IoT Commands (v2.1.0 firmware surface)

### DIFF
--- a/source/.gitignore
+++ b/source/.gitignore
@@ -34,4 +34,3 @@ mocks/
 # AI stuff
 .playwright*
 .claude
-docs/plans

--- a/source/docs/feature/2026-06-16-shadow-v2-config/00-overview-and-contract.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/00-overview-and-contract.md
@@ -1,0 +1,205 @@
+# AWS IoT Device Shadow config (v2.1.0) - overview & contract
+
+Tracking issue: #159. This doc set is the device<->cloud contract both repos
+(`EnergyMe-Home` firmware, `energyme-infra` cloud) validate against before coding.
+
+## Doc index
+
+| # | Doc | Scope | Cloud writer needed to test? |
+|---|-----|-------|------------------------------|
+| 00 | this | contract, apply logic, cloud checklist, open decisions | - |
+| 01 | `01-scaffold-shadow-module.md` | `shadow.cpp/.h`: subscribe, publish-reported, delta dispatch, version/clientToken, mutex | no |
+| 02 | `02-info-shadow.md` | reported-only identity; retires `system/static` | **no** (console-verifiable) |
+| 03 | `03-issues-shadow.md` | reported-only issue registry; transition-triggered | **no** (console-verifiable) |
+| 04 | `04-system-shadow.md` | writable behavioural config (trimmed set) + `mqtt_log_level` auto-revert | yes |
+| 05 | `05-meter-shadow.md` | writable ADE7953 calibration + sample time | yes |
+| 06 | `06-channels-shadow.md` | writable per-channel config, object-keyed | yes |
+| 07 | `07-commands.md` | IoT Commands: restart, factory_reset, energy_reset | yes |
+| 08 | `08-v2-cutover.md` | retire config topics (`command`/`system/static`/`channel`), buffer bump, fw 2.1.0 (topic stays v1) | n/a |
+
+**Build/test order:** 01 -> 02 -> 03 give on-device, cloud-independent proof
+(reported-only shadows are verifiable by inspecting shadow state in the AWS
+console with zero cloud backend). 04-07 need a cloud `desired`/command writer to
+exercise the inbound path. 08 is the breaking cut, last.
+
+## Scope decisions (locked)
+
+- Deliverable now: this contract doc set. No infra issues opened.
+- **No topic-version bump: `MQTT_TOPIC_VERSION` stays `"v1"`.** No surviving topic
+  changes payload, so a version would be ceremony. Migration is additive (shadows
+  + Commands on net-new `$aws/...` topics) + subtractive (3 config topics stop
+  being published). Keeping v1 avoids rule duplication, a rollout window,
+  device-policy ARN migration, and the "delete v1 early = data loss" footgun.
+  Surviving telemetry is untouched, so **zero ingest gap** for any fleet mix.
+  Firmware release still bumps to 2.1.0 (firmware semver, not the topic string).
+- Secrets stay local-only (WiFi, CustomMQTT creds, InfluxDB token, web password).
+- Energy counters / instantaneous power stay on telemetry topics (shadow writes
+  would burn the 20 RPS/thing budget).
+- Secrets stay local-only (WiFi, CustomMQTT creds, InfluxDB token, web password).
+- Energy counters / instantaneous power stay on telemetry topics (shadow writes
+  would burn the 20 RPS/thing budget).
+
+## Verified AWS facts (load-bearing)
+
+- **Shadow doc size cap = 8 KB, state only; metadata (timestamps) excluded.**
+  Worst-case `channels` reported (17 ch x ~200 B) ~= 3.4 KB. Single shadow is fine.
+- **Named-shadow + Commands topics are plain MQTT sub/pub**, MQTT 3.1.1 /
+  PubSubClient-compatible, available eu-west-1. No AWS device SDK required.
+- Shadow RPS limit 20/thing; in-flight unacked 10/thing.
+
+## Protocol: publish-reported-first, no GET (the apply logic)
+
+The device **never** publishes `/get`. A GET returns the full document
+*including* the metadata block (a timestamp per field) -> large payload that can
+overflow the inbound buffer. **For the same reason the device does NOT subscribe
+to `/update/accepted`**: its response echoes the full reported state *plus* a
+per-field metadata block, which for `channels` is the single largest inbound
+message and would stress the RX buffer. The device subscribes only to
+`/update/delta` (small: changed fields + minimal metadata) and `/update/rejected`
+(tiny). `version` is sourced from the delta payload, not from `/accepted`. Flow,
+per named shadow `<name>`, on every MQTT (re)connect:
+
+1. Subscribe `update/delta`, `update/rejected`. (NOT `update/accepted`.)
+2. Publish `{state:{reported:<full current NVS config>}}` to `update`.
+3. AWS stores reported. If a `desired` exists and differs, AWS auto-pushes
+   `update/delta` (no GET needed).
+4. On `delta`: apply each field -> persist NVS -> publish **one combined**
+   `{state:{reported:{<applied>}, desired:{<field>:null}}}`. The `desired:null`
+   removes the pending intent; that publish *is* the ack.
+5. The delta payload carries `version`; record it for the next
+   optimistic-concurrency check (no `/accepted` subscription needed).
+
+### The asymmetric desired-null semantic (conflict policy = "cloud wins on reconnect")
+
+The combined `{reported, desired:null}` publish is the **same shape** for both the
+cloud-delta path and the local-edit path. The difference is *when* desired is nulled:
+
+| Trigger | Publish | Effect |
+|---------|---------|--------|
+| Cloud delta | `{reported:{f:cloudVal}, desired:{f:null}}` | apply cloud value, clear intent |
+| Local UI edit | `{reported:{f:localVal}, desired:{f:null}}` | local value wins, clears any pending cloud intent for `f` |
+| Reconnect (reported-first) | `{reported:<full>}` (does **not** null desired) | any pending cloud `desired` survives -> AWS re-sends delta -> **cloud value re-applied** |
+
+So: **a local edit wins only when actively made** (it nulls desired). **Across a
+reconnect, a still-pending cloud desired wins** (reported-first does not clear it).
+Cloud must re-assert `desired` to override a value the user changed locally while online.
+
+### Version / clientToken
+
+- Track `version` from each `update/delta` payload (it includes the doc version).
+  Echo it on the combined delta-ack publish for optimistic locking. On
+  `update/rejected` code 409 (version conflict): re-publish reported **without**
+  version and wait for a fresh delta. (Verify `version` is present in the delta
+  payload during impl - it is in the standard shadow delta document.)
+- Do **not** send `version` on the reconnect reported-first publish (avoids
+  spurious 409 on reconnect).
+- `clientToken`: per-publish token (from `esp_random()`) included on outbound
+  updates for cloud-side traceability and correlation on `/rejected`. The device
+  does **not** use it for dedup (no `/accepted` subscription). Optional; drop if
+  it adds no value once the cloud side is settled.
+
+### Unknown desired field
+
+Do not apply; still null it (`{desired:{unknownField:null}}`) and `LOG_WARNING`.
+Forward-compat, not an error.
+
+### Contract constraints on the cloud writer
+
+(This repo can't enforce these on-device; they are part of the cloud contract.)
+
+- **Chunk `channels` desired writes.** A single delta that sets `desired` for many
+  channels with max-length labels + per-field metadata can exceed the device RX
+  buffer (`MQTT_BUFFER_SIZE`, 9 KB) and be silently dropped. The backend must
+  write channel `desired` in batches of **<= N channels per update** (N chosen so
+  worst-case wire delta < buffer; see 06). Other shadows are small, no constraint.
+- **Clear `desired` on `factory_reset`.** After a reset the device reports
+  defaults; any still-pending `desired` would be delta'd back and partially undo
+  the reset. The backend must clear all shadows' `desired` for the thing when it
+  issues `factory_reset` (07).
+
+## Shadow catalog (schemas corrected against actual firmware)
+
+Field names below match the **current firmware JSON** (the existing
+`*ToJson` serializers), not the issue's illustrative names. Each shadow doc has
+the authoritative schema.
+
+1. **info** (reported-only) - identity. Source: `systemStaticInfoToJson` fields
+   flattened (`utils.cpp`). Replaces `_publishSystemStatic`. See 02.
+2. **issues** (reported-only) - `IssueRegistry::issuesToJson` output verbatim,
+   plus derived `active_count`. See 03.
+3. **system** (writable) - exactly 5 fields, the ones configurable + persisted
+   today: `led_brightness`, `send_power_data`, `mqtt_log_level`,
+   `log_level_print`, `log_level_save`. `ntp_server`/`timezone` are out (NTP/TZ
+   work automatically once cloud-connected; device runs UTC internally).
+   `modbus_*` is out (hardcoded in firmware, not configurable). See 04.
+4. **meter** (writable) - ADE7953 calibration (struct `Ade7953Configuration`,
+   camelCase keys, NVS `ade7953_ns`) + `sample_time`. See 05.
+5. **channels** (writable) - per-channel object keyed by index 0-16, nested
+   `ctSpecification`, `_channelDataMutex`, channel-0 invariant. See 06.
+
+## Cloud-side required changes (REFERENCE ONLY - not implemented in this repo)
+
+**This repo does not touch `energyme-infra`.** The list below is the
+coordination contract: it is implemented and tracked on the cloud side
+separately. It is here only so the firmware contract is validated end-to-end.
+These do **not** exist today (infra ADR-001 defers shadows to "Phase 2"):
+
+1. **Device policy** (`energyme-home-{env}-device-policy`): add a statement for
+   **`$aws/commands/things/${iot:Connection.Thing.ThingName}/*`** (subscribe +
+   receive + publish) - Commands topics are NOT under `$aws/things/*`, so the
+   current policy does not cover them. Shadow topics (`$aws/things/.../shadow/*`)
+   ARE already covered by the existing `AllowSubscribe`/`AllowReceive`/`AllowPublishShadow`.
+2. **Shadow read/write backend** ("Intelligence backend"): the desired-state
+   writer + reported-state reader (one ingestion Lambda + rule). Net-new; nothing
+   writes `desired` today. Reuses the existing `device-ops` DynamoDB table
+   (schemaless - add a map per shadow on the per-device item; no new table). It
+   replaces what `system_static` + `channel_handler` write today.
+3. **IoT Commands**: create 3 command templates (restart, factory_reset,
+   energy_reset) + a `StartCommandExecution` dispatcher. Net-new.
+4. **No v2 rules / no policy-ARN migration**: topic stays `v1`, so existing
+   telemetry rules + policy publish ARNs are unchanged. The 3 retired topics'
+   rules (`system/static`, `command`, `channel`) just go idle once firmware stops
+   publishing; delete them whenever convenient. Only the `$aws/commands/*` policy
+   statement (item 1) is added.
+
+## Open decisions (for joint cloud review)
+
+1. ~~`system` shadow scope~~ **RESOLVED:** ship the 5 configurable fields.
+   `ntp_server`/`timezone` out (auto via cloud/NTP, device is UTC). `modbus_*` out
+   (not configurable in firmware). No follow-up needed for this work.
+2. ~~`channels` source of truth~~ **RESOLVED:** shadow is the single source of
+   truth for all configurable state. The device **stops publishing the `channel`
+   topic** (was config, not telemetry); cloud reads channel
+   config from the `channels` shadow and retires `channel`-topic ingestion. Same
+   principle retires `system/static` (-> `info` shadow). **Guiding rule:**
+   telemetry topics carry only measurements/statistics/dynamic runtime; all
+   configurable state lives in shadows. (WiFi credentials are the one carve-out:
+   local-only, never in a shadow - AWS forbids secrets in shadow docs.)
+3. ~~`issues` ack path~~ **RESOLVED:** via shadow **desired/delta**. Cloud writes
+   `desired.ack=[codes]`; device acks those, reports new states, nulls
+   `desired.ack`. `issues` is partially-writable (only the `ack` key). See 03.
+4. ~~`git_commit` in `info`~~ **RESOLVED:** publish `sketch_md5`
+   (`ESP.getSketchMD5()`), NOT git commit. The binary hash proves whether the
+   running firmware is the published build or a modified/recompiled one; a git
+   SHA can lie (uncommitted/dirty tree). See 02.
+
+## Final payload-shape review (gate before "done")
+
+After 01-08 are implemented, do a **joint review of every shadow + command
+payload** (firmware + cloud together) to confirm each carries exactly what's
+needed - nothing missing, nothing extra. Capture the agreed final schemas here.
+
+## Deferred / post-MVP (after the core is up)
+
+The first cut ships the config surface that already exists on-device. Once the
+mechanism is live we optimize and add remaining endpoints. Known candidates to
+revisit in the payload review:
+
+- **WiFi info** (non-secret): connected SSID, RSSI, IP - reportable in `info` or a
+  WiFi shadow. (RSSI is already in `system/dynamic` telemetry today.) **Creds stay
+  local-only.**
+- **WiFi actions**: reconnect / rescan / forget - candidate IoT Commands.
+- Any config currently exposed via REST but not yet mirrored to a shadow.
+- `issues` ack wiring (decision 3) once the cloud desired-writer exists.
+
+These are explicitly **not** in the 01-08 scope; they are the next iteration.

--- a/source/docs/feature/2026-06-16-shadow-v2-config/00-overview-and-contract.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/00-overview-and-contract.md
@@ -71,18 +71,25 @@ per named shadow `<name>`, on every MQTT (re)connect:
 
 ### The asymmetric desired-null semantic (conflict policy = "cloud wins on reconnect")
 
-The combined `{reported, desired:null}` publish is the **same shape** for both the
-cloud-delta path and the local-edit path. The difference is *when* desired is nulled:
+Only the **cloud-delta path** nulls `desired` (the ack/clear). The local-edit path
+goes through the 3 s drift poll and publishes **reported-only**. How each trigger
+treats `desired`:
 
 | Trigger | Publish | Effect |
 |---------|---------|--------|
 | Cloud delta | `{reported:{f:cloudVal}, desired:{f:null}}` | apply cloud value, clear intent |
-| Local UI edit | `{reported:{f:localVal}, desired:{f:null}}` | local value wins, clears any pending cloud intent for `f` |
+| Local edit (REST/UI/internal) | `{reported:{f:localVal}}` via 3 s drift poll (no `desired`) | local value reported within ~3 s; a pending cloud `desired` is **not** cleared |
 | Reconnect (reported-first) | `{reported:<full>}` (does **not** null desired) | any pending cloud `desired` survives -> AWS re-sends delta -> **cloud value re-applied** |
 
-So: **a local edit wins only when actively made** (it nulls desired). **Across a
-reconnect, a still-pending cloud desired wins** (reported-first does not clear it).
-Cloud must re-assert `desired` to override a value the user changed locally while online.
+So: the delta path clears intent on every cloud write. Local edits publish
+reported-only (no `desired:null`) - **safe in the current field set** because the
+delta path already clears `desired` on each cloud write, so no locally-editable
+field carries a standing cloud `desired` to conflict with. **If** a future design
+has the cloud hold a standing `desired` on a locally-editable field, a local edit
+would be re-overridden by the next delta (cloud-wins); to restore
+local-wins-when-active for such a field, add a per-field `desired:null` to the
+drift publish. Across a reconnect, a still-pending cloud `desired` wins
+(reported-first does not clear it).
 
 ### Version / clientToken
 

--- a/source/docs/feature/2026-06-16-shadow-v2-config/00-overview-and-contract.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/00-overview-and-contract.md
@@ -143,6 +143,14 @@ the authoritative schema.
    camelCase keys, NVS `ade7953_ns`) + `sample_time`. See 05.
 5. **channels** (writable) - per-channel object keyed by index 0-16, nested
    `ctSpecification`, `_channelDataMutex`, channel-0 invariant. See 06.
+6. **wifi** (reported-only) - non-secret network state: `connected`, `ssid`,
+   `ip`, `gateway`, `subnet`, `dns`, `mac`, plus `static_ip`/`fallback_to_dhcp`
+   mode flags. Read from `WiFi.*` + `CustomWifi::getConfiguration`. Published on
+   (re)connect like the other reported-only shadows. **RSSI is excluded** (volatile,
+   already on `system/dynamic`). **No writable network config**: static IP is set
+   locally via REST only - a bad remote static IP would risk a LAN lock-out, and
+   the local path already has boot-fail/DHCP backstops. WiFi credentials are never
+   in a shadow.
 
 ## Cloud-side required changes (REFERENCE ONLY - not implemented in this repo)
 
@@ -202,9 +210,10 @@ The first cut ships the config surface that already exists on-device. Once the
 mechanism is live we optimize and add remaining endpoints. Known candidates to
 revisit in the payload review:
 
-- **WiFi info** (non-secret): connected SSID, RSSI, IP - reportable in `info` or a
-  WiFi shadow. (RSSI is already in `system/dynamic` telemetry today.) **Creds stay
-  local-only.**
+- ~~**WiFi info** (non-secret)~~ **DONE:** shipped as the reported-only `wifi`
+  shadow (connected/ssid/ip/gateway/subnet/dns/mac + static_ip/fallback_to_dhcp).
+  RSSI stays on `system/dynamic`. Creds remain local-only. Writable network config
+  (static IP/DHCP from cloud) deliberately **not** added - LAN lock-out risk.
 - **WiFi actions**: reconnect / rescan / forget - candidate IoT Commands.
 - Any config currently exposed via REST but not yet mirrored to a shadow.
 - `issues` ack wiring (decision 3) once the cloud desired-writer exists.

--- a/source/docs/feature/2026-06-16-shadow-v2-config/00-overview-and-contract.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/00-overview-and-contract.md
@@ -81,15 +81,52 @@ treats `desired`:
 | Local edit (REST/UI/internal) | `{reported:{f:localVal}}` via 3 s drift poll (no `desired`) | local value reported within ~3 s; a pending cloud `desired` is **not** cleared |
 | Reconnect (reported-first) | `{reported:<full>}` (does **not** null desired) | any pending cloud `desired` survives -> AWS re-sends delta -> **cloud value re-applied** |
 
-So: the delta path clears intent on every cloud write. Local edits publish
-reported-only (no `desired:null`) - **safe in the current field set** because the
-delta path already clears `desired` on each cloud write, so no locally-editable
-field carries a standing cloud `desired` to conflict with. **If** a future design
-has the cloud hold a standing `desired` on a locally-editable field, a local edit
-would be re-overridden by the next delta (cloud-wins); to restore
-local-wins-when-active for such a field, add a per-field `desired:null` to the
-drift publish. Across a reconnect, a still-pending cloud `desired` wins
-(reported-first does not clear it).
+So: the delta path clears intent on each cloud write **that produces a delta**.
+Local edits publish reported-only (no `desired:null`), so a `desired` left equal to
+`reported` is never cleared by the device.
+
+> **DECISION (2026-06-17, verified e2e on .174): the cloud owns clearing `desired`,
+> reactively, after convergence.** This is the load-bearing contract; the device's
+> delta-ack null is only a latency optimization on top of it. `desired` is a
+> *transient remote command*, not a persistent setpoint - steady-state the local
+> value is authoritative (aligns with local-first).
+
+1. **(MUST - load-bearing) Clear `desired` after observing convergence.** The cloud
+   desired-state writer writes a field only to *command* a change, then publishes
+   `desired:{f:null}` once it observes `reported` match the value it wrote -
+   **including the immediate case where `reported` already equalled it** (a no-op
+   write -> null it right away). This is *reactive* (it watches the actual reported
+   shadow), so it is robust even when the writer's own `reported` view lags the
+   device.
+2. **(SHOULD - optimization, NOT the safety mechanism) Avoid writing
+   `desired == reported`** and avoid declarative "full desired state" re-syncs. This
+   only saves shadow churn. It is *predictive* (compares against the writer's
+   possibly-stale `reported` cache), so it is best-effort; clause 1 is what
+   guarantees correctness, and it cleans up any no-op that slips through.
+
+**Failure mode if clause 1 is skipped:** AWS emits a delta **only when
+`desired != reported`**, and a no-GET device nulls `desired` only in the delta-ack.
+So a `desired` written equal to (or left equal to) `reported` produces **no delta**,
+the device never sees it, and it stays. That stuck `desired` then reverts the next
+*local* edit to the field: the local edit moves `reported`, `desired` now differs,
+AWS emits a delta, and the device applies the stale `desired` over the local change.
+*Reproduced on .174 (2026-06-17):* wrote `desired.led_brightness=44` when `reported`
+was already 44 -> local REST set 88 -> device reverted to 44 within ~2 s.
+
+**Why the fix is the cloud, not the device:** the device cannot see a
+`desired == reported` without a GET (no diff -> no delta -> no notification), and the
+design deliberately avoids GET / `/update/accepted`. A device-side "drift also nulls
+`desired`" alternative was considered and **rejected** - it trades this (sustained)
+bug for a coincident-write race, where a local edit firing while a fresh cloud
+`desired` is still in flight would wipe the cloud intent at AWS with no re-trigger.
+The cloud already ingests `reported` and can watch convergence, so it is the natural
+owner. (A periodic device GET to sweep stuck `desired` was also rejected: it
+re-introduces the avoided GET + `/get/accepted` subscriptions/buffer, needs
+version-conditional nulls to avoid the same race, and only bounds the harm window to
+the poll interval.)
+
+Across a reconnect, a still-pending cloud `desired` wins (reported-first does not
+clear it) - consistent with the cloud-wins-on-reconnect policy.
 
 ### Version / clientToken
 

--- a/source/docs/feature/2026-06-16-shadow-v2-config/01-scaffold-shadow-module.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/01-scaffold-shadow-module.md
@@ -1,0 +1,180 @@
+# 01 - Scaffold `shadow` module
+
+**Goal:** a reusable `Shadow` module that handles the protocol (00) for any named
+shadow, so 02-06 only register a shadow + supply serialize/apply callbacks.
+
+**Files:** new `src/shadow.cpp`, `include/shadow.h`. Hooks into `src/mqtt.cpp`.
+No cloud writer needed to land/unit-test this phase.
+
+## Public API (`shadow.h`)
+
+```cpp
+namespace Shadow {
+    // Build the full reported state for this shadow into doc["state"]["reported"].
+    using ReportFn = void (*)(JsonDocument& doc);
+    // Apply one delta. Return fields actually applied (to echo into reported) via
+    // `appliedReported`; list unknown/echo-null fields via `desiredNull`.
+    // Return false if nothing applied (still acks by nulling).
+    using ApplyFn  = bool (*)(JsonObjectConst delta,
+                              JsonObject appliedReported,
+                              JsonArray  desiredNullKeys);
+
+    struct Descriptor {
+        const char* name;        // "info", "system", ...
+        bool        writable;    // false => reported-only, no delta subscribe
+        ReportFn    report;
+        ApplyFn     apply;        // nullptr when !writable
+    };
+
+    void begin();                         // create mutex, register descriptors
+    void registerShadow(const Descriptor&);
+
+    // Called by mqtt.cpp:
+    void onMqttConnected();               // subscribe + publish-reported-first all
+    bool routeMessage(const char* topic, const char* payload); // true if handled
+    void publishReported(const char* name);                    // one shadow
+
+    // Called by modules on local edit (clears pending desired for changed fields):
+    void publishLocalEdit(const char* name, JsonObjectConst changedFields);
+}
+```
+
+## Topic construction
+
+Reuse `_constructMqttTopicReservedThings` pattern (mqtt.cpp:690) but it is
+`static` in the `Mqtt` namespace. Add a small public helper in mqtt or duplicate
+in shadow:
+
+```
+prefix = "$aws/things/" + DEVICE_ID + "/shadow/name/" + name
+sub:  prefix + "/update/delta", "/update/rejected"   (NOT /update/accepted)
+pub:  prefix + "/update"
+```
+
+**Do not subscribe `/update/accepted`:** its response echoes the full reported
+state + a per-field metadata block (largest inbound message for `channels`) and
+would stress `MQTT_BUFFER_SIZE`. `version` comes from the delta payload instead.
+
+`MQTT_TOPIC_BUFFER_SIZE` (128) is enough: longest = `$aws/things/<12>/shadow/name/channels/update/rejected` ~= 60 chars.
+
+## Per-shadow runtime state
+
+```cpp
+struct ShadowState {
+    Descriptor desc;
+    uint32_t   version       = 0;     // last accepted version (0 = unknown)
+    bool       reportPending = false; // queue a reported publish
+};
+```
+
+Store in a small static array (5 entries). Guard with a single `_shadowMutex`
+(the apply callbacks themselves take the owning module's mutex - see per-shadow docs).
+
+## Message routing (`routeMessage`)
+
+Called from `_subscribeCallback` (mqtt.cpp:833) before the existing command/jobs
+checks. Match `strstr(topic, "/shadow/name/")`, extract `<name>`, then suffix:
+
+- `/update/delta`    -> parse `version` (store), **copy the delta payload into a
+  per-shadow pending buffer, set `applyPending`**. Do NOT apply here.
+- `/update/rejected` -> if code 409 -> request `publishReported(name)` (no
+  version), else WARN. (Flag only; publish drains in the task body.)
+
+(No `/update/accepted` handling - not subscribed; see topic construction above.)
+
+### Execution model (do NOT apply in the callback)
+
+`_subscribeCallback` runs inside `_clientMqtt.loop()` (MQTT task). Applying a
+delta does blocking SPI/NVS writes and waits on `_configMutex`/`_channelDataMutex`
+(up to `CONFIG_MUTEX_TIMEOUT_MS` = 1000 ms) - doing that in the callback stalls
+`loop()` and MQTT keepalive (the #138 anti-pattern). So the callback only **copies
+the delta out** (the PSRAM message buffer is freed when the callback returns - see
+mqtt.cpp:838) and flags it. A new `_checkPublishShadows()` in `_handleConnectedState`
+(mqtt.cpp:1895, mirrors `_checkIfPublishMeterNeeded`) runs in the task body and:
+drains `applyPending` (-> `_handleDelta`), then drains `reportPending` (-> publish).
+Per-shadow pending buffer sized for the worst-case delta; only one pending delta
+per shadow (a newer delta overwrites - AWS will re-send if still divergent).
+
+Parse with `SpiRamAllocator` + `JsonDocument` (same pattern as
+`_handleCommandMessage`, mqtt.cpp:844). The 32 KB `MQTT_SUBSCRIBE_MESSAGE_BUFFER_SIZE`
+is the app-level copy; the binding constraint is the static PubSubClient RX buffer
+`MQTT_BUFFER_SIZE`, bumped to **9 KB** (08). With `/accepted` not subscribed, the
+worst-case inbound message is a delta (changed desired fields + their metadata),
+which the 9 KB buffer must hold without truncation.
+
+## Delta handler (`_handleDelta`) - the core
+
+```
+doc = parse(payload)                       // {state:{...}, version, clientToken}
+delta = doc["state"]                        // changed desired fields only
+out = {}                                    // {state:{reported:{}, desired:{}}}
+rep = out["state"]["reported"].to<JsonObject>()
+des = out["state"]["desired"].to<JsonObject>()
+
+desc.apply(delta, rep, /*unknownKeys*/...)  // applies + fills rep; lists unknowns
+for each key in delta NOT applied: WARN, (already added to des as null by apply)
+for each key in rep: des[key] = nullptr     // null every echoed field
+for each unknown key: des[key] = nullptr
+
+out["version"]     = state.version          // optimistic lock (omit if 0)
+out["clientToken"] = _newToken()            // esp_random hex
+publish(out -> <name>/update)
+```
+
+Key rule: **every key the device touches (applied or unknown) gets nulled in
+`desired`** in the same publish. That is the ack + intent-clear.
+
+## `publishReported(name)` (reconnect / periodic / event)
+
+```
+doc = {state:{reported:{}}}
+desc.report(doc)                            // module fills reported
+// NO version, NO desired  -> pending cloud desired survives (cloud-wins-on-reconnect)
+publish(doc -> <name>/update)
+```
+
+## `publishLocalEdit(name, changedFields)`
+
+```
+doc = {state:{reported: changedFields, desired:{<each changed key>: null}}}
+doc["clientToken"] = _newToken()
+publish(doc -> <name>/update)               // local wins: nulls pending desired
+```
+
+## clientToken / version helpers
+
+```cpp
+static void _newToken(char out[24]); // snprintf "%08x%08x", esp_random(), esp_random()
+```
+
+`esp_random()` is fine (hardware RNG, no WiFi dependency post-init).
+
+## mqtt.cpp integration points
+
+| Location | Change |
+|----------|--------|
+| `Mqtt::begin()` (mqtt.cpp:208 area) | call `Shadow::begin()` |
+| `_subscribeToTopics()` (mqtt.cpp:756) | call `Shadow::onMqttConnected()` |
+| `_subscribeCallback` dispatch (mqtt.cpp:833) | `if (Shadow::routeMessage(topic,message)) {}` first |
+
+`Shadow::onMqttConnected()` subscribes all shadows then sets `reportPending` for
+each; actual publishes drained in `_handleConnectedState` (mqtt.cpp:1895) via a
+new `_checkPublishShadows()` (mirrors `_checkIfPublishMeterNeeded`, mqtt.cpp:1407)
+so we publish from the MQTT task loop, not the callback.
+
+## Tests
+
+- **Native unit tests** (`pio test -e native`, run from WSL - see repo memory):
+  put pure delta-merge logic in `lib/shadow_logic/` (no Arduino deps):
+  - delta -> {reported, desired:null} doc shape (applied + unknown keys all nulled).
+  - version omitted when 0, included when known.
+  - local-edit doc shape.
+  Mock `ApplyFn` with a fake field map. This isolates the hard logic (00) from MQTT.
+- On-device: covered by 02/03 (reported-only, console-verifiable).
+
+## Acceptance
+
+- [ ] `lib/shadow_logic` unit tests pass (delta-ack shape, version gating, local-edit shape).
+- [ ] Subscribes + publishes reported for a registered no-op shadow on reconnect.
+- [ ] Unknown desired field -> nulled + WARN, no crash.
+- [ ] No `/get` publish anywhere.

--- a/source/docs/feature/2026-06-16-shadow-v2-config/01-scaffold-shadow-module.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/01-scaffold-shadow-module.md
@@ -34,8 +34,8 @@ namespace Shadow {
     bool routeMessage(const char* topic, const char* payload); // true if handled
     void publishReported(const char* name);                    // one shadow
 
-    // Called by modules on local edit (clears pending desired for changed fields):
-    void publishLocalEdit(const char* name, JsonObjectConst changedFields);
+    // Called by the mqtt.cpp task loop (drift-detect local edits + drain queued deltas):
+    void checkPublish();   // every ~3 s: republish any writable shadow whose reported drifted
 }
 ```
 
@@ -133,13 +133,19 @@ desc.report(doc)                            // module fills reported
 publish(doc -> <name>/update)
 ```
 
-## `publishLocalEdit(name, changedFields)`
+## `checkPublish()` - local-edit drift-detect (replaced `publishLocalEdit`)
 
 ```
-doc = {state:{reported: changedFields, desired:{<each changed key>: null}}}
-doc["clientToken"] = _newToken()
-publish(doc -> <name>/update)               // local wins: nulls pending desired
+for each writable shadow:
+  doc = {state:{reported:{}}}; desc.report(doc)   // rebuild current reported
+  if reported changed since last published snapshot:
+    publish(doc -> <name>/update)                 // reported-only: NO version, NO desired:null
 ```
+
+Source-agnostic: any local change (REST/UI/internal) reaches the shadow within ~3 s.
+Reported-only by design - it does **not** null `desired` (that would race in-flight
+cloud deltas); the cloud owns clearing `desired` (see 00, asymmetric desired-null
+decision). This replaced the original per-handler `publishLocalEdit`.
 
 ## clientToken / version helpers
 

--- a/source/docs/feature/2026-06-16-shadow-v2-config/02-info-shadow.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/02-info-shadow.md
@@ -1,0 +1,66 @@
+# 02 - `info` shadow (reported-only)
+
+**Goal:** publish static device identity to the `info` named shadow; retire the
+`system/static` retained topic publish. **Lowest risk, fully console-verifiable
+with no cloud backend** - this is the first hardware-provable phase.
+
+**Files:** `src/shadow.cpp` (register descriptor), `src/mqtt.cpp` (remove
+`_publishSystemStatic`), reuse `utils.cpp` sources.
+
+## Schema (flattened from `systemStaticInfoToJson`, utils.cpp:211)
+
+```json
+{ "state": { "reported": {
+  "firmware_version":  "2.1.0",          // FIRMWARE_BUILD_VERSION (constants.h:12)
+  "firmware_build_date":"Jun 15 2026",   // FIRMWARE_BUILD_DATE (constants.h:14)
+  "sketch_md5":        "<32hex>",        // ESP.getSketchMD5() (utils.cpp:46)
+  "hardware_profile":  "v6.1",           // globalHwProfile->version
+  "pcb_revision":      "v6.1",           // factory NVS FACTORY_KEY_PCB_REVISION
+  "community_mode":    false,            // globalCommunityMode
+  "device_id":         "588c81c47a00",   // DEVICE_ID (globals.h:9)
+  "serial_number":     "...",            // factory NVS FACTORY_KEY_SERIAL_NUMBER
+  "manufacturing_unix":0                 // factory NVS FACTORY_KEY_MFG_TS (ulong)
+}}}
+```
+
+Notes:
+- `sketch_md5` (`ESP.getSketchMD5()`) is the identity hash: the binary digest
+  proves whether the running firmware is the published build or a modified one
+  (git SHA can't - dirty/uncommitted trees lie). Same hash used for OTA validation.
+- `mac_address`: derive from `device_id` (insert colons) only if cloud needs it;
+  `device_id` already is the MAC. Omit to save bytes.
+- All values are read-only at runtime; no `apply` callback (`writable=false`).
+
+## ReportFn
+
+Reuse the sources `populateSystemStaticInfo`/`systemStaticInfoToJson` already
+read (utils.cpp). Write a thin `Shadow::reportInfo(doc)` that fills the flat
+keys above into `doc["state"]["reported"]`. Do not nest under `data`.
+
+## Publish cadence
+
+- On every MQTT (re)connect (via `Shadow::onMqttConnected`).
+- Once per 24 h via a low-priority `esp_timer` (identity rarely changes; keeps
+  shadow `lastUpdated` fresh). Add `_infoTimer` in shadow.cpp.
+
+## Retire `system/static`
+
+- Remove `_publishSystemStatic()` (mqtt.cpp:1277-1295), its topic buffer
+  `_mqttTopicSystemStatic`, `_setTopicSystemStatic()`, `MQTT_TOPIC_SYSTEM_STATIC`,
+  and the `_publishMqtt.systemStatic` flag + its check.
+- **Do this removal in 08 (cutover)**, not here, to keep this phase additive and
+  independently testable (info shadow live *alongside* system/static briefly).
+
+## Tests
+
+- On-device: enable cloud, reconnect, inspect `info` named shadow in AWS IoT
+  console (Manage > Things > <id> > Device Shadows). Confirm all fields present,
+  values match `/api/v1/system/info` (or existing static topic payload).
+- Confirm 24 h timer fires (temporarily shorten for bench).
+
+## Acceptance
+
+- [ ] `info` shadow reported state populated on connect; matches device identity.
+- [ ] No `desired`/delta handling (reported-only).
+- [ ] 24 h refresh timer works.
+- [ ] Worst-case payload < 1 KB.

--- a/source/docs/feature/2026-06-16-shadow-v2-config/03-issues-shadow.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/03-issues-shadow.md
@@ -1,0 +1,79 @@
+# 03 - `issues` shadow (reported-only)
+
+**Goal:** publish the runtime issue registry to the `issues` named shadow, on
+connect and on every registry state transition. **Console-verifiable, no cloud
+backend.** Builds on #145/#178 (`IssueRegistry`).
+
+**Files:** `src/shadow.cpp` (register), `src/issueregistry.cpp` (transition hook).
+
+## Schema (`IssueRegistry::issuesToJson`, issueregistry.cpp:123 - used verbatim)
+
+```json
+{ "state": { "reported": {
+  "active_count": 2,                       // derived: count isActive() states
+  "issues": [
+    { "code":"cloud_mqtt_disconnected", "state":"active_unacked",
+      "severity":"warning", "firstSeenUnix":1748000000,
+      "lastChangeUnix":1748001000, "occurrences":3,
+      "message":"..." },
+    { "code":"ct_polarity_flipped", "channel":2, "state":"cleared_unacked",
+      "severity":"info", "firstSeenUnix":..., "lastChangeUnix":...,
+      "occurrences":1, "message":"..." }
+  ]
+}}}
+```
+
+Field names are the registry's own (`code`, `firstSeenUnix`, `lastChangeUnix`,
+`occurrences`; `channel` omitted for global-scope issues). Do **not** rename to
+the issue's illustrative `id`/`first_occurred` - keep parity with REST + web UI.
+
+## ReportFn
+
+```cpp
+void reportIssues(JsonDocument& doc) {
+    JsonObject rep = doc["state"]["reported"].to<JsonObject>();
+    rep["active_count"] = IssueRegistry::activeCount();  // ADD: derive from isActive()
+    JsonDocument tmp; IssueRegistry::issuesToJson(tmp);  // {issues:[...]}
+    rep["issues"] = tmp["issues"];
+}
+```
+
+Add `IssueRegistry::activeCount()` (issueregistry.cpp): loop instances, count
+`IssueLogic::isActive(state)`. `issuesToJson` already takes `_registryMutex`.
+
+## Publish triggers
+
+- On MQTT (re)connect (via `onMqttConnected`).
+- On every transition: hook `_updateInstance` raise/clear edges
+  (issueregistry.cpp:491-492) and `ack`/`ackAll` (issueregistry.cpp:165/191).
+  Set a `_publishMqtt`-style flag, NOT a direct publish from the registry tick
+  (registry runs in its own task; cross-task publish must not touch PubSubClient).
+  Use `Shadow::requestReport("issues")` which sets `reportPending`; drained by
+  `_checkPublishShadows()` in the MQTT task loop.
+
+**Concurrency:** registry tick (separate task) only flips an atomic flag.
+`issuesToJson` is mutex-guarded. Shadow publish happens in MQTT task. No new locks.
+
+## Ack path (resolved): shadow desired/delta
+
+`issues` is **partially writable** - only the `ack` key. Cloud writes
+`desired.ack = ["code1", ...]`; on delta the device calls `IssueRegistry::ack()`
+per code, then publishes reported (updated states) + `desired.ack:null`. An ack
+is idempotent state intent, which fits desired/reported (Commands are for
+transient actions, not state). The `report` fields stay reported-only; only `ack`
+is accepted in a delta. Ship reported-only first (this doc), wire `ack` once the
+cloud writer exists.
+
+## Tests
+
+- On-device: trigger an issue (e.g. disable WiFi to raise `cloud_mqtt_disconnected`),
+  confirm `issues` shadow updates within one publish cycle; ack via REST, confirm
+  shadow reflects `active_acked` / removal.
+- Verify rate: rapid transitions coalesce (flag-based, one publish per loop), do
+  not exceed 20 RPS/thing.
+
+## Acceptance
+
+- [ ] `issues` shadow matches `/api/v1/issues` after each transition.
+- [ ] `active_count` correct.
+- [ ] Transitions coalesce into <=1 publish per MQTT loop interval.

--- a/source/docs/feature/2026-06-16-shadow-v2-config/04-system-shadow.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/04-system-shadow.md
@@ -1,0 +1,89 @@
+# 04 - `system` shadow (writable)
+
+**Goal:** mirror behavioural config in the `system` named shadow, applying cloud
+deltas. **First writable shadow - needs a cloud `desired` writer to test the
+inbound path.** Replaces the deprecated `command` sub-commands `set_send_power_data`
+and `set_mqtt_log_level`.
+
+**Files:** `src/shadow.cpp`, `src/mqtt.cpp` (setters already exist),
+`src/customlog.cpp` + `src/led.cpp` (expose setters if needed).
+
+## Scope (resolved) - 5 fields
+
+Only fields that are **configurable + persisted today**. `ntp_server`/`timezone`
+are out (NTP + TZ resolve automatically once cloud-connected; device runs UTC
+internally). `modbus_tcp_*` is out (hardcoded in firmware, not configurable).
+`log_level_save_file` does not exist. No follow-up plumbing in this work.
+
+```json
+{ "state": { "reported": {
+  "led_brightness":   75,        // Led::getBrightness/setBrightness, NVS led_ns/brightness (uint8 0..100)
+  "send_power_data":  true,      // Mqtt _sendPowerDataEnabled, NVS mqtt_ns/send_power (bool)
+  "mqtt_log_level":   "INFO",    // Mqtt _mqttLogLevelInt, NVS mqtt_ns/log_level_int (0..5)
+  "log_level_print":  "INFO",    // AdvancedLogger getPrintLevel/setPrintLevel
+  "log_level_save":   "WARNING"  // AdvancedLogger getSaveLevel/setSaveLevel
+}}}
+```
+
+Cloud contract: the backend must never write `ntp_server`/`timezone`/`modbus_*`
+to this shadow - they are out of scope and have no device-side setter.
+
+## Field -> setter map (ApplyFn)
+
+| Shadow field | Type | Setter | Persist |
+|---|---|---|---|
+| `led_brightness` | uint8 0..100 | `Led::setBrightness(v)` (led.cpp:210) | auto (`_saveConfiguration`) |
+| `send_power_data` | bool | `Mqtt::setSendPowerData(v)` (expose `_setSendPowerDataEnabled`, mqtt.cpp:512) | auto |
+| `mqtt_log_level` | enum str | `Mqtt::setMqttLogLevel(s)` (expose `_setMqttLogLevel`, mqtt.cpp:534) | persistent levels only - see below |
+| `log_level_print` | enum str | `AdvancedLogger::setPrintLevel(parse(s))` | lib-internal |
+| `log_level_save` | enum str | `AdvancedLogger::setSaveLevel(parse(s))` | lib-internal |
+
+ApplyFn validates each value (reuse existing range checks: `Led::isBrightnessValid`,
+the log-level string switch in `_setMqttLogLevel`). Invalid value -> skip that
+field, WARN, still null it in desired.
+
+`Mqtt::_setSendPowerDataEnabled` / `_setMqttLogLevel` are currently `static`;
+add thin public wrappers in the `Mqtt` namespace.
+
+## `mqtt_log_level` auto-revert (the one stateful sub-feature)
+
+- **Persistent levels** (`INFO`/`WARNING`/`ERROR`/`FATAL`): persist to NVS as new
+  baseline (existing `_saveMqttLogLevelToPreferences`). Cancel any revert timer.
+- **Transient levels** (`VERBOSE`/`DEBUG`): apply at runtime, **do not persist**.
+  Start/reset a 5-min one-shot `esp_timer`.
+- **Timer fires:** revert the runtime level to the persisted baseline, then **set
+  a `reportPending` flag for the `system` shadow** so the MQTT task publishes
+  `{reported:{mqtt_log_level:<baseline>}, desired:{mqtt_log_level:null}}`.
+  **Do NOT publish from the esp_timer task** - PubSubClient is not thread-safe;
+  the timer callback only flips state + flag (same rule as the `issues` registry
+  tick, 03). The MQTT-task `_checkPublishShadows()` drains the publish.
+- **Reboot while verbose:** comes back at persisted baseline (because not persisted).
+- Backend holds verbose by re-writing `desired.mqtt_log_level="DEBUG"` every <5 min.
+
+Implement with `esp_timer_create` one-shot, `esp_timer_start_once(5*60*1e6)`;
+restart on each transient set. Mirrors the existing remote-log-level workflow
+(repo memory: remote log level via MQTT/CloudWatch).
+
+## Local-edit hook
+
+`/api/v1/led/brightness` (customserver.cpp:2717) and `/api/v1/logs/level`
+(customserver.cpp:1800) PUT handlers -> after applying, call
+`Shadow::publishLocalEdit("system", {changed field})` so a local change nulls any
+pending cloud desired (local-wins-when-active, 00).
+
+## Tests
+
+- Native unit: ApplyFn field routing + validation (invalid value skipped+nulled);
+  auto-revert decision (persistent vs transient classification).
+- On-device (needs cloud writer): write `desired.led_brightness=20` -> device
+  applies, LED dims, reported=20, desired cleared. Write `desired.mqtt_log_level
+  ="DEBUG"` -> verbose for 5 min -> auto-revert to baseline + shadow reflects it.
+- Local: PUT brightness via REST -> shadow reported updates, pending desired cleared.
+
+## Acceptance
+
+- [ ] Trimmed schema only; backend contract notes excluded fields.
+- [ ] All 5 fields apply from delta, persist, echo reported + null desired.
+- [ ] `mqtt_log_level` transient auto-reverts after 5 min; persistent does not.
+- [ ] Local REST edits publish `{reported, desired:null}`.
+- [ ] Invalid values skipped + WARN, not applied.

--- a/source/docs/feature/2026-06-16-shadow-v2-config/04-system-shadow.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/04-system-shadow.md
@@ -48,28 +48,39 @@ add thin public wrappers in the `Mqtt` namespace.
 ## `mqtt_log_level` auto-revert (the one stateful sub-feature)
 
 - **Persistent levels** (`INFO`/`WARNING`/`ERROR`/`FATAL`): persist to NVS as new
-  baseline (existing `_saveMqttLogLevelToPreferences`). Cancel any revert timer.
-- **Transient levels** (`VERBOSE`/`DEBUG`): apply at runtime, **do not persist**.
-  Start/reset a 5-min one-shot `esp_timer`.
-- **Timer fires:** revert the runtime level to the persisted baseline, then **set
-  a `reportPending` flag for the `system` shadow** so the MQTT task publishes
-  `{reported:{mqtt_log_level:<baseline>}, desired:{mqtt_log_level:null}}`.
-  **Do NOT publish from the esp_timer task** - PubSubClient is not thread-safe;
-  the timer callback only flips state + flag (same rule as the `issues` registry
-  tick, 03). The MQTT-task `_checkPublishShadows()` drains the publish.
-- **Reboot while verbose:** comes back at persisted baseline (because not persisted).
+  baseline (existing `_saveMqttLogLevelToPreferences`). Cancel any revert timer and
+  **clear the reboot-restore marker**.
+- **Transient levels** (`VERBOSE`/`DEBUG`): apply at runtime (baseline NVS key
+  untouched), start/reset a 5-min one-shot `esp_timer`, **and persist a separate
+  reboot-restore marker** (`mqtt_ns/transient_log`, write-only-on-change so a
+  cloud-held verbose window doesn't wear flash).
+- **Timer fires:** revert the runtime level to the persisted baseline, **clear the
+  marker**, then **set a `reportPending` flag for the `system` shadow** so the MQTT
+  task republishes `mqtt_log_level=<baseline>`. **Do NOT publish from the esp_timer
+  task** - PubSubClient is not thread-safe; the timer callback only flips state +
+  flag (same rule as the `issues` registry tick, 03). The MQTT-task drains it.
+- **Reboot while verbose:** the marker survives, so on boot `Shadow::begin()`
+  restores the transient level and **restarts the 5-min timer** - a debug session
+  keeps boot-time logs. The persisted baseline is never overwritten by a transient.
+  (Tradeoff: a device that crash-loops faster than 5 min stays verbose until it
+  stabilizes; accepted, since a crash loop is exactly when boot logs are wanted.)
 - Backend holds verbose by re-writing `desired.mqtt_log_level="DEBUG"` every <5 min.
 
 Implement with `esp_timer_create` one-shot, `esp_timer_start_once(5*60*1e6)`;
 restart on each transient set. Mirrors the existing remote-log-level workflow
 (repo memory: remote log level via MQTT/CloudWatch).
 
-## Local-edit hook
+## Local-edit propagation (drift-detect)
 
-`/api/v1/led/brightness` (customserver.cpp:2717) and `/api/v1/logs/level`
-(customserver.cpp:1800) PUT handlers -> after applying, call
-`Shadow::publishLocalEdit("system", {changed field})` so a local change nulls any
-pending cloud desired (local-wins-when-active, 00).
+Local changes (REST/UI, or any internal write) are **not** hooked per-handler.
+`Shadow::checkPublish()` runs a source-agnostic drift check every
+`SHADOW_DRIFT_CHECK_INTERVAL_MS` (3 s) over the writable shadows: rebuild each
+`reported` doc, diff it against the last published snapshot, and republish on any
+change (reported-only, no `version`, **no `desired:null`**). A local edit therefore
+reaches the shadow within ~3 s. This replaced the earlier per-handler
+`publishLocalEdit` hook (removed). Implication: local edits no longer null
+`desired` - see 00 ("asymmetric desired-null semantic") for why that is safe in the
+current field set.
 
 ## Tests
 
@@ -78,12 +89,16 @@ pending cloud desired (local-wins-when-active, 00).
 - On-device (needs cloud writer): write `desired.led_brightness=20` -> device
   applies, LED dims, reported=20, desired cleared. Write `desired.mqtt_log_level
   ="DEBUG"` -> verbose for 5 min -> auto-revert to baseline + shadow reflects it.
-- Local: PUT brightness via REST -> shadow reported updates, pending desired cleared.
+  Reboot while verbose -> device restores DEBUG + restarts the 5-min timer.
+- Local: change brightness via REST/UI -> shadow reported updates within ~3 s
+  (drift-detect); reported-only, no `desired:null`.
 
 ## Acceptance
 
 - [ ] Trimmed schema only; backend contract notes excluded fields.
 - [ ] All 5 fields apply from delta, persist, echo reported + null desired.
-- [ ] `mqtt_log_level` transient auto-reverts after 5 min; persistent does not.
-- [ ] Local REST edits publish `{reported, desired:null}`.
+- [ ] `mqtt_log_level` transient auto-reverts after 5 min; persistent does not;
+      transient survives a reboot (restored + timer restarted); persistent-set and
+      auto-revert clear the marker.
+- [ ] Local edits reach the shadow within ~3 s via drift-detect (reported-only).
 - [ ] Invalid values skipped + WARN, not applied.

--- a/source/docs/feature/2026-06-16-shadow-v2-config/05-meter-shadow.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/05-meter-shadow.md
@@ -1,0 +1,72 @@
+# 05 - `meter` shadow (writable)
+
+**Goal:** mirror ADE7953 calibration + sample time in the `meter` named shadow.
+Needs a cloud writer to test inbound. Writes here are **rare** (devices are
+factory-calibrated; this is advanced recalibration only).
+
+**Files:** `src/shadow.cpp`, reuse `src/ade7953.cpp` config API.
+
+## Schema (matches `configurationToJson`, ade7953.cpp:622 - camelCase, struct `Ade7953Configuration`)
+
+```json
+{ "state": { "reported": {
+  "aVGain":4050000, "aIGain":4300000, "bIGain":4300000,
+  "aIRmsOs":0, "bIRmsOs":0,
+  "aWGain":4194304, "bWGain":4194304, "aWattOs":0, "bWattOs":0,
+  "aVarGain":4194304, "bVarGain":4194304, "aVarOs":0, "bVarOs":0,
+  "aVaGain":4194304, "bVaGain":4194304, "aVaOs":0, "bVaOs":0,
+  "phCalA":0, "phCalB":0,
+  "sample_time":200
+}}}
+```
+
+Use the firmware's existing JSON key names (`aVGain` ...), **not** the issue's
+`av_gain` illustrative names. NVS namespace `ade7953_ns`; calibration via
+`_saveConfigurationToPreferences` (ade7953.cpp:2684), sample time key
+`sample_time` (uint64, `putULong64`). Includes `aIRmsOs`/`bIRmsOs` which the
+issue's draft omitted.
+
+## ReportFn
+
+```cpp
+void reportMeter(JsonDocument& doc) {
+    JsonDocument cfg; Ade7953::getConfigurationAsJson(cfg);  // camelCase calibration
+    JsonObject rep = doc["state"]["reported"].to<JsonObject>();
+    for (auto kv : cfg.as<JsonObjectConst>()) rep[kv.key()] = kv.value();
+    rep["sample_time"] = Ade7953::getSampleTime();
+}
+```
+
+## ApplyFn
+
+- Calibration fields: collect into a `JsonDocument`, call
+  `Ade7953::setConfigurationFromJson(doc, /*partial=*/true)` (ade7953.cpp) -> it
+  takes `_configMutex`, applies to the chip, and persists. `partial=true` lets a
+  delta carry a subset.
+- `sample_time`: `Ade7953::setSampleTime(v)` (validates >= `MINIMUM_SAMPLE_TIME`
+  200 ms).
+- Echo applied fields into reported; null them in desired. Reject out-of-range
+  -> skip + WARN + null.
+
+Mutex: `setConfigurationFromJson` / `setSampleTime` already acquire
+`_configMutex` (ade7953.cpp) internally. ApplyFn must NOT hold `_shadowMutex`
+while calling them (call after releasing) to avoid lock-order inversion.
+
+## Local-edit hook
+
+`PUT/PATCH /api/v1/ade7953/config` and `PUT /api/v1/ade7953/sample-time`
+(customserver.cpp) -> `Shadow::publishLocalEdit("meter", changed)`.
+
+## Tests
+
+- Native unit: partial-delta merge into config doc; sample_time range guard.
+- On-device (cloud writer): write `desired.phCalB=42` -> applies, persists across
+  reboot, reported reflects it, desired cleared. Verify a power reading shifts as
+  expected for a known gain change on the bench.
+
+## Acceptance
+
+- [ ] Reported = current calibration (camelCase) + sample_time.
+- [ ] Partial deltas apply via `setConfigurationFromJson(partial=true)` + persist.
+- [ ] Out-of-range skipped + WARN + nulled.
+- [ ] No lock-order inversion (`_shadowMutex` released before `_configMutex`).

--- a/source/docs/feature/2026-06-16-shadow-v2-config/05-meter-shadow.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/05-meter-shadow.md
@@ -52,10 +52,13 @@ Mutex: `setConfigurationFromJson` / `setSampleTime` already acquire
 `_configMutex` (ade7953.cpp) internally. ApplyFn must NOT hold `_shadowMutex`
 while calling them (call after releasing) to avoid lock-order inversion.
 
-## Local-edit hook
+## Local-edit propagation (drift-detect)
 
-`PUT/PATCH /api/v1/ade7953/config` and `PUT /api/v1/ade7953/sample-time`
-(customserver.cpp) -> `Shadow::publishLocalEdit("meter", changed)`.
+No per-handler hook. Local edits via `PUT/PATCH /api/v1/ade7953/config` and
+`PUT /api/v1/ade7953/sample-time` (customserver.cpp) are picked up by
+`Shadow::checkPublish()`, which drift-detects the changed `reported` every 3 s and
+republishes (reported-only, no `desired:null`). See 04 / 00. (The earlier
+per-handler `publishLocalEdit` was removed.)
 
 ## Tests
 

--- a/source/docs/feature/2026-06-16-shadow-v2-config/06-channels-shadow.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/06-channels-shadow.md
@@ -1,0 +1,110 @@
+# 06 - `channels` shadow (writable)
+
+**Goal:** mirror per-channel config (17 channels, 0-16) in the `channels` named
+shadow, **object-keyed by index** (arrays are atomic in shadow deltas - keying by
+index lets the cloud patch one channel/one field). Needs a cloud writer to test.
+
+**Files:** `src/shadow.cpp`, reuse `src/ade7953.cpp` channel API.
+
+**Source of truth (resolved):** the `channels` shadow is canonical for channel
+config. The device **stops publishing the `channel` topic** (it was configurable
+state, not telemetry); cloud reads config from this shadow. Remove the `channel`
+topic publish in 08. (Topic version stays `v1`.)
+
+**Deploy sequencing (hard constraint):** the firmware change that *removes the
+`channel` publish* (08) must NOT ship to the fleet until the cloud
+channels-shadow ingestion is live. If firmware lands first, the `channel_handler`
+Lambda loses its input before the shadow path exists -> cloud channel config goes
+stale. Adding the `channels` shadow *publish* (this doc) is safe to ship anytime;
+only the removal is order-dependent.
+
+**Inbound delta size (buffer):** the worst-case *inbound* message is a bulk
+`desired` write across many channels with max-length `label`+`groupLabel` (64 B
+each) plus a per-field metadata block - roughly 2x the state. Compute this and
+confirm it fits `MQTT_BUFFER_SIZE` (9 KB); if not, the cloud writer must chunk
+channel `desired` to <= N channels/update (contract constraint in 00). The
+*outbound* reported publish streams and is not buffer-bound.
+
+## Schema (per channel = `channelDataToJson`, ade7953.cpp:970; NVS `channels_ns`)
+
+```json
+{ "state": { "reported": {
+  "0": { "active":true, "reverse":false, "label":"Main", "phase":1,
+         "ctSpecification":{"currentRating":50.0,"voltageOutput":0.333,"scalingFraction":0.0},
+         "groupLabel":"Group 0", "role":"GRID" },
+  "1": { ... },
+  "16":{ ... }
+}}}
+```
+
+Use firmware's actual shape: `phase` is **uint8** (1/2/3), CT params are nested
+under `ctSpecification` (`currentRating`/`voltageOutput`/`scalingFraction`),
+`groupLabel` (camelCase), `role` is an enum **string** (`GRID`/`LOAD`/`PV`/
+`BATTERY`/`INVERTER`). NOT the issue's flat `phase:"A"`, `ct_current`, etc.
+
+Size: 17 ch x ~200 B ~= 3.4 KB reported (metadata excluded from the 8 KB cap).
+Single shadow confirmed feasible. Validate worst-case with 63-char `label` +
+`groupLabel` once during impl (`NAME_BUFFER_SIZE` 64).
+
+## ReportFn
+
+```cpp
+void reportChannels(JsonDocument& doc) {
+    JsonObject rep = doc["state"]["reported"].to<JsonObject>();
+    for (uint8_t i=0;i<MAX_CHANNEL_COUNT;i++){
+        JsonDocument ch; Ade7953::getChannelDataAsJson(ch,i);  // {index,active,...}
+        ch.remove("index");                                    // index is the key
+        char k[3]; snprintf(k,sizeof k,"%u",i);
+        rep[k] = ch;
+    }
+}
+```
+
+## ApplyFn (nested delta routing - the tricky part)
+
+A delta can be `{"3":{"label":"Boiler"}}` (one field of one channel). For each
+top-level key that is a numeric channel index:
+
+```
+idx = atoi(key); if (idx>=MAX_CHANNEL_COUNT) { WARN; null; continue; }
+JsonDocument merged;
+Ade7953::getChannelDataAsJson(merged, idx);     // start from current
+deepMerge(merged, delta[key]);                   // overlay changed subfields
+merged["index"] = idx;
+Ade7953::setChannelDataFromJson(merged, /*partial=*/true, &roleChanged);
+// echo the CHANGED subfields into reported[key]; null desired[key] (whole object)
+```
+
+Invariant: channel 0 cannot be disabled - `setChannelData` already forces
+`active=true` for index 0 (ade7953.cpp:792). ApplyFn relies on that; do not
+duplicate the guard.
+
+Mutex: channel writes use **`_channelDataMutex`** (NOT `_configMutex`). Acquired
+inside `setChannelDataFromJson`/`setChannelData`. ApplyFn must not hold
+`_shadowMutex` across the call.
+
+`role` change side effects (`roleChanged`, transient re-read flags) are handled by
+`setChannelData` (`armTransients` default true). Pass through unchanged.
+
+## Local-edit hook
+
+`PUT/PATCH /api/v1/ade7953/channel` and `PUT /api/v1/ade7953/channels`
+(customserver.cpp) -> `Shadow::publishLocalEdit("channels", {"<idx>": changed})`.
+For the bulk endpoint, include each changed index.
+
+## Tests
+
+- Native unit: nested deep-merge (delta subfield -> full channel), index bounds,
+  channel-0 disable rejected, role string<->enum mapping.
+- On-device (cloud writer): write `desired.{"5":{"label":"X","active":true}}` ->
+  applies, persists, reported["5"] updated, desired cleared. Write `{"0":{"active":false}}`
+  -> rejected (stays active), nulled, WARN.
+- Worst-case size: fill all 17 labels+groupLabels to 63 chars, confirm reported < 8 KB.
+
+## Acceptance
+
+- [ ] Object-keyed reported for all 17 channels matches `/api/v1/ade7953/channel`.
+- [ ] Nested partial delta applies one field of one channel.
+- [ ] Channel 0 disable rejected + nulled.
+- [ ] Reported < 8 KB at worst case.
+- [ ] Uses `_channelDataMutex`; no lock-order inversion.

--- a/source/docs/feature/2026-06-16-shadow-v2-config/06-channels-shadow.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/06-channels-shadow.md
@@ -86,11 +86,13 @@ inside `setChannelDataFromJson`/`setChannelData`. ApplyFn must not hold
 `role` change side effects (`roleChanged`, transient re-read flags) are handled by
 `setChannelData` (`armTransients` default true). Pass through unchanged.
 
-## Local-edit hook
+## Local-edit propagation (drift-detect)
 
-`PUT/PATCH /api/v1/ade7953/channel` and `PUT /api/v1/ade7953/channels`
-(customserver.cpp) -> `Shadow::publishLocalEdit("channels", {"<idx>": changed})`.
-For the bulk endpoint, include each changed index.
+No per-handler hook. Local edits via `PUT/PATCH /api/v1/ade7953/channel` and
+`PUT /api/v1/ade7953/channels` (customserver.cpp, bulk included) are picked up by
+`Shadow::checkPublish()`, which drift-detects the changed channel object(s) every
+3 s and republishes (reported-only). See 04 / 00. (The earlier per-handler
+`publishLocalEdit` was removed.)
 
 ## Tests
 

--- a/source/docs/feature/2026-06-16-shadow-v2-config/07-commands.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/07-commands.md
@@ -67,11 +67,22 @@ In `_subscribeCallback`, match the **request topic precisely** - only
 
 ```cpp
 else if (strstr(topic,"/commands/things/") && endsWith(topic,"/request/json"))
-    _handleCommandExecution(topic, message);
+    _queueCommand(topic, message);            // copy + flag only; drained in task body
 else if (strstr(topic,"/commands/things/"))
     /* AWS echoed our own status publish (e.g. .../response/rejected/json). Ignore -
        never reprocess. */ ;
 ```
+
+**Process commands in the task body, not the callback.** `_subscribeCallback` only
+queues (`_queueCommand` copies the request into a single mutex-guarded slot);
+`_drainPendingCommand()` in the MQTT task loop calls `_handleCommandExecution`. The
+apply (per-channel NVS writes, up to ~1 s) and the status publishes must not run
+inside the PubSubClient callback - same rule as shadow deltas (#138), and publishing
+there also reuses PubSubClient's buffer, corrupting the QoS1 PUBACK it writes after
+the callback. `loop()` delivers one PUBLISH per call and the body drains every
+iteration, so one slot suffices; an overwrite is logged (never silently dropped).
+The dev `inject-command` shim routes through the same queue + drain, so it exercises
+the real processing path.
 
 **Do NOT** match the broad `strstr("/commands/things/") && strstr("/executions/")`:
 it also catches AWS's `.../response/rejected/json` echo of a status publish AWS

--- a/source/docs/feature/2026-06-16-shadow-v2-config/07-commands.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/07-commands.md
@@ -47,23 +47,38 @@ thing when issuing `factory_reset` (also noted as a cloud-writer constraint in 0
 ```json
 { "status":"IN_PROGRESS" }
 { "status":"SUCCEEDED" }
-{ "status":"FAILED",   "statusReason":{"reasonCode":"...","reasonDescription":"..."} }
-{ "status":"REJECTED", "statusReason":{"reasonCode":"stale_command",...} }
+{ "status":"FAILED",   "statusReason":{"reasonCode":"BAD_PAYLOAD","reasonDescription":"..."} }
+{ "status":"REJECTED", "statusReason":{"reasonCode":"STALE_COMMAND",...} }
 ```
 
 States: CREATED(cloud) -> IN_PROGRESS -> SUCCEEDED/FAILED/REJECTED/TIMED_OUT.
 Publish IN_PROGRESS on accept, terminal status when done.
 
+**`reasonCode` MUST be uppercase** - AWS requires the pattern `[A-Z0-9_-]+` and
+rejects the status update otherwise. Device codes: `BAD_PAYLOAD`,
+`MISSING_OPERATION`, `STALE_COMMAND`, `CONFIRM_MISMATCH`, `BAD_CHANNELS`,
+`UNKNOWN_OPERATION`. `reasonDescription` is free text. (The happy path
+IN_PROGRESS->SUCCEEDED sends no `statusReason`.)
+
 ## Handler routing
 
-In `_subscribeCallback` (mqtt.cpp:833), before the legacy `command` check:
+In `_subscribeCallback`, match the **request topic precisely** - only
+`.../request/json` (the subscribed topic) is an inbound command:
 
 ```cpp
-if (strstr(topic,"/commands/things/") && strstr(topic,"/executions/")) {
-    _handleCommandExecution(topic, message);   // parse execId from topic
-    return;
-}
+else if (strstr(topic,"/commands/things/") && endsWith(topic,"/request/json"))
+    _handleCommandExecution(topic, message);
+else if (strstr(topic,"/commands/things/"))
+    /* AWS echoed our own status publish (e.g. .../response/rejected/json). Ignore -
+       never reprocess. */ ;
 ```
+
+**Do NOT** match the broad `strstr("/commands/things/") && strstr("/executions/")`:
+it also catches AWS's `.../response/rejected/json` echo of a status publish AWS
+rejected (e.g. unknown/expired execution, or a malformed status). That echo has no
+`operation`, so the handler re-rejects it -> publishes again -> AWS echoes again ->
+**infinite ~110 ms publish loop**. A lowercase `reasonCode` (see above) would have
+triggered the same loop in production. Found + fixed during command testing on .174.
 
 `_handleCommandExecution`: extract `<execId>` between `/executions/` and
 `/request/`; parse JSON; staleness check; dispatch on `operation`; publish status.

--- a/source/docs/feature/2026-06-16-shadow-v2-config/07-commands.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/07-commands.md
@@ -1,0 +1,109 @@
+# 07 - IoT Commands (transient operations)
+
+**Goal:** migrate transient operations off the deprecated `command` topic to AWS
+IoT Core **Commands** (GA): `restart`, `factory_reset`, `energy_reset`. Jobs stay
+OTA-only. Needs cloud command templates + a dispatcher to test end-to-end.
+
+**Files:** new `_handleCommandExecution` in `src/mqtt.cpp` (or `commands.cpp`),
+alongside the existing Jobs router.
+
+## Verified protocol (plain MQTT sub/pub, PubSubClient-compatible)
+
+Device does **not** know `executionId` ahead of time -> subscribe with wildcard,
+parse the id from the received topic, publish status to the matching response topic.
+
+```
+SUBSCRIBE (request):  $aws/commands/things/<DEVICE_ID>/executions/+/request/+
+PUBLISH   (response): $aws/commands/things/<DEVICE_ID>/executions/<execId>/response/json
+SUBSCRIBE (optional): .../executions/<execId>/response/accepted/+   (ack from cloud)
+```
+
+`+` last segment = payload-format (`json`/`cbor`); we use `json`. MQTT 3.1.1 is
+supported. **The device IoT policy must grant `$aws/commands/things/<thing>/*`**
+(sub/receive/publish) - it currently only covers `$aws/things/*` (see 00 cloud checklist).
+
+## Request payload (from the command template)
+
+```json
+{ "operation":"restart" }                          // restart
+{ "operation":"factory_reset", "confirm":"<device_id>" }  // anti-fat-finger
+{ "operation":"energy_reset", "channels":[3,7] }   // or "channels":"all"
+```
+
+**staleness guard:** reject any command older than 5 min (avoids acting on a
+command queued during an offline window). Mirror the OTA `_otaRebootPending`/age
+-check style. **VERIFY (final payload review):** the guard needs a server
+timestamp the device can read - confirm the Commands request payload carries one,
+or have the command template inject `createdAt` via a parameter. If neither is
+available, the staleness guard has nothing to check.
+
+**factory_reset vs lingering desired (VERIFY / contract):** after a reset the
+device reports defaults; any pending cloud `desired` would be delta'd back and
+partially undo the reset. The backend must clear all shadows' `desired` for the
+thing when issuing `factory_reset` (also noted as a cloud-writer constraint in 00).
+
+## Response (UpdateCommandExecution)
+
+```json
+{ "status":"IN_PROGRESS" }
+{ "status":"SUCCEEDED" }
+{ "status":"FAILED",   "statusReason":{"reasonCode":"...","reasonDescription":"..."} }
+{ "status":"REJECTED", "statusReason":{"reasonCode":"stale_command",...} }
+```
+
+States: CREATED(cloud) -> IN_PROGRESS -> SUCCEEDED/FAILED/REJECTED/TIMED_OUT.
+Publish IN_PROGRESS on accept, terminal status when done.
+
+## Handler routing
+
+In `_subscribeCallback` (mqtt.cpp:833), before the legacy `command` check:
+
+```cpp
+if (strstr(topic,"/commands/things/") && strstr(topic,"/executions/")) {
+    _handleCommandExecution(topic, message);   // parse execId from topic
+    return;
+}
+```
+
+`_handleCommandExecution`: extract `<execId>` between `/executions/` and
+`/request/`; parse JSON; staleness check; dispatch on `operation`; publish status.
+
+## Per-operation
+
+| op | action | maps to existing |
+|----|--------|------------------|
+| `restart` | `setRestartSystem("Command: restart")` (publish SUCCEEDED first, then reboot delayed) | `_handleRestartMessage` (mqtt.cpp:875) |
+| `factory_reset` | require `confirm==DEVICE_ID` else REJECTED; wipe user NVS, keep factory NVS | existing factory-reset path (utils/customserver) |
+| `energy_reset` | reset cumulative kWh for listed channels or all | existing energy-reset path (ade7953) |
+
+`restart`/`factory_reset` reboot: publish SUCCEEDED, `delay(2000)` to flush
+(same pattern as OTA reboot, mqtt.cpp:1054), then restart.
+
+## Removed (in 08)
+
+`MQTT_TOPIC_SUBSCRIBE_COMMAND`, `_subscribeCommand`, `_handleCommandMessage`,
+`_handleSetSendPowerDataMessage`, `_handleSetMqttLogLevelMessage`,
+`_handleRestartMessage` (mqtt.cpp:776/841-913). `set_send_power_data` /
+`set_mqtt_log_level` are replaced by the `system` shadow (04).
+
+## Cloud side (energyme-infra, for the contract)
+
+- `CreateCommand` x3 (namespace `AWS-IoT`) with the payloads above.
+- Dispatcher Lambda/service calling `StartCommandExecution`.
+- Policy statement for `$aws/commands/...` (item 1 in 00 cloud checklist).
+
+## Tests
+
+- On-device (needs cloud command): `StartCommandExecution` restart -> device
+  publishes IN_PROGRESS then SUCCEEDED, reboots. factory_reset with wrong
+  `confirm` -> REJECTED, no wipe. energy_reset `[3]` -> only ch3 counter zeroed.
+- Staleness: start a command, keep device offline 6 min, reconnect -> REJECTED
+  `stale_command`.
+
+## Acceptance
+
+- [ ] Wildcard request subscribe; execId parsed from topic; JSON status to response topic.
+- [ ] All 3 ops work end-to-end on dev AWS.
+- [ ] factory_reset confirm guard enforced.
+- [ ] Commands >5 min old rejected.
+- [ ] OTA Jobs path unchanged.

--- a/source/docs/feature/2026-06-16-shadow-v2-config/08-v2-cutover.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/08-v2-cutover.md
@@ -1,0 +1,99 @@
+# 08 - config-topic retirement + 2.1.0 release
+
+**Goal:** stop publishing the retired config topics/handlers, bump **firmware** to
+2.1.0. **Last phase** - everything above is additive. **No topic-version bump:**
+`MQTT_TOPIC_VERSION` stays `"v1"`.
+
+**Files:** `include/mqtt.h`, `src/mqtt.cpp`, `platformio.ini`/version.
+
+## No topic version bump (decision)
+
+A topic version signals an **incompatible payload/contract change**. None of the
+surviving topics change payload (`meter`/`log`/`statistics`/`crash`/`system/dynamic`
+are byte-identical). The migration is **additive** (shadows + Commands are net-new
+`$aws/things/...` / `$aws/commands/...` topics, version-independent by
+construction) and **subtractive** (`system/static`, `command`, `channel` just stop
+being published). Keeping `v1` avoids rule duplication, a parallel-rules rollout
+window, device-policy ARN migration, and the "delete v1 early = data loss"
+footgun. Version-when-you-break: bump a specific topic the day its payload changes,
+not preemptively.
+
+`system/dynamic` -> `system` rename is **dropped** (cosmetic; only existed to
+disambiguate from the now-gone `system/static`). Keep `system/dynamic` as-is - no
+new rule, and no name collision with the `system` shadow.
+
+## Topic map
+
+| Topic | Action | Reason |
+|---|---|---|
+| `energyme/home/v1/<id>/system/static` | retired (stop publishing) | -> `info` shadow (02) |
+| `energyme/home/v1/<id>/command` (subscribe) | retired | -> Commands (07) + `system` shadow (04) |
+| `energyme/home/v1/<id>/channel` | retired (stop publishing) | configurable state -> `channels` shadow (06) |
+| `energyme/home/v1/<id>/system/dynamic` | **kept**, unchanged | telemetry, payload identical |
+| `meter`, `log`, `statistics`, `crash` | **kept**, unchanged | telemetry, payload identical |
+
+**Principle:** telemetry topics carry only measurements/statistics/dynamic
+runtime; configurable state moves to shadows. WiFi creds stay local-only (never shadow).
+
+Cloud: the 3 retired topics' v1 rules go idle (zero cost with no producer); delete
+them whenever convenient. No rollout window, no ingest gap (surviving topics are
+untouched).
+
+**Deploy sequencing (hard constraint):** do NOT ship the `channel` and
+`system/static` publish removals to the fleet until the cloud shadow-ingestion
+path (`channels`/`info`) is live. Removing them first leaves the
+`system_static`/`channel_handler` Lambdas without input before the shadow path
+exists -> stale cloud device state. Shadow *publishes* (02-06) are safe earlier;
+only these removals are order-dependent.
+
+## Removals (firmware)
+
+- `_publishSystemStatic` + `_mqttTopicSystemStatic` + `_setTopicSystemStatic` +
+  `MQTT_TOPIC_SYSTEM_STATIC` + `_publishMqtt.systemStatic` (mqtt.cpp:1277, 57, 749).
+- `MQTT_TOPIC_SUBSCRIBE_COMMAND`, `_subscribeCommand` (mqtt.cpp:776),
+  `_handleCommandMessage` (841), `_handleSetSendPowerDataMessage`,
+  `_handleSetMqttLogLevelMessage`, `_handleRestartMessage`.
+- The `endsWith(topic, MQTT_TOPIC_SUBSCRIBE_COMMAND)` branch in `_subscribeCallback`.
+- `_publishChannel` + `_mqttTopicChannel` + `_setTopicChannel` + `MQTT_TOPIC_CHANNEL`
+  + `_publishMqtt.channel` + `requestChannelPublish()` (channel config -> `channels` shadow).
+
+`MQTT_TOPIC_VERSION`, `MQTT_TOPIC_SYSTEM_DYNAMIC`, and the telemetry topic defines
+are **unchanged**.
+
+## Buffer
+
+- `mqtt.h` `MQTT_BUFFER_SIZE (5*1024)` -> `(9*1024)`. Sized for the worst-case
+  **inbound delta** (cloud setting `desired` on many/all channel fields at once +
+  their per-field metadata), the largest message the static PubSubClient RX buffer
+  must hold once `/update/accepted` is intentionally NOT subscribed (01). The 8 KB
+  figure is the shadow *state* quota (metadata-excluded); the *wire* message
+  including metadata can exceed it, hence 9 KB + framing headroom.
+  **Hardware-verify item:** the 5 KB baseline already saw esp-aes alloc failures
+  during MQTT-TLS handshake under heap pressure (repo memory: 2.0.0 heap pressure).
+  Nearly doubling the static buffer adds pressure at exactly that point.
+  Bench-verify TLS connect + free-heap after the bump on a real device before
+  merging; if tight, free it between uses or move to PSRAM.
+
+## Firmware version bump
+
+- 2.0.x -> **2.1.0** (minor: new cloud config surface). This is the **firmware**
+  semver, NOT a topic version. Per repo convention it is a **separate release step
+  on `development`**, NOT inside a feature branch. Do it when cutting the release,
+  not during 01-07.
+
+## Tests
+
+- Full regression: surviving telemetry still ingested on v1; local REST API
+  unchanged; OTA Job still works; all 5 shadows + 3 Commands functional on dev.
+- Confirm no firmware references to removed defines/handlers remain (grep).
+- Confirm a 2.0.x device and a 2.1.0 device both ingest the surviving v1 topics
+  (no cloud change needed for those).
+
+## Acceptance (rolls up #159 criteria, topic-version item dropped)
+
+- [ ] `MQTT_TOPIC_VERSION` unchanged (`v1`); surviving telemetry topics unchanged.
+- [ ] `command` topic + handlers removed; `system/static` + `channel` publishes removed.
+- [ ] `MQTT_BUFFER_SIZE` = 9 KB, hardware-verified for TLS/heap.
+- [ ] No local REST API regression.
+- [ ] Firmware 2.1.0 (separate release step).
+- [ ] Surviving telemetry payload contents unchanged.

--- a/source/docs/feature/2026-06-16-shadow-v2-config/PROGRESS.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/PROGRESS.md
@@ -2,20 +2,26 @@
 
 Legend: ⬜ not started · 🟡 in progress · ✅ done · ⛔ blocked
 
-_Last updated: 2026-06-16 (planning complete, validated with cloud side)._
+_Last updated: 2026-06-17 (01-07 implemented + hardware-verified on dev .174; 08 buffer bump done, removals pending)._
 
 ## Phases (firmware)
 
-| # | Phase | Status | PR | Provable without cloud? | Notes |
-|---|-------|--------|----|-------------------------|-------|
-| 01 | scaffold `shadow` module | ⬜ | - | yes (native unit tests) | core protocol; build first |
-| 02 | `info` shadow | ⬜ | - | **yes** (AWS console) | retire `system/static` deferred to 08 |
-| 03 | `issues` shadow | ⬜ | - | **yes** (AWS console) | ack path wired later |
-| 04 | `system` shadow | ⬜ | - | no (needs desired writer) | 5 fields + mqtt_log_level auto-revert |
-| 05 | `meter` shadow | ⬜ | - | no | ADE7953 calibration |
-| 06 | `channels` shadow | ⬜ | - | no | drops `channel` topic |
-| 07 | Commands | ⬜ | - | no (needs dispatcher) | restart/factory_reset/energy_reset |
-| 08 | config-topic retirement + fw 2.1.0 | ⬜ | - | n/a | topic stays v1; remove command/static/channel, buffer bump |
+Inbound apply path is verified on real hardware via an ENV_DEV-only synthetic
+delta/command injection (`POST /api/v1/shadow/inject-delta`, `.../inject-command`),
+which feeds the real `routeMessage -> drain -> apply -> ack` path with no cloud
+desired-writer. Outbound verified by reading shadows with `aws iot-data
+get-thing-shadow` (admin-dev).
+
+| # | Phase | Status | PR | Verified on dev .174 | Notes |
+|---|-------|--------|----|----------------------|-------|
+| 01 | scaffold `shadow` module | ✅ | - | yes (25 native tests + on-device) | core protocol |
+| 02 | `info` shadow | ✅ | - | yes (AWS read: identity + sketch_md5) | retire `system/static` deferred to 08 |
+| 03 | `issues` shadow | ✅ | - | yes (registry observer + active_count) | ack path wired later |
+| 04 | `system` shadow | ✅ | - | yes (inject led_brightness -> applied) | 5 fields + mqtt_log_level auto-revert |
+| 05 | `meter` shadow | ✅ | - | yes (inject sample_time -> applied/restored) | ADE7953 calibration |
+| 06 | `channels` shadow | ✅ | - | yes (deep-merge + channel-0 invariant) | drops `channel` topic in 08 |
+| 07 | Commands | ✅ | - | code + native tests; e2e needs cloud dispatcher | restart/factory_reset/energy_reset; policy already allows `$aws/commands/*` |
+| 08 | config-topic retirement | 🟡 | - | buffer bump 9 KB verified (heap ~42 KB min free, connects) | removals pending (isolated commit); NO fw version bump here |
 
 ## Decisions log (resolved)
 

--- a/source/docs/feature/2026-06-16-shadow-v2-config/PROGRESS.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/PROGRESS.md
@@ -1,0 +1,89 @@
+# Progress - shadow v2.1.0
+
+Legend: ⬜ not started · 🟡 in progress · ✅ done · ⛔ blocked
+
+_Last updated: 2026-06-16 (planning complete, validated with cloud side)._
+
+## Phases (firmware)
+
+| # | Phase | Status | PR | Provable without cloud? | Notes |
+|---|-------|--------|----|-------------------------|-------|
+| 01 | scaffold `shadow` module | ⬜ | - | yes (native unit tests) | core protocol; build first |
+| 02 | `info` shadow | ⬜ | - | **yes** (AWS console) | retire `system/static` deferred to 08 |
+| 03 | `issues` shadow | ⬜ | - | **yes** (AWS console) | ack path wired later |
+| 04 | `system` shadow | ⬜ | - | no (needs desired writer) | 5 fields + mqtt_log_level auto-revert |
+| 05 | `meter` shadow | ⬜ | - | no | ADE7953 calibration |
+| 06 | `channels` shadow | ⬜ | - | no | drops `channel` topic |
+| 07 | Commands | ⬜ | - | no (needs dispatcher) | restart/factory_reset/energy_reset |
+| 08 | config-topic retirement + fw 2.1.0 | ⬜ | - | n/a | topic stays v1; remove command/static/channel, buffer bump |
+
+## Decisions log (resolved)
+
+1. **`system` scope** - ship 5 configurable fields (`led_brightness`,
+   `send_power_data`, `mqtt_log_level`, `log_level_print`, `log_level_save`).
+   `ntp`/`timezone` out (auto via cloud/NTP, device is UTC). `modbus_*` out
+   (hardcoded, not configurable).
+2. **Configurable state = shadow-only** - device drops `channel` and
+   `system/static` publishes; `channels`/`info` shadows are canonical. Telemetry
+   topics carry only measurements/statistics/dynamic runtime. WiFi creds stay
+   local-only (never in a shadow).
+3. **`issues` ack** - via shadow desired/delta (`desired.ack=[codes]`), not a
+   Command (ack is idempotent state intent).
+4. **Identity hash** - `sketch_md5` (`ESP.getSketchMD5()`), NOT git commit: the
+   binary digest proves published-vs-modified build; a git SHA lies on
+   dirty/uncommitted trees.
+5. **No `/update/accepted` subscription** - its full-state+metadata echo is the
+   largest inbound message; `version` is sourced from the delta payload instead.
+6. **No topic-version bump** - `MQTT_TOPIC_VERSION` stays `v1`; no surviving topic
+   changes payload. Migration is additive (`$aws/...` shadows/Commands) +
+   subtractive (3 config topics stop publishing). Avoids rule duplication, rollout
+   window, policy-ARN migration, and the delete-v1-early footgun. Zero ingest gap.
+   `system/dynamic`->`system` rename dropped (cosmetic).
+7. **Deltas applied in the MQTT task body, NOT the RX callback** - callback copies
+   the delta out + flags; apply (blocking SPI/NVS + mutex up to 1s) runs in
+   `_checkPublishShadows()` so it can't stall `loop()`/keepalive (#138). Same rule
+   for the `mqtt_log_level` revert timer and `issues` tick: flag, never publish
+   cross-task (PubSubClient not thread-safe).
+8. **Cloud-writer contract constraints** - backend chunks `channels` `desired` to
+   <= N channels/update (RX buffer), and clears all `desired` on `factory_reset`.
+
+## Deploy sequencing (hard)
+
+Do NOT ship the `channel`/`system/static` **publish removals** (08) to the fleet
+until the cloud `channels`/`info` shadow-ingestion is live - else the
+`channel_handler`/`system_static` Lambdas lose input and cloud state goes stale.
+Shadow publishes (02-06) are safe to ship earlier; only removals are order-dependent.
+
+## Cloud-side dependencies (EXTERNAL - energyme-infra, not this repo)
+
+Reference only; implemented + tracked in the cloud repo. Listed so the firmware
+contract is validated end-to-end.
+
+| Item | Status | Blocks |
+|------|--------|--------|
+| `$aws/commands/things/<thing>/*` policy statement | ⬜ (agreed to add) | 07 end-to-end test |
+| Shadow ingestion Lambda + rule -> existing `device-ops` table (no new table) | ⬜ | 04/05/06 + reading reported |
+| Desired-state writer ("Intelligence" backend) | ⬜ | 04/05/06 inbound test |
+| 3 command templates + `StartCommandExecution` dispatcher | ⬜ | 07 end-to-end test |
+| Retire idle `system/static`/`command`/`channel` rules (whenever) | ⬜ | cleanup only |
+
+## Hardware-verify items
+
+- `MQTT_BUFFER_SIZE` 5 KB -> 9 KB: re-check TLS handshake + free heap on a real
+  device (known esp-aes alloc pressure at the 5 KB baseline). See 08.
+- `channels` worst-case **inbound delta** (bulk `desired`, 64-char labels +
+  metadata, ~2x state) fits `MQTT_BUFFER_SIZE` 9 KB; else cloud must chunk. See 06.
+- (Final review verifies) Commands request carries a server timestamp for the
+  staleness guard; backend clears `desired` on `factory_reset`. See 07.
+
+## Final gate + post-MVP
+
+- **Final payload-shape review** (firmware + cloud together) before "done":
+  confirm every shadow/command payload has exactly what's needed. See 00.
+- **Post-MVP** (next iteration, not in 01-08): WiFi info (SSID/RSSI/IP, non-secret)
+  + WiFi actions (reconnect/rescan) as shadow/Commands; remaining REST config not
+  yet mirrored; `issues` ack wiring. Creds stay local-only.
+
+## Next step
+
+Implement **01 - scaffold** (`lib/shadow_logic` native unit tests first).

--- a/source/docs/feature/2026-06-16-shadow-v2-config/PROGRESS.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/PROGRESS.md
@@ -2,9 +2,56 @@
 
 Legend: ⬜ not started · 🟡 in progress · ✅ done · ⛔ blocked
 
-_Last updated: 2026-06-17 (session 2: drift-detect, transient-verbose reboot
-restore, issues boot-race fix, wifi shadow, command reasonCode casing - all
-committed + hardware-verified on .174)._
+_Last updated: 2026-06-17 (session 3: real broker-delivered shadow e2e via admin-dev
+`desired` writes - full writable matrix + bulk buffer stress + reject paths verified on
+.174; surfaced the asymmetric-null cloud-contract finding below)._
+
+## Update 2026-06-17 (session 3 - REAL broker-delivered shadow e2e via admin-dev)
+
+Closed the gap #190 listed as cloud-gated: drove `desired` writes against the **dev
+shadows** with `aws iot-data update-thing-shadow` (admin-dev) - the real AWS->broker
+->device delta path the dev `inject-delta` shim could not exercise. UDP-correlated on
+.174 (build `c509e555`).
+
+- **Writable matrix (system/meter/channels), real deltas:** brightness, send_power_data,
+  log levels, sample_time, calibration (phCalB, aIRmsOs/bIRmsOs), channel label/active/
+  role, multi-field + multi-channel deltas - all apply -> persist -> report -> null
+  `desired`, ~1 s round trip. Each delta `routeMessage`-queued then `_applyDelta`'d in
+  the **task body** (deferred, not the callback) - confirmed in UDP.
+- **Reject paths all run real validation (not silent drops):** WARN observed for
+  led_brightness 200 (range), mqtt_log_level BOGUS (unknown), sample_time 50 (<min),
+  channel 0 disable (blocked), channel key 99 (invalid) - each still completes the ack
+  that nulls `desired` (no stuck delta / loop).
+- **Bulk buffer stress (06's worst case):** 16-channel delta, 63-char label+groupLabel
+  each, arrived as a single **3848-byte** inbound message and applied (<9 KB
+  `MQTT_BUFFER_SIZE`). Single-shadow channels path confirmed feasible; no cloud chunking
+  needed for label+groupLabel.
+- **Concurrency + lifecycle paths all verified:** (a) local+cloud interplay - drift(local)
+  + delta(cloud) on different fields converge, cloud-after-local wins; (b) idle 30 s - 0
+  spurious version bumps; (c) reported-only shadow write (`wifi`) inert (writable-gated
+  subscribe, confirmed `shadow.cpp:191` + UDP); (d) NVS persistence across reboot
+  (brightness/levels/sample_time/calib/labels/role); (e) transient `mqtt_log_level` full
+  lifecycle - cloud-set DEBUG -> survives reboot (restored + 5-min timer restarted,
+  baseline untouched) -> auto-reverted to INFO at exactly 5 min; (f) **offline->reconnect-
+  apply** - `desired` written while device off-broker (cloud disabled via API) applied on
+  reconnect via reported-first->re-delta (cloud-wins-on-reconnect, 00 line 82); (g) **409
+  optimistic-concurrency** forced via rapid double-writes - device re-publishes reported
+  *without* version, fresh delta applies, converges to latest; 1 conflict/round, **no loop**
+  (00 lines 96-100). All UDP-correlated.
+
+### FINDING (no firmware change) - asymmetric-null seam needs the cloud contract
+
+A cloud `desired` written **equal to** `reported` (a no-op write, or re-asserting an
+already-satisfied value) produces **no delta** (AWS only deltas on `desired != reported`).
+A no-GET device nulls `desired` only in the delta-ack, so it never sees or clears that
+`desired`. The stuck `desired` then **reverts the next local edit** to the field.
+*Reproduced on .174:* `desired.led_brightness=44` when reported already 44 -> local REST
+88 -> reverted to 44 in ~2 s. Resolution is the **cloud contract** (cloud owns clearing
+`desired`: write-to-change then `desired:null` after convergence; never write
+`desired==reported`/re-assert) - documented in `00-overview-and-contract.md`. A
+device-side drift-null was considered and rejected (trades it for a coincident-write
+race; needs the avoided GET). **Not a #190 blocker** - the trigger needs the (unbuilt)
+cloud writer; firmware is correct under the contract.
 
 ## Update 2026-06-17 (session 2 - post-MVP hardening, committed + verified on .174)
 

--- a/source/docs/feature/2026-06-16-shadow-v2-config/PROGRESS.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/PROGRESS.md
@@ -36,6 +36,14 @@ On top of the 01-08 MVP (now **6 shadows**):
   bug above) would have *triggered* this loop in production - both fixes needed.
   Real broker-delivered command on `/request/json` still pending the cloud dispatcher
   (inject bypasses the RX router, so that match condition is not yet hardware-exercised).
+- **Commands now processed in the task body, not the PubSubClient callback:**
+  `_subscribeCallback` queues the request (`_queueCommand`, single mutex-guarded slot,
+  warn-on-overwrite); `_drainPendingCommand()` in the MQTT loop runs the apply +
+  status publishes. Avoids blocking the callback on per-channel NVS writes (#138) and
+  the QoS1-PUBACK buffer corruption from publishing inside `loop()`. The dev inject
+  now shares this queue+drain, so the inject suite exercises the real processing path
+  (only the RX-callback enqueue itself stays cloud-gated). factory_reset verified
+  end-to-end on .174 (IN_PROGRESS->SUCCEEDED->wipe->reboot; confirm-guard rejects).
 
 ## Update 2026-06-17 (corrected root cause + topic fix - SUPERSEDES the banner below)
 

--- a/source/docs/feature/2026-06-16-shadow-v2-config/PROGRESS.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/PROGRESS.md
@@ -2,26 +2,63 @@
 
 Legend: ⬜ not started · 🟡 in progress · ✅ done · ⛔ blocked
 
-_Last updated: 2026-06-17 (01-07 implemented + hardware-verified on dev .174; 08 buffer bump done, removals pending)._
+_Last updated: 2026-06-17 (all 8 phases implemented + committed; MQTT storm
+root-caused + fixed; cutover build hardware-verified stable on dev .174)._
 
-## Phases (firmware)
+## RESOLVED - MQTT reconnect storm root cause (2026-06-17)
 
-Inbound apply path is verified on real hardware via an ENV_DEV-only synthetic
-delta/command injection (`POST /api/v1/shadow/inject-delta`, `.../inject-command`),
-which feeds the real `routeMessage -> drain -> apply -> ack` path with no cloud
-desired-writer. Outbound verified by reading shadows with `aws iot-data
-get-thing-shadow` (admin-dev).
+A persistent **MQTT reconnect storm** (broker closes the session ~30 ms after
+CONNACK, connect/drop every ~1.2 s, zero stable session) was traced - via the
+`connectivity-handler` Lambda's IoT lifecycle events - to
+`disconnectReason: CLIENT_ERROR`, `clientInitiatedDisconnect: false`. That is a
+**client-side protocol/limit violation**, which ruled out dup-client-id, auth
+(policy is permissive), keep-alive and network. Bench device .155 (different
+identity, non-shadow firmware) holds 1 connection for 40 h with 0 errors, so the
+broker/account/network are healthy - the fault was **.174-firmware-specific**.
 
-| # | Phase | Status | PR | Verified on dev .174 | Notes |
-|---|-------|--------|----|----------------------|-------|
-| 01 | scaffold `shadow` module | ✅ | - | yes (25 native tests + on-device) | core protocol |
-| 02 | `info` shadow | ✅ | - | yes (AWS read: identity + sketch_md5) | retire `system/static` deferred to 08 |
-| 03 | `issues` shadow | ✅ | - | yes (registry observer + active_count) | ack path wired later |
-| 04 | `system` shadow | ✅ | - | yes (inject led_brightness -> applied) | 5 fields + mqtt_log_level auto-revert |
-| 05 | `meter` shadow | ✅ | - | yes (inject sample_time -> applied/restored) | ADE7953 calibration |
-| 06 | `channels` shadow | ✅ | - | yes (deep-merge + channel-0 invariant) | drops `channel` topic in 08 |
-| 07 | Commands | ✅ | - | code + native tests; e2e needs cloud dispatcher | restart/factory_reset/energy_reset; policy already allows `$aws/commands/*` |
-| 08 | config-topic retirement | 🟡 | - | buffer bump 9 KB verified (heap ~42 KB min free, connects) | removals pending (isolated commit); NO fw version bump here |
+**Cause:** the device subscribed to the `$aws/commands/things/<id>/executions/+/request/+`
+reserved topic, but **AWS IoT Commands is not provisioned** in this account (no
+dispatcher; `list-commands` is not even a valid API here). Subscribing to an
+unrecognized reserved topic makes the broker reject the session with CLIENT_ERROR.
+A secondary `AdvancedLogTask` panic crash-loop was just the log firehose from the
+storm (stopped the instant cloud was disabled).
+
+**Fixes (both hardware-verified on .174):**
+- `fix(mqtt)` `2205b5c` - gate the IoT Commands subscription behind
+  `MQTT_IOT_COMMANDS_SUBSCRIBE_ENABLED` (OFF until provisioned end-to-end). The
+  handler + ENV_DEV injection stay compiled/tested; only the broker subscribe is
+  withheld.
+- `fix(shadow)` `0a14b4d` - `requestReport` before `Shadow::begin` is a benign
+  no-op (was 16 "unknown shadow" warnings/boot from the ADE7953 channel load).
+
+Process note: the earlier "hardware-verified 01-07" claims had been made on
+**intermediate** builds; the committed cutover binary (`41f8bf8`, 9 KB buffer)
+only reached hardware during this session (build `2573984c`). The 9 KB buffer did
+not fix the storm (the storm was the commands subscribe, not buffer size), but it
+is retained as correct sizing for the worst-case inbound shadow delta.
+
+## Verified on the cutover build (`2573984c`, dev .174)
+
+- Single stable MQTT connection: device `connections=1` held > 5 min; broker
+  lifecycle since re-enable = 1 connected / 0 disconnected / **0 CLIENT_ERROR**.
+- Telemetry flowing: 90 publishes, **0 publish errors**, no crash.
+- All 5 shadows report end-to-end (AWS versions incrementing: info, issues,
+  system, meter, channels).
+- Inbound apply round-trip: ENV_DEV `inject-delta` (`system.led_brightness`
+  75 -> 30 -> 75) applied on-device, reported reached AWS, `desired` backstop
+  cleared. (Real broker-delivered delta still needs a cloud desired-writer; not
+  testable read-only.)
+
+| # | Phase | Code | Verified on cutover build (.174) | Notes |
+|---|-------|------|----------------------------------|-------|
+| 01 | scaffold `shadow` module | ✅ | 25 native tests + stable on-device | core protocol |
+| 02 | `info` shadow | ✅ | AWS read: identity + sketch_md5; version inc | - |
+| 03 | `issues` shadow | ✅ | registry observer + active_count; version inc | ack path wired later |
+| 04 | `system` shadow | ✅ | inject led_brightness -> applied -> AWS | 5 fields + mqtt_log_level auto-revert |
+| 05 | `meter` shadow | ✅ | reports; version inc | ADE7953 calibration |
+| 06 | `channels` shadow | ✅ | reports; version inc | dropped `channel` topic |
+| 07 | Commands | ✅ (subscribe gated OFF) | native tests; broker e2e blocked on provisioning | gate flips ON when IoT Commands is live |
+| 08 | config-topic retirement | ✅ (`41f8bf8`) | telemetry stable, no config topics published | 9 KB buffer + removals; NO fw version bump here |
 
 ## Decisions log (resolved)
 
@@ -67,20 +104,23 @@ contract is validated end-to-end.
 
 | Item | Status | Blocks |
 |------|--------|--------|
-| `$aws/commands/things/<thing>/*` policy statement | ⬜ (agreed to add) | 07 end-to-end test |
-| Shadow ingestion Lambda + rule -> existing `device-ops` table (no new table) | ⬜ | 04/05/06 + reading reported |
-| Desired-state writer ("Intelligence" backend) | ⬜ | 04/05/06 inbound test |
+| `$aws/commands/things/<thing>/*` policy statement | ✅ present in policy | - |
+| **IoT Commands feature provisioned** (account not set up; `list-commands` invalid) | ⬜ | **device commands subscribe is gated OFF until this exists** |
+| Shadow ingestion Lambda + rule -> existing `device-ops` table (no new table) | ⬜ | reading reported cloud-side |
+| Desired-state writer ("Intelligence" backend) | ⬜ | real broker-delivered delta test (inject path already proven) |
 | 3 command templates + `StartCommandExecution` dispatcher | ⬜ | 07 end-to-end test |
 | Retire idle `system/static`/`command`/`channel` rules (whenever) | ⬜ | cleanup only |
 
 ## Hardware-verify items
 
-- `MQTT_BUFFER_SIZE` 5 KB -> 9 KB: re-check TLS handshake + free heap on a real
-  device (known esp-aes alloc pressure at the 5 KB baseline). See 08.
-- `channels` worst-case **inbound delta** (bulk `desired`, 64-char labels +
-  metadata, ~2x state) fits `MQTT_BUFFER_SIZE` 9 KB; else cloud must chunk. See 06.
-- (Final review verifies) Commands request carries a server timestamp for the
-  staleness guard; backend clears `desired` on `factory_reset`. See 07.
+- ✅ `MQTT_BUFFER_SIZE` 5 KB -> 9 KB: TLS handshake fine, free internal heap
+  ~65 KB during steady cloud operation on `2573984c`. No esp-aes alloc failures.
+- ⬜ `channels` worst-case **inbound delta** (bulk `desired`, 64-char labels +
+  metadata, ~2x state) fits `MQTT_BUFFER_SIZE` 9 KB; else cloud must chunk. Not
+  yet exercised at worst case (no cloud desired-writer). See 06.
+- ⬜ (Final review) Commands request carries a server timestamp for the staleness
+  guard; backend clears `desired` on `factory_reset`. Blocked on IoT Commands
+  provisioning. See 07.
 
 ## Final gate + post-MVP
 
@@ -92,4 +132,10 @@ contract is validated end-to-end.
 
 ## Next step
 
-Implement **01 - scaffold** (`lib/shadow_logic` native unit tests first).
+Firmware MVP is implemented + committed + hardware-stable on dev .174. Remaining:
+1. Push `feat/iot-shadow-config` + open PR -> `development` (gated on Jibril's go-ahead).
+2. Cloud side (energyme-infra): shadow ingestion + desired-state writer to test the
+   real broker-delivered delta; provision IoT Commands, then flip
+   `MQTT_IOT_COMMANDS_SUBSCRIBE_ENABLED` ON for the commands e2e.
+3. Separate release step on `development`: bump firmware version to 2.1.0 (NOT in
+   this branch).

--- a/source/docs/feature/2026-06-16-shadow-v2-config/PROGRESS.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/PROGRESS.md
@@ -2,8 +2,40 @@
 
 Legend: ⬜ not started · 🟡 in progress · ✅ done · ⛔ blocked
 
-_Last updated: 2026-06-17 (all 8 phases implemented + committed; MQTT storm
-root-caused + fixed; IoT Commands subscribe topic corrected + verified on .174)._
+_Last updated: 2026-06-17 (session 2: drift-detect, transient-verbose reboot
+restore, issues boot-race fix, wifi shadow, command reasonCode casing - all
+committed + hardware-verified on .174)._
+
+## Update 2026-06-17 (session 2 - post-MVP hardening, committed + verified on .174)
+
+On top of the 01-08 MVP (now **6 shadows**):
+- **Local-change propagation is source-agnostic:** `checkPublish()` drift-detects
+  any writable-shadow change every 3 s and republishes, replacing the per-REST
+  `publishLocalEdit` hook (removed). Local edits reach the cloud within ~3 s; they
+  publish reported-only (no `desired:null`) - see 00 for the conflict-policy note.
+- **Transient `mqtt_log_level` survives reboot:** a separate NVS marker
+  (`mqtt_ns/transient_log`) restores the VERBOSE/DEBUG level + restarts the 5-min
+  timer on boot, so a debug session keeps boot-time logs. Persistent-set and
+  auto-revert clear it. Restore + clear both verified on .174.
+- **`wifi` shadow (6th, reported-only):** connected/ssid/ip/gateway/subnet/dns/mac +
+  static_ip/fallback_to_dhcp; read back from AWS (version 1). No writable network
+  config, no creds, RSSI stays on `system/dynamic`.
+- **`issues` boot-race fixed:** `IssueRegistry::begin()` moved before
+  `CustomServer::begin()`, and `issuesToJson` returns empty-200 on a null mutex
+  (was HTTP 500 on early boot). Verified: 40/40 200s post-reboot, 0 mutex errors.
+- **Command `reasonCode` casing fixed:** uppercased to AWS `[A-Z0-9_-]+` (resolves
+  the known follow-up noted below).
+- **Command rejected-echo loop fixed (found during command testing on .174):** the
+  MQTT RX router treated *any* `/commands/things/.../executions/...` topic as a
+  command, so AWS's `.../response/rejected/json` echo of a rejected status publish
+  was reprocessed (no `operation` -> re-rejected -> echoed -> **infinite ~110 ms
+  publish loop** hammering the broker). Now only `.../request/json` (the subscribed
+  topic) routes to the handler; other `/commands/things/` topics are logged +
+  ignored. Verified on .174: each injected command processes exactly once, 14
+  publishes / 14 ignores (1:1, bounded), no repeats. NB: a lowercase reasonCode (the
+  bug above) would have *triggered* this loop in production - both fixes needed.
+  Real broker-delivered command on `/request/json` still pending the cloud dispatcher
+  (inject bypasses the RX router, so that match condition is not yet hardware-exercised).
 
 ## Update 2026-06-17 (corrected root cause + topic fix - SUPERSEDES the banner below)
 
@@ -23,9 +55,10 @@ MQTT connection >4 min, 68 telemetry publishes / 0 errors, **0 CLIENT_ERROR** at
 connectivity-handler since connect. Storm fix proven; the round-trip (device RECEIVES
 a command) is pending the cloud CreateCommand + StartCommandExecution dispatcher.
 
-Known follow-up (fix during the reject-path round-trip): device reject/fail
-`reasonCode`s are lowercase but AWS requires `[A-Z0-9_-]+`; uppercase them. Happy path
-(restart IN_PROGRESS -> SUCCEEDED) sends no statusReason, so unaffected.
+~~Known follow-up~~ **RESOLVED (session 2):** device reject/fail `reasonCode`s
+uppercased to AWS `[A-Z0-9_-]+` (BAD_PAYLOAD, MISSING_OPERATION, STALE_COMMAND,
+CONFIRM_MISMATCH, BAD_CHANNELS, UNKNOWN_OPERATION). Happy path
+(IN_PROGRESS -> SUCCEEDED) sends no statusReason, so was already unaffected.
 
 ## RESOLVED - MQTT reconnect storm root cause (2026-06-17)
 
@@ -156,8 +189,9 @@ contract is validated end-to-end.
 
 ## Next step
 
-Firmware MVP is implemented + committed + hardware-stable on dev .174. Remaining:
-1. Push `feat/iot-shadow-config` + open PR -> `development` (gated on Jibril's go-ahead).
+Firmware MVP + session-2 hardening implemented + committed + hardware-stable on
+dev .174. Remaining:
+1. PR `feat/iot-shadow-config` -> `development` opened (not merged - awaiting review).
 2. Cloud side (energyme-infra): shadow ingestion + desired-state writer to test the
    real broker-delivered delta; build the `restart` command + StartCommandExecution
    dispatcher (contentType application/json) for the commands round-trip. The subscribe

--- a/source/docs/feature/2026-06-16-shadow-v2-config/PROGRESS.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/PROGRESS.md
@@ -3,7 +3,29 @@
 Legend: ⬜ not started · 🟡 in progress · ✅ done · ⛔ blocked
 
 _Last updated: 2026-06-17 (all 8 phases implemented + committed; MQTT storm
-root-caused + fixed; cutover build hardware-verified stable on dev .174)._
+root-caused + fixed; IoT Commands subscribe topic corrected + verified on .174)._
+
+## Update 2026-06-17 (corrected root cause + topic fix - SUPERSEDES the banner below)
+
+The CLIENT_ERROR storm was NOT caused by IoT Commands being unprovisioned. Real
+cause: the device subscribed to `.../executions/+/request/+` - a `+` at the
+PAYLOAD-FORMAT segment, an unsupported AWS reserved-topic subscribe (AWS docs:
+"Unsupported ... subscribe operations to reserved topics can result in a terminated
+connection"). The documented form allows `+` only at the execution-id position. The
+"not provisioned" reading was an artifact of the local AWS CLI 2.15.38 lacking
+`list-commands`; the cloud side confirmed IoT Commands IS available in eu-west-1.
+
+Fix `a9fbce8`: subscribe to `.../executions/+/request/json` (flag stays ON). Coupling:
+the cloud dispatcher must create commands with contentType application/json.
+
+Verified on dev .174 (build `e338ab8f`, commands subscription ACTIVE): single stable
+MQTT connection >4 min, 68 telemetry publishes / 0 errors, **0 CLIENT_ERROR** at the
+connectivity-handler since connect. Storm fix proven; the round-trip (device RECEIVES
+a command) is pending the cloud CreateCommand + StartCommandExecution dispatcher.
+
+Known follow-up (fix during the reject-path round-trip): device reject/fail
+`reasonCode`s are lowercase but AWS requires `[A-Z0-9_-]+`; uppercase them. Happy path
+(restart IN_PROGRESS -> SUCCEEDED) sends no statusReason, so unaffected.
 
 ## RESOLVED - MQTT reconnect storm root cause (2026-06-17)
 
@@ -16,10 +38,12 @@ CONNACK, connect/drop every ~1.2 s, zero stable session) was traced - via the
 identity, non-shadow firmware) holds 1 connection for 40 h with 0 errors, so the
 broker/account/network are healthy - the fault was **.174-firmware-specific**.
 
-**Cause:** the device subscribed to the `$aws/commands/things/<id>/executions/+/request/+`
-reserved topic, but **AWS IoT Commands is not provisioned** in this account (no
-dispatcher; `list-commands` is not even a valid API here). Subscribing to an
-unrecognized reserved topic makes the broker reject the session with CLIENT_ERROR.
+**Cause (SUPERSEDED - see Update at top):** the device subscribed to
+`$aws/commands/things/<id>/executions/+/request/+`. The original reading below blamed
+"IoT Commands not provisioned" (an artifact of the local CLI lacking `list-commands`);
+the real cause is the `+` at the payload-format segment - an unsupported reserved-topic
+subscribe that makes the broker terminate the session with CLIENT_ERROR. IoT Commands
+IS available in eu-west-1.
 A secondary `AdvancedLogTask` panic crash-loop was just the log firehose from the
 storm (stopped the instant cloud was disabled).
 
@@ -57,7 +81,7 @@ is retained as correct sizing for the worst-case inbound shadow delta.
 | 04 | `system` shadow | ✅ | inject led_brightness -> applied -> AWS | 5 fields + mqtt_log_level auto-revert |
 | 05 | `meter` shadow | ✅ | reports; version inc | ADE7953 calibration |
 | 06 | `channels` shadow | ✅ | reports; version inc | dropped `channel` topic |
-| 07 | Commands | ✅ (subscribe gated OFF) | native tests; broker e2e blocked on provisioning | gate flips ON when IoT Commands is live |
+| 07 | Commands | ✅ subscribe fixed (`a9fbce8`, /request/json) + verified | storm gone on .174 (0 CLIENT_ERROR, sub ACTIVE); round-trip pending cloud dispatcher | reasonCode casing follow-up |
 | 08 | config-topic retirement | ✅ (`41f8bf8`) | telemetry stable, no config topics published | 9 KB buffer + removals; NO fw version bump here |
 
 ## Decisions log (resolved)
@@ -105,10 +129,10 @@ contract is validated end-to-end.
 | Item | Status | Blocks |
 |------|--------|--------|
 | `$aws/commands/things/<thing>/*` policy statement | ✅ present in policy | - |
-| **IoT Commands feature provisioned** (account not set up; `list-commands` invalid) | ⬜ | **device commands subscribe is gated OFF until this exists** |
+| **IoT Commands available in eu-west-1** | ✅ confirmed cloud-side (`list-commands` responds) | resolved - was a topic-shape bug, not provisioning |
 | Shadow ingestion Lambda + rule -> existing `device-ops` table (no new table) | ⬜ | reading reported cloud-side |
 | Desired-state writer ("Intelligence" backend) | ⬜ | real broker-delivered delta test (inject path already proven) |
-| 3 command templates + `StartCommandExecution` dispatcher | ⬜ | 07 end-to-end test |
+| Command(s) + `StartCommandExecution` dispatcher (contentType application/json) | ⬜ | 07 round-trip test (storm fix already proven on .174) |
 | Retire idle `system/static`/`command`/`channel` rules (whenever) | ⬜ | cleanup only |
 
 ## Hardware-verify items
@@ -119,8 +143,8 @@ contract is validated end-to-end.
   metadata, ~2x state) fits `MQTT_BUFFER_SIZE` 9 KB; else cloud must chunk. Not
   yet exercised at worst case (no cloud desired-writer). See 06.
 - ⬜ (Final review) Commands request carries a server timestamp for the staleness
-  guard; backend clears `desired` on `factory_reset`. Blocked on IoT Commands
-  provisioning. See 07.
+  guard; backend clears `desired` on `factory_reset`. Blocked on the cloud command
+  dispatcher. See 07.
 
 ## Final gate + post-MVP
 
@@ -135,7 +159,8 @@ contract is validated end-to-end.
 Firmware MVP is implemented + committed + hardware-stable on dev .174. Remaining:
 1. Push `feat/iot-shadow-config` + open PR -> `development` (gated on Jibril's go-ahead).
 2. Cloud side (energyme-infra): shadow ingestion + desired-state writer to test the
-   real broker-delivered delta; provision IoT Commands, then flip
-   `MQTT_IOT_COMMANDS_SUBSCRIBE_ENABLED` ON for the commands e2e.
+   real broker-delivered delta; build the `restart` command + StartCommandExecution
+   dispatcher (contentType application/json) for the commands round-trip. The subscribe
+   topic fix (`a9fbce8`) is done + verified on .174; the flag is already ON.
 3. Separate release step on `development`: bump firmware version to 2.1.0 (NOT in
    this branch).

--- a/source/docs/feature/2026-06-16-shadow-v2-config/README.md
+++ b/source/docs/feature/2026-06-16-shadow-v2-config/README.md
@@ -1,0 +1,66 @@
+# Feature: AWS IoT Device Shadow config (v2.1.0)
+
+**Status:** planning complete, validated with cloud side - ready to implement
+**Issue:** #159 | **Cloud repo:** `energyme-infra` | **Started:** 2026-06-16
+
+This folder is the working workspace for the shadow feature. It is meant to be
+driven incrementally with AI: read the contract, pick a phase, implement with
+tests, update progress. Everything an implementer (human or AI) needs is here.
+
+## Why we are doing this
+
+Today the device's **configurable state** (channel setup, system toggles, meter
+calibration) only flows device -> cloud as telemetry, and there is no way for the
+cloud to *change* it. There is also no cloud visibility of the on-device issue
+registry. We want **cloud-side configuration parity with the local web UI/REST
+API**, mediated by the EnergyMe Intelligence backend, using the right AWS
+primitives for each job:
+
+- **Named Device Shadows** for configurable state (desired/reported sync).
+- **IoT Commands** for transient actions (restart, factory_reset, energy_reset).
+- **IoT Jobs** stay OTA-only (unchanged).
+
+Guiding principle established for this work: **telemetry topics carry only
+measurements / statistics / dynamic runtime; all configurable state lives in
+shadows.** Secrets (WiFi creds, etc.) stay local-only - never in a shadow.
+
+## Expected output ("done" looks like)
+
+- Firmware `Shadow` module + 5 named shadows (`info`, `issues`, `system`,
+  `meter`, `channels`) and 3 Commands. Topic namespace stays `v1` (no bump).
+- Reported-only shadows (`info`, `issues`) provable on hardware with no cloud
+  backend; writable shadows + Commands provable end-to-end on dev AWS.
+- `command` topic, `system/static` and `channel` publishes removed (config now
+  shadow-only); firmware at 2.1.0; **topic version stays `v1`**.
+- No regression in the local REST API; telemetry payload contents unchanged.
+- Cloud side (tracked in `energyme-infra`): `$aws/commands/*` policy, shadow
+  ingestion Lambda into the existing `device-ops` table, desired-state writer,
+  3 command templates + dispatcher. No v2 rules, no policy-ARN migration.
+
+## How to work in this folder
+
+1. Read **`00-overview-and-contract.md`** first - it is the device<->cloud
+   contract (topics, payloads, the shadow apply logic) both repos agreed on.
+2. Pick the lowest open phase in **`PROGRESS.md`**. Build order is 01 -> 08;
+   `02`/`03` (reported-only) are the first hardware-provable steps and need no
+   cloud backend.
+3. Each `0N-*.md` is a self-contained step: goal, files, schema, exact
+   functions/NVS keys, test plan, acceptance checklist.
+4. Use TDD where logic is pure (native unit tests in `lib/`, run from WSL).
+5. Update `PROGRESS.md` as each phase lands (status, PR, notes, decisions).
+
+## Documents
+
+| Doc | Phase |
+|-----|-------|
+| `00-overview-and-contract.md` | contract + apply logic + cloud checklist + decisions |
+| `01-scaffold-shadow-module.md` | `shadow.cpp/.h` core |
+| `02-info-shadow.md` | reported-only identity (first provable) |
+| `03-issues-shadow.md` | reported-only issue registry |
+| `04-system-shadow.md` | writable behavioural config |
+| `05-meter-shadow.md` | writable ADE7953 calibration |
+| `06-channels-shadow.md` | writable per-channel config |
+| `07-commands.md` | IoT Commands (restart/factory_reset/energy_reset) |
+| `08-v2-cutover.md` | retire config topics, buffer bump, fw 2.1.0 (topic stays v1) |
+
+`PROGRESS.md` - live status and decision log.

--- a/source/docs/plans/2026-03-01-info-tooltip-system.md
+++ b/source/docs/plans/2026-03-01-info-tooltip-system.md
@@ -1,0 +1,359 @@
+# Info Tooltip System Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add reusable `ⓘ` info tooltip icons to any page label, starting with ADE7953 "Failed Readings" on `info.html`, that work on both desktop (hover/click) and mobile (tap).
+
+**Architecture:** A new `tooltip.css` file defines the `.info-tooltip` component with `position: fixed` (JS-positioned) to avoid being clipped by parent containers. A new `tooltip.js` shared script handles click-to-toggle, viewport-aware positioning, and click-outside-to-close. Both files are included in all pages so the pattern is immediately reusable everywhere.
+
+**Tech Stack:** Vanilla CSS + vanilla JS (no dependencies). Follows existing patterns: `#333` dark tooltip, `6px` border-radius, `0.3s` transition, Trebuchet MS font.
+
+---
+
+### Task 1: Create `tooltip.css`
+
+**Files:**
+- Create: `source/css/tooltip.css`
+
+**Step 1: Create the file**
+
+```css
+/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* Copyright (C) 2025 Jibril Sharafi */
+
+/* ───────────────────────────────────────────
+   Info Tooltip Component
+   Usage:
+     <span class="info-tooltip">
+       <button class="info-tooltip-icon"
+               onclick="toggleTooltip(this)"
+               aria-label="More info">ⓘ</button>
+       <div class="info-tooltip-popover" role="tooltip">
+         Explanation text here.
+       </div>
+     </span>
+   ─────────────────────────────────────────── */
+
+.info-tooltip {
+    display: inline-flex;
+    align-items: center;
+    position: relative;
+    margin-left: 5px;
+    vertical-align: middle;
+}
+
+.info-tooltip-icon {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    font-size: 13px;
+    line-height: 1;
+    color: #aaa;
+    transition: color 0.2s ease;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+}
+
+.info-tooltip-icon:hover,
+.info-tooltip-icon:focus {
+    color: #555;
+    outline: none;
+}
+
+/* The floating popover — positioned via JS using position:fixed
+   so it is never clipped by overflow:hidden parent containers */
+.info-tooltip-popover {
+    position: fixed;
+    z-index: 9000;
+    background-color: #333;
+    color: #fff;
+    font-size: 13px;
+    font-family: 'Trebuchet MS', sans-serif;
+    line-height: 1.5;
+    padding: 10px 14px;
+    border-radius: 6px;
+    max-width: 260px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    pointer-events: none;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+    /* Ensure text wraps cleanly */
+    white-space: normal;
+    word-wrap: break-word;
+}
+
+.info-tooltip-popover.open {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+}
+
+/* Small arrow pointing down toward the icon (default: popover above icon) */
+.info-tooltip-popover::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 6px solid transparent;
+    border-top-color: #333;
+}
+
+/* When popover is below the icon, arrow points up */
+.info-tooltip-popover.arrow-up::after {
+    top: auto;
+    bottom: 100%;
+    border-top-color: transparent;
+    border-bottom-color: #333;
+}
+
+/* Mobile: full-width bottom sheet style instead of floating */
+@media screen and (max-width: 480px) {
+    .info-tooltip-popover {
+        position: fixed !important;
+        left: 12px !important;
+        right: 12px !important;
+        bottom: 20px !important;
+        top: auto !important;
+        max-width: none;
+        width: auto;
+        border-radius: 10px;
+        font-size: 14px;
+        padding: 14px 16px;
+    }
+
+    /* Hide arrow on mobile bottom sheet */
+    .info-tooltip-popover::after {
+        display: none;
+    }
+}
+```
+
+**Step 2: Verify the file exists**
+
+```bash
+ls source/css/tooltip.css
+```
+
+Expected: file listed.
+
+**Step 3: Commit**
+
+```bash
+git add source/css/tooltip.css
+git commit -m "feat: add info-tooltip CSS component"
+```
+
+---
+
+### Task 2: Create `tooltip.js`
+
+**Files:**
+- Create: `source/js/tooltip.js`
+
+**Step 1: Create the file**
+
+```javascript
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+/**
+ * Shared info-tooltip logic.
+ * Included in every page alongside tooltip.css.
+ *
+ * toggleTooltip(iconButton) — call from onclick="toggleTooltip(this)"
+ */
+
+let _activeTooltip = null;
+
+function toggleTooltip(iconButton) {
+    const popover = iconButton.nextElementSibling;
+    if (!popover || !popover.classList.contains('info-tooltip-popover')) return;
+
+    const isOpen = popover.classList.contains('open');
+
+    // Close any currently open tooltip first
+    _closeAllTooltips();
+
+    if (!isOpen) {
+        _positionTooltip(popover, iconButton);
+        popover.classList.add('open');
+        _activeTooltip = popover;
+    }
+}
+
+function _positionTooltip(popover, anchor) {
+    // On mobile (<= 480px) CSS handles positioning via bottom-sheet rules
+    if (window.innerWidth <= 480) return;
+
+    const rect = anchor.getBoundingClientRect();
+    const popoverWidth = 260; // matches max-width in CSS
+    const gap = 8; // space between icon and popover
+
+    // Temporarily make visible (off-screen) to measure height
+    popover.style.visibility = 'hidden';
+    popover.style.opacity = '0';
+    popover.style.display = 'block';
+    const popoverHeight = popover.offsetHeight || 80;
+    popover.style.display = '';
+    popover.style.visibility = '';
+
+    // Prefer above the icon
+    let top = rect.top - popoverHeight - gap;
+    let arrowUp = false;
+
+    // If not enough room above, show below
+    if (top < 8) {
+        top = rect.bottom + gap;
+        arrowUp = true;
+    }
+
+    // Horizontal: center on icon, clamp to viewport
+    let left = rect.left + rect.width / 2 - popoverWidth / 2;
+    left = Math.max(8, Math.min(left, window.innerWidth - popoverWidth - 8));
+
+    popover.style.top = top + 'px';
+    popover.style.left = left + 'px';
+    popover.classList.toggle('arrow-up', arrowUp);
+}
+
+function _closeAllTooltips() {
+    document.querySelectorAll('.info-tooltip-popover.open').forEach(p => {
+        p.classList.remove('open');
+    });
+    _activeTooltip = null;
+}
+
+// Close on outside click / scroll
+document.addEventListener('click', function (e) {
+    if (_activeTooltip && !e.target.closest('.info-tooltip')) {
+        _closeAllTooltips();
+    }
+});
+
+document.addEventListener('scroll', _closeAllTooltips, true);
+```
+
+**Step 2: Verify the file exists**
+
+```bash
+ls source/js/tooltip.js
+```
+
+Expected: file listed.
+
+**Step 3: Commit**
+
+```bash
+git add source/js/tooltip.js
+git commit -m "feat: add info-tooltip JS positioning logic"
+```
+
+---
+
+### Task 3: Add tooltip to `info.html` (ADE7953 failed readings)
+
+**Files:**
+- Modify: `source/html/info.html`
+
+**Step 1: Add `<link>` and `<script>` to `<head>` of `info.html`**
+
+In the `<head>` block, after the existing CSS links and before `</head>`, add:
+
+```html
+    <link rel="stylesheet" type="text/css" href="/css/tooltip.css">
+```
+
+And before `</body>`, add:
+
+```html
+    <script src="/js/tooltip.js"></script>
+```
+
+**Step 2: Add tooltip to "Failed Readings" label**
+
+Find this block in `info.html` (inside the ADE7953 card):
+
+```html
+                <div class="info-item">
+                    <span class="info-label"><span class="emoji">❌</span>Failed Readings</span>
+                    <span class="info-value" id="ade7953ReadingFailures">Loading...</span>
+                </div>
+```
+
+Replace with:
+
+```html
+                <div class="info-item">
+                    <span class="info-label">
+                        <span class="emoji">❌</span>Failed Readings
+                        <span class="info-tooltip">
+                            <button class="info-tooltip-icon" onclick="toggleTooltip(this)" aria-label="More info about failed readings">ⓘ</button>
+                            <div class="info-tooltip-popover" role="tooltip">
+                                A failed reading occurs when the ADE7953 energy meter chip does not respond correctly over SPI. A small number is normal on startup; persistently high counts may indicate hardware or wiring issues.
+                            </div>
+                        </span>
+                    </span>
+                    <span class="info-value" id="ade7953ReadingFailures">Loading...</span>
+                </div>
+```
+
+**Step 3: Test manually**
+
+Open `info.html` in a browser (or via the device's web server). Click the `ⓘ` icon next to "Failed Readings":
+- Desktop: popover floats above (or below if near top of viewport), not clipped by the card
+- Mobile (narrow): popover appears as a bottom sheet
+- Clicking outside closes it
+
+**Step 4: Commit**
+
+```bash
+git add source/html/info.html
+git commit -m "feat: add info tooltip to ADE7953 failed readings"
+```
+
+---
+
+### Task 4: Include tooltip files in all other pages (optional but recommended)
+
+**Files:**
+- Modify each: `source/html/index.html`, `channel.html`, `configuration.html`, `calibration.html`, `integrations.html`, `update.html`, `log.html`, `waveform.html`, `ade7953-tester.html`, `swagger.html`
+
+**Step 1: For each HTML file, add the CSS link to `<head>`**
+
+After existing CSS `<link>` tags:
+```html
+    <link rel="stylesheet" type="text/css" href="/css/tooltip.css">
+```
+
+And the JS script before `</body>`:
+```html
+    <script src="/js/tooltip.js"></script>
+```
+
+**Step 2: Commit**
+
+```bash
+git add source/html/*.html
+git commit -m "feat: include tooltip CSS/JS in all pages"
+```
+
+---
+
+## Verification
+
+End-to-end test checklist:
+
+- [ ] `ⓘ` icon appears inline next to "Failed Readings" label, not disrupting layout
+- [ ] Clicking `ⓘ` opens the popover above the icon (or below if near screen top)
+- [ ] Popover is not clipped by the `.info-card` container
+- [ ] Clicking outside closes the popover
+- [ ] On mobile (< 480px): popover appears as a bottom sheet
+- [ ] Other cards are unaffected
+- [ ] Page loads without JS errors in console
+- [ ] Adding another `ⓘ` elsewhere requires only the HTML snippet (no new CSS/JS needed)

--- a/source/docs/plans/2026-03-08-pcb-version-handling-design.md
+++ b/source/docs/plans/2026-03-08-pcb-version-handling-design.md
@@ -1,0 +1,176 @@
+# PCB Version Handling Design
+
+**Date:** 2026-03-08
+**Status:** Approved
+**Firmware Version:** 2.0.0 (breaking change from 1.x)
+
+---
+
+## Context
+
+The EnergyMe-Home firmware v1.x hardcodes all hardware config for PCB v5 in `pins.h`. v6.1 PCB has different GPIO pins, different voltage transformer ratios, and will have factory calibration data (ADE7953 gains/offsets) embedded in a dedicated NVS partition at production time. Certs are provisioned into the existing `certificates_ns` NVS namespace via the existing provisioning API.
+
+v5 devices are few in number and will receive only critical bugfixes on a `legacy/v5` branch. v2.0.0 targets v6.1+ exclusively.
+
+This is an open source project — the firmware must function gracefully even without eFuse provisioning (community builders who don't use the commercial provisioning pipeline).
+
+---
+
+## Strategy
+
+**Branching:**
+- Create `legacy/v5` branch from current `main` — v5 devices stay on v1.x, critical fixes cherry-picked
+- `main` becomes v2.0.0 — v6.1+ only, no v5 compatibility code
+
+**PCB Versions Supported:**
+- v5 → `legacy/v5` branch only (eFuse value: 5)
+- v6.1 → v2.0.0 `main` (eFuse value: 61)
+- Future versions → add new `HardwareProfile` entry
+
+**Version Detection:** Runtime, via eFuse `hardwareVersion` field (already in `EfuseProvisioningData` struct in `structs.h`, read by `readEfuseProvisioningData()` in `utils.cpp:932`)
+
+**Two operational modes:**
+
+| Mode | Trigger | Behavior |
+|---|---|---|
+| **Provisioned** | eFuse `isProvisioned == 0x01` | Full features. Uses eFuse `hardwareVersion` → exact PCB profile. Certs from NVS. Cloud enabled. |
+| **Community** | eFuse not programmed | Log INFO. v6.1 default profile. Standard calibration. Cloud (MQTT/AWS) disabled. Web UI, Modbus, InfluxDB still work. |
+
+---
+
+## Architecture
+
+### 1. Hardware Profile System
+
+**New file:** `include/hardware_profile.h`
+
+```cpp
+struct HardwareProfile {
+    uint16_t version;  // PCB version (61=v6.1, ...)
+
+    // RGB LED
+    uint8_t ledRedPin, ledGreenPin, ledBluePin;
+    // Button
+    uint8_t buttonPin;
+    // Multiplexer (74HC4067)
+    uint8_t muxS0Pin, muxS1Pin, muxS2Pin, muxS3Pin;
+    // ADE7953 SPI
+    uint8_t ade7953SsPin, ade7953SckPin, ade7953MisoPin;
+    uint8_t ade7953MosiPin, ade7953ResetPin, ade7953InterruptPin;
+    // Voltage measurement
+    float voltageDividerR1;
+    float voltageDividerR2;
+    // Feature flags (additive for future versions)
+    bool hasFactoryPartition;  // true when factory NVS partition is present and populated
+};
+```
+
+**New file:** `src/hardware_profile.cpp`
+- Defines `PCB_PROFILES[]` with one entry per supported PCB version (currently: v6.1 only)
+- `initHardwareProfile()`: reads eFuse via existing `readEfuseProvisioningData()`, selects profile, sets `g_hwProfile` and `g_communityMode`
+- Exposes `const HardwareProfile* getHardwareProfile()` accessor
+
+**To add a new PCB version:** add one entry to `PCB_PROFILES[]`. No other changes needed.
+
+`pins.h` is **deleted** — all usages replaced with `g_hwProfile->...` fields.
+
+### 2. Boot Sequence
+
+`setup()` in `main.cpp` calls `initHardwareProfile()` first, before any hardware init:
+
+```
+setup()
+  └─ initHardwareProfile()             ← eFuse read, profile + mode selected
+  └─ initLed(...)                      ← uses g_hwProfile->ledRedPin etc.
+  └─ SPI.begin(sck, miso, mosi, ss)    ← uses g_hwProfile ADE7953 pins
+  └─ ade7953.begin(...)                ← uses g_hwProfile reset/interrupt pins
+  └─ loadCalibration()                 ← reads calibration_ns (factory-seeded or user-set)
+  └─ initMqtt()                        ← skipped if g_communityMode == true
+  └─ ... rest of setup
+```
+
+`SPI.begin(sck, miso, mosi, ss)` overload takes explicit pins — runtime selection works cleanly.
+
+### 3. Community Mode — Cloud Gating
+
+A global `bool g_communityMode` (set in `initHardwareProfile()`):
+- If `true`: log `INFO: eFuse not provisioned — running in community mode, cloud disabled`
+- MQTT/AWS initialization is skipped entirely
+- All local integrations (web UI, Modbus, InfluxDB) remain unconditional
+
+If eFuse is programmed but `hardwareVersion` is unknown: log `WARN`, use v6.1 profile, community mode stays `false` (device is provisioned but on unknown PCB — unusual, proceed carefully).
+
+### 4. Factory Calibration (ADE7953 Gains/Offsets) — DEFERRED
+
+**Deferred:** Factory NVS partition implementation is deferred. TODO comments mark all relevant locations.
+
+**Intended design when implemented:**
+
+The factory partition (`factory_data, data, nvs`) stores original ADE7953 calibration gains and offsets written at production time. The runtime `calibration_ns` NVS namespace (existing) always holds the *active* calibration — factory-seeded initially, then user-overridable via the web UI calibration page.
+
+**Calibration flow:**
+1. First boot / after reset-to-factory: if `hasFactoryPartition` → read gains/offsets from factory partition → write to `calibration_ns` as starting point
+2. Normal operation: ADE7953 reads from `calibration_ns` (existing behavior, unchanged)
+3. User adjusts via calibration UI: values saved to `calibration_ns` (existing behavior, unchanged)
+4. "Reset to factory": if `hasFactoryPartition` → reload from factory partition → overwrite `calibration_ns`; else → apply hardcoded defaults from `ade7953.h` (`DEFAULT_CONFIG_AV_GAIN` etc.)
+
+This means the existing calibration read/write code in `ade7953.cpp` and the calibration web API **do not change** — they always operate on `calibration_ns`. Factory partition is only touched during first-boot seeding and reset-to-factory.
+
+**Existing default constants to preserve:** `DEFAULT_CONFIG_AV_GAIN`, `DEFAULT_CONFIG_AI_GAIN`, `DEFAULT_CONFIG_BI_GAIN`, etc. in `ade7953.h` — these remain the fallback when no factory partition exists.
+
+**TODO locations to mark:**
+- `src/ade7953.cpp` — calibration loading: note factory partition seeding should happen here
+- `src/customserver.cpp` — reset-to-factory endpoint (or add one): note factory partition reset path
+- `partitions.csv` — note factory_data partition to be added
+- `include/hardware_profile.h` — `hasFactoryPartition` flag with TODO explaining intent
+- MQTT provisioning code (`src/mqtt.cpp`, provisioning request handling) — note factory cert/data delivery path is deferred
+
+### 5. Secrets & Certs — NVS Only
+
+`HAS_SECRETS` removed entirely. Certs always from NVS `certificates_ns` via existing Preferences API. Existing provisioning API (`/api/provisioning/certificate`) remains for manual cert delivery. For provisioned v6.1+ devices: certs pre-programmed into NVS at factory.
+
+### 6. Build Environments
+
+Simplified from 4 to 2:
+
+| Environment | Purpose |
+|---|---|
+| `esp32s3-dev` | Development: debug symbols, verbose logging |
+| `esp32s3-prod` | Production: size optimized, minimal logging |
+
+Remove embedded secret files from `board_build.embed_txtfiles`. Remove `-DHAS_SECRETS`.
+
+---
+
+## Files to Create
+
+| File | Description |
+|---|---|
+| `include/hardware_profile.h` | `HardwareProfile` struct, extern `g_hwProfile`, `g_communityMode`, function declarations |
+| `src/hardware_profile.cpp` | Profile table (v6.1 only for now), `initHardwareProfile()`, `getHardwareProfile()` |
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `include/pins.h` | Delete — all usages replaced with `g_hwProfile->...` |
+| `src/main.cpp` | Call `initHardwareProfile()` first; explicit SPI pins; gate MQTT on `g_communityMode` |
+| `src/mqtt.cpp` | Remove `HAS_SECRETS` blocks; always use NVS certs; add TODO for factory provisioning path |
+| `include/mqtt.h` | Remove `HAS_SECRETS` cert logic |
+| `src/ade7953.cpp` | Use `g_hwProfile` for voltage divider ratios; add TODO for factory partition calibration seeding |
+| `src/led.cpp` | Use `g_hwProfile` for LED pins |
+| `src/customserver.cpp` | Remove `HAS_SECRETS` TODOs; add TODO for reset-to-factory factory-partition path |
+| `platformio.ini` | Simplify to 2 envs, remove secrets embedding, remove `HAS_SECRETS` |
+| `include/constants.h` | Bump to version 2.0.0 |
+| `partitions.csv` | Add TODO comment for `factory_data` partition (deferred) |
+
+---
+
+## Verification
+
+1. **Community mode:** Flash to unprogrammed device → INFO log, MQTT not started, web UI/Modbus/InfluxDB functional
+2. **v6.1 provisioned:** Flash to eFuse-programmed device (`hardwareVersion=61`) → correct pins, certs from NVS, MQTT connects
+3. **Unknown eFuse version:** WARN log, v6.1 profile used, boots safely
+4. **Calibration override:** Adjust calibration via web UI → saved to `calibration_ns` → survives reboot
+5. **Reset to factory (pre-partition):** Reset-to-factory applies hardcoded defaults from `ade7953.h`
+6. **Build:** Both envs build cleanly, no `HAS_SECRETS` errors, no `pins.h` references

--- a/source/docs/plans/2026-03-09-aws-config-storage-policy.md
+++ b/source/docs/plans/2026-03-09-aws-config-storage-policy.md
@@ -1,0 +1,32 @@
+# AWS Configuration Storage Policy
+
+## Decision
+
+All AWS IoT Core configuration constants are kept compile-time in `include/awsconfig.h`. They are not stored in NVS, the factory partition, or any runtime-updatable preference.
+
+## Rationale
+
+These values are fleet-wide infrastructure constants. Changing any of them requires a coordinated update on both the firmware side and the AWS cloud side simultaneously (rule renames, endpoint DNS, topic routing). Storing them in NVS would add load/validate/fallback logic with no practical benefit — an OTA is always required anyway to ensure all devices switch atomically.
+
+## What Lives Where
+
+| Config item | Storage | Rationale |
+|---|---|---|
+| AWS IoT Core endpoint | Compile-time (`awsconfig.h`) | Fleet-wide; any change requires OTA + cloud coordination |
+| Basic Ingest rule names | Compile-time (`awsconfig.h`) | Tied to AWS IoT Core rules; change requires OTA |
+| MQTT topic prefixes | Compile-time (`mqtt.h`) | Tied to cloud routing; change requires OTA |
+| Amazon Root CA cert | Compile-time (`awsconfig.h`) | Public cert; valid until 2038; change requires OTA |
+| Device certificate (PEM) | Factory NVS partition | Device-specific; pre-loaded at manufacturing |
+| Device private key | Factory NVS partition | Device-specific; pre-loaded at manufacturing |
+
+## Changing Endpoint or Rules
+
+1. Update `awsconfig.h` (endpoint) or `awsconfig.h` (rule names) / `mqtt.h` (topic prefixes)
+2. Update the corresponding AWS IoT Core infrastructure (new rule, DNS alias, etc.)
+3. Deploy OTA — devices will switch atomically on reboot
+
+## See Also
+
+- `include/awsconfig.h` — endpoint, rule names, Amazon Root CA
+- `include/mqtt.h` — topic prefix constants (`MQTT_TOPIC_1`, `MQTT_TOPIC_2`)
+- `docs/plans/2026-03-08-pcb-version-handling-design.md` — factory NVS partition and certificate pre-loading at manufacturing

--- a/source/docs/plans/2026-05-22-ade7953-scheduler-starvation-fix.md
+++ b/source/docs/plans/2026-05-22-ade7953-scheduler-starvation-fix.md
@@ -1,0 +1,231 @@
+# ADE7953 Scheduler Starvation Fix
+
+**Date:** 2026-05-22
+**Status:** Draft
+**Tracking:** Issue #149
+**Firmware Version:** 2.0.1 (planned)
+
+---
+
+## Context
+
+The ADE7953 meter task uses Weighted Deficit Round-Robin (WDRR) to pick which multiplexed channel to sample next. Issue #149 documents that the algorithm silently starves a channel whose readings get discarded (the dominant scenario being a backwards-clamped CT producing negative active power on a LOAD-role channel). The starved channel can go 30 to 60+ seconds without a successful read while its neighbours are sampled normally; the user perceives this as "missing data" with no error log.
+
+Three problems interact to produce the failure:
+
+1. `_findNextActiveChannel` decrements `_channelDeficit[i]` by 1.0 the moment a channel is selected, but on a discarded read `_readMeterValues` returns `false` and no refund is performed. The deficit drifts ever more negative.
+2. `_recalculateWeights` is only reached at the end of a *successful* read. A channel locked in a discard loop has its weight frozen at `WEIGHT_MIN_BASE = 0.1`, so it can never reclaim deficit ground against neighbours with weights of 0.4 to 0.6.
+3. The priority-override path (`_pendingPriorityRead`) returns early without running the gain phase. The only mechanism that currently rescues a starved channel skips the very accumulation step it needs to repair the deficit hole.
+
+The current safety nets (`ADE7953_MAX_FAILURES_BEFORE_RESTART = 100` over 1 minute) do not trip because the discard rate is ~10/min, well under the threshold.
+
+The user observation that triggered the investigation: "channels can go minutes unnoticed". Requirement: 100% guarantee that no active channel goes more than 15 seconds without being sampled.
+
+---
+
+## Strategy
+
+Five-part fix, each independently committable and testable:
+
+1. **Refund the deficit on discarded reads.** Capture `_processChannelReading`'s return value at its single call site in `_handleCycendInterrupt` and, on `false`, restore the decrement applied during selection.
+2. **Make the priority-override path run the gain phase.** Move the deficit accumulation loop above the priority claim loop in `_findNextActiveChannel`.
+3. **Arm priority read when `reverse` flag flips via API.** A user-initiated reverse change is intent for "read me now".
+4. **Clamp `_channelDeficit[]` magnitude to a fixed bound.** Belt-and-suspenders against any future arithmetic edge case (weight-table shock, NaN, OTA pause/resume).
+5. **15-second watchdog.** First scan in `_findNextActiveChannel`: force-pick any active channel whose `_meterValues[i].lastMillis` is older than `CHANNEL_MAX_GAP_MS`. Hard upper bound regardless of WDRR state. Logs at `LOG_WARNING` so chronic starvation surfaces to the user.
+
+Validation via local Python simulator (NOT committed) that mirrors the C++ scheduler one-for-one. The simulator reproduces issue #149's ch4 starvation against the *current* code, then verifies every documented edge case against the *fixed* code before any firmware flash.
+
+---
+
+## Constants
+
+Added to `include/ade7953.h`:
+
+```cpp
+// Hard upper bound on time between successful reads for any active multiplexed channel.
+// If exceeded, _findNextActiveChannel force-picks the starved channel and logs a warning.
+#define CHANNEL_MAX_GAP_MS 15000ULL
+
+// Symmetric clamp on per-channel deficit magnitude. Safety net against arithmetic edge cases.
+// With the discard-refund in place, deficits naturally stay near zero; this bound just guards
+// against any future shock (weight-table change, NaN, OTA pause).
+#define MAX_CHANNEL_DEFICIT_BOUND 5.0f
+```
+
+No new constants in `constants.h` (the scoping is meter-specific).
+
+---
+
+## Component Design
+
+### Fix 1 - Deficit refund on discarded reads
+
+**Where:** `src/ade7953.cpp::_handleCycendInterrupt` around line 1841.
+
+**Change:**
+
+```cpp
+if (_currentChannel != INVALID_CHANNEL) {
+    bool readOk = _processChannelReading(_currentChannel, linecycUnix);
+    if (!readOk && _currentChannel != 0) {
+        // Refund the deficit decremented by _findNextActiveChannel on selection.
+        // A discarded read is not a "service"; without this the channel drifts deeply
+        // negative and starves (issue #149).
+        if (acquireMutex(&_channelDataMutex)) {
+            _channelDeficit[_currentChannel] += 1.0f;
+            releaseMutex(&_channelDataMutex);
+        }
+    }
+}
+```
+
+Single site, single mutex acquisition, channel 0 excluded (not part of WDRR).
+
+### Fix 2 - Gain phase runs before priority return
+
+**Where:** `src/ade7953.cpp::_findNextActiveChannel` (currently line 4457).
+
+**Current order:**
+1. Priority-claim loop (returns early if any channel has `_pendingPriorityRead`).
+2. Gain loop (adds weight to deficit for every active channel).
+3. Argmax selection.
+4. Decrement winner.
+
+**New order:**
+1. Watchdog scan (Fix 5, see below).
+2. Gain loop.
+3. Deficit clamp (Fix 4, see below).
+4. Priority-claim loop (returns the claimed channel; does NOT decrement its deficit - the priority slot is a freebie).
+5. Argmax selection.
+6. Decrement winner.
+
+### Fix 3 - Reverse-flag PUT arms priority
+
+**Where:** `src/ade7953.cpp::setChannelData` around line 763.
+
+**Change:** snapshot `bool oldReverse = _channelData[channelIndex].reverse;` alongside the existing snapshots, then inside the `armTransients` block:
+
+```cpp
+if (oldReverse != _channelData[channelIndex].reverse && channelIndex > 0) {
+    _channelData[channelIndex]._pendingPriorityRead = true;
+}
+```
+
+### Fix 4 - Deficit clamp
+
+**Where:** new step in `_findNextActiveChannel` right after the gain loop.
+
+```cpp
+for (uint8_t i = 1; i < globalHwProfile->totalChannelCount; i++) {
+    // NaN guard - a NaN deficit fails every comparison and breaks argmax selection
+    if (isnanf(_channelDeficit[i])) _channelDeficit[i] = 0.0f;
+    if (_channelDeficit[i] > MAX_CHANNEL_DEFICIT_BOUND) _channelDeficit[i] = MAX_CHANNEL_DEFICIT_BOUND;
+    if (_channelDeficit[i] < -MAX_CHANNEL_DEFICIT_BOUND) _channelDeficit[i] = -MAX_CHANNEL_DEFICIT_BOUND;
+}
+```
+
+Also add a NaN guard in `_recalculateWeights` before accumulating into `totalAbsPower` and `totalVariability`.
+
+### Fix 5 - Starvation watchdog
+
+**Where:** first step in `_findNextActiveChannel`.
+
+```cpp
+uint64_t now = millis64();
+for (uint8_t i = 1; i < globalHwProfile->totalChannelCount; i++) {
+    if (!_channelData[i].active) continue;
+    if (_meterValues[i].lastMillis == 0) continue; // Never read - _pendingPriorityRead handles it
+    uint64_t gap = now - _meterValues[i].lastMillis;
+    if (gap > CHANNEL_MAX_GAP_MS) {
+        LOG_WARNING("Channel %u starved (%llu ms since last read), forcing pick", i, gap);
+        // Reset deficit to 0 to avoid immediate re-trigger
+        if (acquireMutex(&_channelDataMutex)) {
+            _channelDeficit[i] = 0.0f;
+            releaseMutex(&_channelDataMutex);
+        }
+        return i;
+    }
+}
+```
+
+Watchdog runs *before* the gain phase, so a starved channel is returned immediately without further bookkeeping. The deficit reset prevents the warning from firing again on the very next call.
+
+---
+
+## Data Flow
+
+**Normal read:** CYCEND → `_processChannelReading` succeeds → `lastMillis` updated → `_findNextActiveChannel` (watchdog clean, no priority, gain + clamp + argmax + decrement) → mux set to next channel.
+
+**Discarded read:** CYCEND → `_processChannelReading` returns false → deficit refunded → `lastMillis` unchanged → next `_findNextActiveChannel` call: discarded channel has its full deficit, competes fairly next round.
+
+**Discard storm (CT permanently misoriented):** Channel keeps being picked and discarded. Net deficit change per round: 0 (selection -1.0 + refund +1.0). At the 15 s mark, watchdog force-picks the channel, logs the warning, the read still fails, deficit reset, cycle continues with one `LOG_WARNING` every 15 s. The user has a clear signal that something is physically wrong.
+
+**User PUT reverse: false:** `setChannelData` sees `reverse` flipped → arms `_pendingPriorityRead` → next CYCEND, the priority-claim loop returns immediately (after gain + clamp), reading lands with corrected sign.
+
+**Boot sequence:** All `lastMillis == 0`, watchdog skips them. `_pendingPriorityRead` is armed on inactive→active for each channel (existing path in `_setChannelDataFromPreferences`), so first read is forced via priority. After the first read, the watchdog takes over.
+
+---
+
+## Edge Cases
+
+| # | Scenario | Expected behaviour |
+|---|----------|--------------------|
+| 1 | Flipped CT for 60 s | LOAD-discards happen, deficit stays near 0, watchdog fires every 15 s, no silent gap > 15 s. |
+| 2 | Single huge transient -100 kW | Auto-polarity unchanged (already gated by `AUTO_POLARITY_MIN_POWER_W = 5W`), validation rejects per `VALIDATE_POWER_MIN/MAX`, single discard, no permanent flip. |
+| 3 | Random 30% discard rate across all channels | Every channel read at its weight share +/- 20% over a 1 h window. |
+| 4 | All channels discarding simultaneously | No deadlock. Watchdog rotates through all of them, one force-pick per 15 s per channel. |
+| 5 | Channel deactivated mid-stream | Its deficit reset to 0 by gain loop's `else` branch, others redistribute traffic. |
+| 6 | Channel toggles active/inactive every 100 ms | Deficit oscillates but never escapes `[-5, +5]` thanks to clamp. |
+| 7 | Variability spikes 1000x on one channel | Weight redistribution happens, but min-base still ensures other channels are serviced. |
+| 8 | NaN active power injected | `isnanf` guards in `_recalculateWeights` and the clamp prevent NaN propagation into deficits. |
+| 9 | 1 hour of skewed traffic | Every active channel read at least once per 15 s, verified by simulator. |
+| 10 | Channel 0 in any scenario | Always read on every CYCEND, never in the rotation, never in deficit arrays. |
+| 11 | Concurrent setChannelData + scheduler | `_channelDataMutex` serializes; priority flag survives concurrent arm + claim. |
+| 12 | OTA pause + resume | Watchdog tolerates a 15 s+ pause: on resume, all stale channels get force-picked one by one. |
+
+---
+
+## Testing
+
+**Local Python simulator** (`_scheduler_sim/`, gitignored, removed before final commit):
+
+- `scheduler_buggy.py` - faithful port of the *current* C++ algorithm, used to first reproduce issue #149's ch4 starvation.
+- `scheduler_fixed.py` - port of the *fixed* algorithm including all five fixes.
+- `scenarios.py` - the 12 edge cases above as deterministic generators.
+- `test_scheduler.py` - pytest suite asserting:
+  - Buggy version: ch4 read count drops to <= 5 per 100 s during a 60 s discard storm (reproduces #149).
+  - Fixed version: every active channel read at least once per `CHANNEL_MAX_GAP_MS` in every scenario.
+  - Fixed version: read distribution within 20% of weight share over 1 h simulated time.
+  - Fixed version: `|deficit[i]|` stays under `MAX_CHANNEL_DEFICIT_BOUND` in every scenario.
+  - Fixed version: after a 60 s discard storm clears, all channels return to their weight share within one round.
+  - NaN injection: simulator continues running, no channel index becomes invalid.
+
+**On-device validation** (Jibril, hardware):
+
+1. Flash fixed firmware on the dev board.
+2. Clamp ch4 backwards, wait 30 s. Expect: ch4 sampled at watchdog cadence (~15 s) with a `LOG_WARNING` line per pick, no silent gaps.
+3. Correct the orientation, PUT `reverse: false`. Expect: ch4's very next CYCEND lands a successful reading, channel returns to its normal cadence within the next round, no further warnings.
+4. Toggle ch4 active/inactive several times. Expect: scheduler stabilises immediately.
+5. Run for 1 hour, capture UDP log. Expect: zero `Channel %u starved` warnings under normal operation.
+
+---
+
+## Commit Plan
+
+Each step independently testable against the simulator before moving to the next:
+
+1. `fix(ade7953): refund channel deficit on discarded reads`
+2. `fix(ade7953): run gain phase before priority-override return`
+3. `fix(ade7953): arm priority read on reverse flag change`
+4. `fix(ade7953): clamp deficit magnitude and guard against nan`
+5. `feat(ade7953): add 15s starvation watchdog with warning log`
+
+Commits land on `fix/ade7953-scheduler-starvation`, off `development`. PR closes #149.
+
+---
+
+## Risks and Rollback
+
+- **Risk:** the watchdog could mask a deeper hardware problem (mux not switching, SPI flake) by repeatedly force-picking a channel that never reads successfully. **Mitigation:** every force-pick logs `LOG_WARNING` with the gap; existing `ADE7953_MAX_FAILURES_BEFORE_RESTART = 100/min` still trips on the underlying SPI failures.
+- **Risk:** the deficit clamp could mask a genuine weight-table issue. **Mitigation:** the clamp is symmetric and large (5x the typical operating range), so it only triggers in pathological cases. Add a `LOG_DEBUG` when the clamp engages so issues are still visible at higher log levels.
+- **Rollback:** each commit is independent. The watchdog (Fix 5) is the most behaviour-changing; the first four are pure correctness fixes that match what WDRR is supposed to do per the literature.

--- a/source/include/issueregistry.h
+++ b/source/include/issueregistry.h
@@ -62,6 +62,15 @@ namespace IssueRegistry
     // Acknowledge every visible instance. Returns the number acked.
     uint32_t ackAll();
 
+    // Number of currently-active instances (ActiveUnacked + ActiveAcked).
+    uint32_t activeCount();
+
+    // Observer hook: invoked from the registry task on any state transition or
+    // ack so a consumer (e.g. the issues shadow) can refresh its mirror. The
+    // callback must be cheap and non-blocking - set a flag, never publish.
+    using ChangeCallback = void (*)();
+    void setChangeCallback(ChangeCallback cb);
+
     // Task information
     TaskInfo getTaskInfo();
 }

--- a/source/include/mqtt.h
+++ b/source/include/mqtt.h
@@ -52,7 +52,12 @@
 #define MQTT_PREFERENCES_OTA_EXPECTED_SHA256_KEY "ota_sha256" // Expected firmware SHA256 for validation
 
 // MQTT buffer sizes - all moved to PSRAM for better memory utilization
-#define MQTT_BUFFER_SIZE (5 * 1024) // Needs to be at least 4 kB for the certificates
+// 9 KB sized for the worst-case inbound shadow /update/delta (changed desired
+// fields + per-field metadata) now that /update/accepted is intentionally not
+// subscribed. This static PubSubClient RX/TX buffer lives in internal RAM and
+// adds pressure at the TLS handshake (see the 2.0.0 esp-aes alloc memory) -
+// verify free internal heap after connect on real hardware.
+#define MQTT_BUFFER_SIZE (9 * 1024)
 #define MQTT_SUBSCRIBE_MESSAGE_BUFFER_SIZE (32 * 1024) // PSRAM buffer for MQTT subscribe messages (reduced for efficiency)
 #define CERTIFICATE_BUFFER_SIZE (16 * 1024)   // PSRAM buffer for certificate storage (was 4KB)
 #define MINIMUM_CERTIFICATE_LENGTH 128 // Minimum length for valid certificates (to avoid empty strings)
@@ -91,35 +96,33 @@
 #define MQTT_PREFERENCES_MQTT_LOG_LEVEL_KEY "log_level_int"
 
 // MQTT topic suffixes (application-level; see awsconfig.h for the namespace prefix)
-// Publish topics
+// Publish topics. system/static + channel retired (-> info + channels shadows);
+// configurable state lives in shadows, telemetry topics carry runtime data only.
 #define MQTT_TOPIC_METER "meter"
-#define MQTT_TOPIC_SYSTEM_STATIC "system/static"
 #define MQTT_TOPIC_SYSTEM_DYNAMIC "system/dynamic"
-#define MQTT_TOPIC_CHANNEL "channel"
 #define MQTT_TOPIC_STATISTICS "statistics"
 #define MQTT_TOPIC_CRASH "crash"
 #define MQTT_TOPIC_LOG "log"
-// Subscribe topics
-#define MQTT_TOPIC_SUBSCRIBE_COMMAND "command"
+// Subscribe topics. The legacy `command` topic is retired (-> IoT Commands +
+// system shadow); only AWS IoT Jobs (OTA) and shadow/command reserved topics remain.
 #define MQTT_TOPIC_SUBSCRIBE_JOBS "jobs"
 #define MQTT_TOPIC_SUBSCRIBE_QOS 1
+
+// AWS IoT Commands (transient operations): reject any request older than this.
+#define COMMAND_MAX_AGE_SECONDS 300 // 5 minutes
 
 struct PublishMqtt
 {
   bool meter;
   bool systemDynamic;
-  bool systemStatic;
-  bool channel;
   bool statistics;
   bool crash;
   bool requestOta;
 
-  PublishMqtt() : 
+  PublishMqtt() :
     meter(false), // Need to fill queue first
-    systemDynamic(true), 
-    systemStatic(true), 
-    channel(true), 
-    statistics(true), 
+    systemDynamic(true),
+    statistics(true),
     crash(false), // May not be present
     requestOta(true) {} // Always require on connection
 };
@@ -156,4 +159,10 @@ namespace Mqtt
     void setRuntimeLogLevel(int level);      // runtime only - NOT persisted (transient verbose)
     bool getSendPowerData();
     void setSendPowerData(bool enabled);     // persisted
+
+#ifdef ENV_DEV
+    // Dev-only: inject a synthetic IoT Command execution through the real handler
+    // (staged from the caller's task, dispatched on the MQTT task). Never in prod.
+    void injectCommandExecution(const char* executionId, const char* payload);
+#endif
 }

--- a/source/include/mqtt.h
+++ b/source/include/mqtt.h
@@ -111,14 +111,15 @@
 // AWS IoT Commands (transient operations): reject any request older than this.
 #define COMMAND_MAX_AGE_SECONDS 300 // 5 minutes
 
-// AWS IoT Commands subscription gate.
-// WARNING - FLEET HAZARD WHEN ON BUT CLOUD NOT READY: enabling this subscribes to
-// "$aws/commands/things/<id>/executions/+/request/+". If AWS IoT Commands is not
-// live/accepted in the account + region (eu-west-1), the broker closes the session
-// with disconnectReason CLIENT_ERROR ~30 ms after connect - a ~1.2 s reconnect
-// storm on EVERY device that runs it (observed on dev .174). Do NOT cut a fleet
-// release with this ON until IoT Commands is verified end-to-end in eu-west-1
-// (reserved topic accepted + a StartCommandExecution dispatcher exists).
+// AWS IoT Commands subscription gate (compile-time feature flag).
+// The device subscribes to "$aws/commands/things/<id>/executions/+/request/json"
+// - '+' is the execution-id wildcard only; the payload-format segment is the
+// concrete "json", never a '+'. An earlier build used '+' at the payload-format
+// position, an unsupported reserved-topic subscribe that made the broker drop the
+// session with CLIENT_ERROR (~1.2 s reconnect storm, observed on dev .174). The
+// corrected topic is safe to subscribe even before a dispatcher exists. For the
+// device to RECEIVE commands, the cloud must create them with contentType
+// application/json (so AWS publishes to .../request/json, matching this subscribe).
 #define MQTT_IOT_COMMANDS_SUBSCRIBE_ENABLED true
 
 struct PublishMqtt

--- a/source/include/mqtt.h
+++ b/source/include/mqtt.h
@@ -111,6 +111,16 @@
 // AWS IoT Commands (transient operations): reject any request older than this.
 #define COMMAND_MAX_AGE_SECONDS 300 // 5 minutes
 
+// AWS IoT Commands subscription gate. The "$aws/commands/..." reserved topic
+// namespace must be provisioned account-side (the IoT Commands feature) before
+// a device may subscribe to it. Subscribing to an unrecognized reserved topic
+// makes the broker close the connection with disconnectReason CLIENT_ERROR -
+// observed on dev .174 as a ~1.2 s connect/drop storm (zero stable session).
+// The cloud command dispatcher is not live yet, so keep this OFF until IoT
+// Commands is provisioned end-to-end; the handler code stays compiled and
+// tested, it just isn't wired to the broker until the cloud side exists.
+#define MQTT_IOT_COMMANDS_SUBSCRIBE_ENABLED false
+
 struct PublishMqtt
 {
   bool meter;

--- a/source/include/mqtt.h
+++ b/source/include/mqtt.h
@@ -111,15 +111,15 @@
 // AWS IoT Commands (transient operations): reject any request older than this.
 #define COMMAND_MAX_AGE_SECONDS 300 // 5 minutes
 
-// AWS IoT Commands subscription gate. The "$aws/commands/..." reserved topic
-// namespace must be provisioned account-side (the IoT Commands feature) before
-// a device may subscribe to it. Subscribing to an unrecognized reserved topic
-// makes the broker close the connection with disconnectReason CLIENT_ERROR -
-// observed on dev .174 as a ~1.2 s connect/drop storm (zero stable session).
-// The cloud command dispatcher is not live yet, so keep this OFF until IoT
-// Commands is provisioned end-to-end; the handler code stays compiled and
-// tested, it just isn't wired to the broker until the cloud side exists.
-#define MQTT_IOT_COMMANDS_SUBSCRIBE_ENABLED false
+// AWS IoT Commands subscription gate.
+// WARNING - FLEET HAZARD WHEN ON BUT CLOUD NOT READY: enabling this subscribes to
+// "$aws/commands/things/<id>/executions/+/request/+". If AWS IoT Commands is not
+// live/accepted in the account + region (eu-west-1), the broker closes the session
+// with disconnectReason CLIENT_ERROR ~30 ms after connect - a ~1.2 s reconnect
+// storm on EVERY device that runs it (observed on dev .174). Do NOT cut a fleet
+// release with this ON until IoT Commands is verified end-to-end in eu-west-1
+// (reserved topic accepted + a StartCommandExecution dispatcher exists).
+#define MQTT_IOT_COMMANDS_SUBSCRIBE_ENABLED true
 
 struct PublishMqtt
 {

--- a/source/include/mqtt.h
+++ b/source/include/mqtt.h
@@ -144,4 +144,9 @@ namespace Mqtt
 
     TaskInfo getMqttTaskInfo();
     TaskInfo getMqttOtaTaskInfo();
+
+    // Shadow module helpers: subscribe/publish on reserved $aws/things/<id>/...
+    // topics (the shadow module builds the "shadow/name/<name>/..." suffix).
+    bool subscribeReservedThings(const char* finalTopic);
+    bool publishReservedThings(JsonDocument& jsonDocument, const char* finalTopic, bool retain = false);
 }

--- a/source/include/mqtt.h
+++ b/source/include/mqtt.h
@@ -149,4 +149,11 @@ namespace Mqtt
     // topics (the shadow module builds the "shadow/name/<name>/..." suffix).
     bool subscribeReservedThings(const char* finalTopic);
     bool publishReservedThings(JsonDocument& jsonDocument, const char* finalTopic, bool retain = false);
+
+    // Config accessors used by the system shadow (04).
+    int  getMqttLogLevel();                  // current runtime level int (0..5)
+    void setMqttLogLevel(const char* level); // persisted baseline (validates the name)
+    void setRuntimeLogLevel(int level);      // runtime only - NOT persisted (transient verbose)
+    bool getSendPowerData();
+    void setSendPowerData(bool enabled);     // persisted
 }

--- a/source/include/mqtt.h
+++ b/source/include/mqtt.h
@@ -94,6 +94,7 @@
 #define MQTT_PREFERENCES_IS_CLOUD_SERVICES_ENABLED_KEY "en_cloud"
 #define MQTT_PREFERENCES_SEND_POWER_DATA_KEY "send_power"
 #define MQTT_PREFERENCES_MQTT_LOG_LEVEL_KEY "log_level_int"
+#define MQTT_PREFERENCES_TRANSIENT_LOG_LEVEL_KEY "transient_log" // active transient (VERBOSE/DEBUG) level, persisted so a debug session survives a reboot; absent = none
 
 // MQTT topic suffixes (application-level; see awsconfig.h for the namespace prefix)
 // Publish topics. system/static + channel retired (-> info + channels shadows);
@@ -168,6 +169,11 @@ namespace Mqtt
     int  getMqttLogLevel();                  // current runtime level int (0..5)
     void setMqttLogLevel(const char* level); // persisted baseline (validates the name)
     void setRuntimeLogLevel(int level);      // runtime only - NOT persisted (transient verbose)
+    // Transient (VERBOSE/DEBUG) reboot-restore marker. Persisted separately from
+    // the baseline so a debug session keeps boot-time logs across a reboot.
+    void saveTransientLogLevel(int level);   // persist active transient level (no-op if unchanged)
+    void clearTransientLogLevel();           // clear the marker (revert / persistent set)
+    int  getTransientLogLevel();             // persisted transient level, or -1 if none
     bool getSendPowerData();
     void setSendPowerData(bool enabled);     // persisted
 

--- a/source/include/shadow.h
+++ b/source/include/shadow.h
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#pragma once
+
+#include <Arduino.h>
+#include <ArduinoJson.h>
+
+#include "constants.h"
+
+// AWS IoT Named Device Shadow module (issue #159).
+//
+// Implements the publish-reported-first / no-GET / no-accepted protocol (see
+// docs/feature/2026-06-16-shadow-v2-config/00-overview-and-contract.md) for any
+// number of named shadows. Each shadow registers a Descriptor with a ReportFn
+// (serialize current state) and, if writable, an ApplyFn (apply a cloud delta).
+//
+// Threading model (no PubSubClient access happens off the MQTT task):
+//  - routeMessage()  runs inside the PubSubClient callback (MQTT task): it only
+//    copies the inbound payload out and flags it, never applies or publishes.
+//  - checkPublish()  runs in the MQTT task body: it drains pending deltas
+//    (apply -> ack publish), pending local edits and pending reports.
+//  - requestReport() / publishLocalEdit() may be called from other tasks
+//    (issue registry, esp_timer, web server); they only set a flag / stage a
+//    buffer under _shadowMutex - the MQTT task does the actual publishing.
+namespace Shadow {
+
+// Fill doc["state"]["reported"] with the shadow's full current state.
+using ReportFn = void (*)(JsonDocument& doc);
+
+// Apply one cloud delta. `delta` holds the changed desired fields (the AWS
+// /update/delta "state" object). Fill `reported` with the values actually
+// applied (echoed back to confirm). `desired` may be used to null specific
+// (possibly nested) keys; any top-level delta key left untouched here is
+// auto-nulled by the envelope so every cloud-sent field is acked/cleared.
+// Return true if at least one field was applied (informational only).
+using ApplyFn = bool (*)(JsonObjectConst delta, JsonObject reported, JsonObject desired);
+
+struct Descriptor {
+    const char* name;     // "info", "system", ... (named-shadow name)
+    bool        writable; // false => reported-only, no delta/rejected subscribe
+    ReportFn    report;
+    ApplyFn     apply;    // nullptr when !writable
+};
+
+// Create the mutex and register all shadow descriptors. Call once from Mqtt::begin().
+void begin();
+
+// Subscribe each writable shadow's delta/rejected topics and queue an initial
+// reported publish for every shadow. Call from the MQTT task after (re)connect.
+void onMqttConnected();
+
+// Inspect an inbound MQTT topic; if it is a shadow topic, copy the payload out,
+// flag it for the task-body drain, and return true (handled). Never applies or
+// publishes - safe to call from the PubSubClient callback. Returns false if the
+// topic is not a shadow topic.
+bool routeMessage(const char* topic, const char* payload);
+
+// Drain pending deltas, local edits and reports for all shadows. Call from the
+// MQTT task body (after _clientMqtt.loop()).
+void checkPublish();
+
+// Queue a full reported publish for one shadow (flag only; cross-task safe).
+void requestReport(const char* name);
+
+// A local (REST/UI) edit just changed `changedFields` for shadow `name`. Stages
+// a combined {reported:changedFields, desired:{each key:null}} publish so the
+// local value wins and clears any pending cloud desired for those keys. Safe to
+// call from the web task (stages under mutex; MQTT task publishes).
+void publishLocalEdit(const char* name, JsonObjectConst changedFields);
+
+#ifdef ENV_DEV
+// Dev-only: feed a synthetic delta document (e.g. {"version":1,"state":{...}})
+// through the real inbound path (routeMessage -> drain -> apply -> ack) without
+// a cloud writer. Returns true if the named shadow accepted it for processing.
+bool injectDelta(const char* name, const char* payload);
+#endif
+
+} // namespace Shadow

--- a/source/include/shadow.h
+++ b/source/include/shadow.h
@@ -19,10 +19,11 @@
 //  - routeMessage()  runs inside the PubSubClient callback (MQTT task): it only
 //    copies the inbound payload out and flags it, never applies or publishes.
 //  - checkPublish()  runs in the MQTT task body: it drains pending deltas
-//    (apply -> ack publish), pending local edits and pending reports.
-//  - requestReport() / publishLocalEdit() may be called from other tasks
-//    (issue registry, esp_timer, web server); they only set a flag / stage a
-//    buffer under _shadowMutex - the MQTT task does the actual publishing.
+//    (apply -> ack publish) and pending reports, and republishes any writable
+//    shadow whose reported state drifted from its last publish (so a local
+//    config change from any source reaches the cloud without a per-call hook).
+//  - requestReport() may be called from other tasks (issue registry, esp_timer,
+//    web server); it only sets a flag - the MQTT task does the actual publishing.
 namespace Shadow {
 
 // Fill doc["state"]["reported"] with the shadow's full current state.
@@ -62,12 +63,6 @@ void checkPublish();
 
 // Queue a full reported publish for one shadow (flag only; cross-task safe).
 void requestReport(const char* name);
-
-// A local (REST/UI) edit just changed `changedFields` for shadow `name`. Stages
-// a combined {reported:changedFields, desired:{each key:null}} publish so the
-// local value wins and clears any pending cloud desired for those keys. Safe to
-// call from the web task (stages under mutex; MQTT task publishes).
-void publishLocalEdit(const char* name, JsonObjectConst changedFields);
 
 #ifdef ENV_DEV
 // Dev-only: feed a synthetic delta document (e.g. {"version":1,"state":{...}})

--- a/source/include/shadow.h
+++ b/source/include/shadow.h
@@ -31,11 +31,12 @@ using ReportFn = void (*)(JsonDocument& doc);
 
 // Apply one cloud delta. `delta` holds the changed desired fields (the AWS
 // /update/delta "state" object). Fill `reported` with the values actually
-// applied (echoed back to confirm). `desired` may be used to null specific
-// (possibly nested) keys; any top-level delta key left untouched here is
-// auto-nulled by the envelope so every cloud-sent field is acked/cleared.
-// Return true if at least one field was applied (informational only).
-using ApplyFn = bool (*)(JsonObjectConst delta, JsonObject reported, JsonObject desired);
+// applied (echoed back to confirm). The envelope auto-nulls every top-level
+// delta key in `desired` after this returns, so the delta clears - callbacks
+// never touch desired (whole-key nulling avoids a re-trigger storm for fields
+// the device cannot converge). Return true if at least one field was applied
+// (informational only).
+using ApplyFn = bool (*)(JsonObjectConst delta, JsonObject reported);
 
 struct Descriptor {
     const char* name;     // "info", "system", ... (named-shadow name)

--- a/source/lib/shadow_logic/shadow_logic.cpp
+++ b/source/lib/shadow_logic/shadow_logic.cpp
@@ -51,4 +51,29 @@ size_t formatClientToken(char* out, size_t outSize, uint32_t r1, uint32_t r2) {
     return 16;
 }
 
+bool extractExecutionId(const char* topic, char* out, size_t outSize) {
+    if (topic == nullptr || out == nullptr || outSize == 0) return false;
+
+    static const char marker[] = "/executions/";
+    const char* start = strstr(topic, marker);
+    if (start == nullptr) return false;
+    start += sizeof(marker) - 1; // advance past "/executions/"
+
+    const char* end = strchr(start, '/');
+    if (end == nullptr || end == start) return false; // missing trailing "/request/..." or empty id
+
+    size_t len = (size_t)(end - start);
+    if (len + 1 > outSize) return false; // would truncate -> wrong response topic
+
+    memcpy(out, start, len);
+    out[len] = '\0';
+    return true;
+}
+
+bool isCommandStale(uint64_t createdAtUnix, uint64_t nowUnix, uint64_t maxAgeSeconds) {
+    if (createdAtUnix == 0) return false;       // no timestamp: cannot judge
+    if (nowUnix <= createdAtUnix) return false; // future/equal (clock skew): not stale
+    return (nowUnix - createdAtUnix) > maxAgeSeconds;
+}
+
 } // namespace ShadowLogic

--- a/source/lib/shadow_logic/shadow_logic.cpp
+++ b/source/lib/shadow_logic/shadow_logic.cpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#include "shadow_logic.h"
+
+#include <cstdio>
+#include <cstring>
+
+namespace ShadowLogic {
+
+// Indexed by level int (0..5); the single source of truth for both directions.
+static const char* const LEVEL_NAMES[] = {
+    "VERBOSE", "DEBUG", "INFO", "WARNING", "ERROR", "FATAL"};
+static constexpr int LEVEL_COUNT = 6;
+
+int logLevelFromString(const char* name) {
+    if (name == nullptr) return LOG_LEVEL_INVALID;
+    for (int i = 0; i < LEVEL_COUNT; i++) {
+        if (strcmp(name, LEVEL_NAMES[i]) == 0) return i;
+    }
+    return LOG_LEVEL_INVALID;
+}
+
+const char* logLevelToString(int level) {
+    if (level < 0 || level >= LEVEL_COUNT) return nullptr;
+    return LEVEL_NAMES[level];
+}
+
+bool isTransientLogLevel(int level) {
+    // VERBOSE (0) and DEBUG (1) are runtime-only and auto-reverted.
+    return level == 0 || level == 1;
+}
+
+bool parseChannelIndex(const char* key, uint8_t channelCount, uint8_t* out) {
+    if (key == nullptr || key[0] == '\0' || out == nullptr) return false;
+
+    uint32_t value = 0;
+    for (const char* p = key; *p != '\0'; p++) {
+        if (*p < '0' || *p > '9') return false;       // non-numeric key
+        value = value * 10u + (uint32_t)(*p - '0');
+        if (value >= (uint32_t)channelCount) return false; // out of range (also caps overflow)
+    }
+
+    *out = (uint8_t)value;
+    return true;
+}
+
+size_t formatClientToken(char* out, size_t outSize, uint32_t r1, uint32_t r2) {
+    if (out == nullptr || outSize < 17) return 0; // 16 hex chars + null terminator
+    snprintf(out, outSize, "%08x%08x", r1, r2);
+    return 16;
+}
+
+} // namespace ShadowLogic

--- a/source/lib/shadow_logic/shadow_logic.h
+++ b/source/lib/shadow_logic/shadow_logic.h
@@ -50,4 +50,23 @@ size_t formatClientToken(char* out, size_t outSize, uint32_t r1, uint32_t r2);
 // omitted to avoid a spurious 409 on the reconnect reported-first publish.
 inline bool shouldSendVersion(uint32_t version) { return version != 0; }
 
+// ----------------------------------------------------------------------------
+// AWS IoT Commands helpers
+// ----------------------------------------------------------------------------
+
+// Extract the executionId from a Commands request topic:
+//   $aws/commands/things/<thing>/executions/<execId>/request/<format>
+// Writes <execId> (null-terminated) into out. Returns false for a null/malformed
+// topic or if the id would not fit (a truncated id would publish the response to
+// the wrong topic and the command would never be acked).
+bool extractExecutionId(const char* topic, char* out, size_t outSize);
+
+// A command is stale when it was created more than maxAgeSeconds ago (guards
+// against acting on one queued during an offline window). createdAtUnix == 0
+// means "no server timestamp available" -> not treated as stale (the caller
+// logs and proceeds; the timestamp must come from the command payload since
+// MQTT 3.1.1 carries no user properties). A future/equal timestamp (clock skew)
+// is also not stale.
+bool isCommandStale(uint64_t createdAtUnix, uint64_t nowUnix, uint64_t maxAgeSeconds);
+
 } // namespace ShadowLogic

--- a/source/lib/shadow_logic/shadow_logic.h
+++ b/source/lib/shadow_logic/shadow_logic.h
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// Pure helpers for the AWS IoT Device Shadow config feature (issue #159).
+//
+// Everything here is free-standing: no Arduino, no ArduinoJson, no FreeRTOS, no
+// logging, no global state. The shadow module (src/shadow.cpp) owns the JSON
+// document shaping and the MQTT plumbing; it feeds these functions the small,
+// error-prone decisions (log-level name mapping, channel-key bounds, token
+// formatting, version gating) so they can be unit-tested on the host (see
+// test/test_shadow_logic) without any hardware or JSON library.
+namespace ShadowLogic {
+
+// Log levels mirror AdvancedLogger::LogLevel and Mqtt::_mqttLogLevelInt:
+//   0=VERBOSE 1=DEBUG 2=INFO 3=WARNING 4=ERROR 5=FATAL
+constexpr int LOG_LEVEL_INVALID = -1;
+
+// Parse a canonical uppercase level name ("INFO", "DEBUG", ...) to its int
+// (0..5). Matches the strict uppercase form used by the existing firmware
+// command parser and by the cloud contract. Returns LOG_LEVEL_INVALID for an
+// unknown name or a null pointer.
+int logLevelFromString(const char* name);
+
+// Int (0..5) to its canonical uppercase name. Returns nullptr if out of range.
+const char* logLevelToString(int level);
+
+// Transient levels (VERBOSE/DEBUG) are applied at runtime, never persisted, and
+// auto-reverted after a timeout; persistent levels (INFO/WARNING/ERROR/FATAL)
+// become the saved baseline. An out-of-range level is not transient.
+bool isTransientLogLevel(int level);
+
+// Parse an object key that must be a channel index ("0".."<channelCount-1>").
+// Accepts only all-digit strings whose value is < channelCount. Returns true
+// and sets *out on success; returns false (leaving *out untouched) for null,
+// empty, non-numeric, or out-of-range keys.
+bool parseChannelIndex(const char* key, uint8_t channelCount, uint8_t* out);
+
+// Format a 16-char lowercase-hex client token ("%08x%08x") from two 32-bit
+// randoms into out. Returns the number of characters written (16), or 0 if the
+// buffer is too small to hold the token plus its null terminator (needs >= 17).
+size_t formatClientToken(char* out, size_t outSize, uint32_t r1, uint32_t r2);
+
+// The optimistic-lock document version is echoed on the delta-ack publish only
+// when it is known (non-zero); a zero version means "not yet seen" and must be
+// omitted to avoid a spurious 409 on the reconnect reported-first publish.
+inline bool shouldSendVersion(uint32_t version) { return version != 0; }
+
+} // namespace ShadowLogic

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -709,7 +709,7 @@ namespace Ade7953
 
     bool setSampleTime(uint64_t sampleTime) {
         if (sampleTime < MINIMUM_SAMPLE_TIME) {
-            LOG_WARNING("Sample time %lu is below minimum %lu", sampleTime, MINIMUM_SAMPLE_TIME);
+            LOG_WARNING("Sample time %llu is below minimum %llu", sampleTime, MINIMUM_SAMPLE_TIME);
             return false;
         }
 

--- a/source/src/customserver.cpp
+++ b/source/src/customserver.cpp
@@ -4,6 +4,7 @@
 #include "customserver.h"
 #include "taskprofiler.h"
 #include "duration_format.h"
+#include "shadow.h"
 
 namespace CustomServer
 {
@@ -83,6 +84,9 @@ namespace CustomServer
     static void _serveBackupEndpoints();
     static void _serveRestoreEndpoints();
     static void _serveFileEndpoints();
+#ifdef ENV_DEV
+    static void _serveShadowDevEndpoints();
+#endif
     
     // Authentication endpoints
     static void _serveAuthStatusEndpoint();
@@ -618,6 +622,9 @@ namespace CustomServer
         _serveAuthEndpoints();
         _serveOtaEndpoints();
         _serveAde7953Endpoints();
+#ifdef ENV_DEV
+        _serveShadowDevEndpoints();
+#endif
         _serveCustomMqttEndpoints();
         _serveInfluxDbEndpoints();
         _serveCrashEndpoints();
@@ -1933,6 +1940,48 @@ namespace CustomServer
             });
         server.addHandler(setUdpDestinationHandler);
     }
+
+#ifdef ENV_DEV
+    // Dev-only: feed a synthetic shadow delta through the real inbound path
+    // (routeMessage -> task drain -> ApplyFn -> ack publish) so the apply logic
+    // can be exercised on hardware without a cloud desired-state writer. Never
+    // compiled into the production firmware.
+    // Body: {"name":"system","doc":{"version":1,"state":{"led_brightness":20}}}
+    static void _serveShadowDevEndpoints() {
+        static AsyncCallbackJsonWebHandler *injectShadowDeltaHandler = new AsyncCallbackJsonWebHandler(
+            "/api/v1/shadow/inject-delta",
+            [](AsyncWebServerRequest *request, JsonVariant &json)
+            {
+                if (!_validateRequest(request, "POST", HTTP_MAX_CONTENT_LENGTH_ADE7953_CHANNEL_DATA * MAX_CHANNEL_COUNT)) return;
+
+                const char *name = json["name"].as<const char *>();
+                if (!name || json["doc"].isNull()) {
+                    _sendErrorResponse(request, HTTP_CODE_BAD_REQUEST, "Body requires 'name' and 'doc'");
+                    return;
+                }
+
+                SpiRamAllocator allocator;
+                JsonDocument deltaDoc(&allocator);
+                deltaDoc.set(json["doc"]);
+
+                size_t len = measureJson(deltaDoc) + 1;
+                char *payload = (char *)ps_malloc(len);
+                if (!payload) {
+                    _sendErrorResponse(request, HTTP_CODE_INTERNAL_SERVER_ERROR, "Allocation failed");
+                    return;
+                }
+                serializeJson(deltaDoc, payload, len);
+
+                bool ok = Shadow::injectDelta(name, payload);
+                free(payload);
+
+                if (ok) _sendSuccessResponse(request, "Synthetic shadow delta injected");
+                else _sendErrorResponse(request, HTTP_CODE_BAD_REQUEST, "Unknown shadow name");
+            });
+        server.addHandler(injectShadowDeltaHandler);
+        LOG_DEBUG("Registered dev-only shadow delta injection endpoint");
+    }
+#endif
 
     // === ADE7953 ENDPOINTS ===
     static void _serveAde7953Endpoints() {

--- a/source/src/customserver.cpp
+++ b/source/src/customserver.cpp
@@ -1979,7 +1979,42 @@ namespace CustomServer
                 else _sendErrorResponse(request, HTTP_CODE_BAD_REQUEST, "Unknown shadow name");
             });
         server.addHandler(injectShadowDeltaHandler);
-        LOG_DEBUG("Registered dev-only shadow delta injection endpoint");
+
+        // Dev-only: inject a synthetic IoT Command execution through the real
+        // handler (no cloud dispatcher needed). The device acts on the operation;
+        // the response publish targets a synthetic execution id.
+        // Body: {"executionId":"dev-1","payload":{"operation":"energy_reset","channels":[3]}}
+        static AsyncCallbackJsonWebHandler *injectCommandHandler = new AsyncCallbackJsonWebHandler(
+            "/api/v1/shadow/inject-command",
+            [](AsyncWebServerRequest *request, JsonVariant &json)
+            {
+                if (!_validateRequest(request, "POST", HTTP_MAX_CONTENT_LENGTH_ADE7953_CHANNEL_DATA)) return;
+
+                const char *execId = json["executionId"].as<const char *>();
+                if (!execId || json["payload"].isNull()) {
+                    _sendErrorResponse(request, HTTP_CODE_BAD_REQUEST, "Body requires 'executionId' and 'payload'");
+                    return;
+                }
+
+                SpiRamAllocator allocator;
+                JsonDocument payloadDoc(&allocator);
+                payloadDoc.set(json["payload"]);
+
+                size_t len = measureJson(payloadDoc) + 1;
+                char *payload = (char *)ps_malloc(len);
+                if (!payload) {
+                    _sendErrorResponse(request, HTTP_CODE_INTERNAL_SERVER_ERROR, "Allocation failed");
+                    return;
+                }
+                serializeJson(payloadDoc, payload, len);
+
+                Mqtt::injectCommandExecution(execId, payload);
+                free(payload);
+                _sendSuccessResponse(request, "Synthetic command injected");
+            });
+        server.addHandler(injectCommandHandler);
+
+        LOG_DEBUG("Registered dev-only shadow delta + command injection endpoints");
     }
 #endif
 

--- a/source/src/issueregistry.cpp
+++ b/source/src/issueregistry.cpp
@@ -216,6 +216,12 @@ namespace IssueRegistry
 
     uint32_t activeCount()
     {
+        // NULL mutex = registry not initialized yet (early boot) or disabled
+        // (PSRAM alloc failed). Report zero, not an error: acquireMutex would just
+        // fail on the NULL handle and log noise on every issues-shadow publish.
+        // (Mirrors the guard in issuesToJson; both are read by _reportIssues.)
+        if (_registryMutex == NULL) return 0;
+
         if (!acquireMutex(&_registryMutex)) {
             LOG_ERROR("Failed to acquire registry mutex for activeCount");
             return 0;

--- a/source/src/issueregistry.cpp
+++ b/source/src/issueregistry.cpp
@@ -40,6 +40,9 @@ namespace IssueRegistry
     static IssueInstance *_instances = nullptr;
     static SemaphoreHandle_t _registryMutex = NULL;
 
+    // Observer notified on any transition/ack (set a flag; never blocks).
+    static ChangeCallback _onChange = nullptr;
+
     // Per-code evaluator state (tick task only - no mutex needed)
     // =========================================================
     static uint32_t _prevFlipCount[MAX_CHANNEL_COUNT] = {};
@@ -167,7 +170,10 @@ namespace IssueRegistry
         }
         releaseMutex(&_registryMutex);
 
-        if (acked) _logTransition("acked", false, code, channel, "");
+        if (acked) {
+            _logTransition("acked", false, code, channel, "");
+            if (_onChange != nullptr) _onChange(); // refresh issues shadow
+        }
         return acked;
     }
 
@@ -195,8 +201,25 @@ namespace IssueRegistry
         for (uint32_t i = 0; i < ackedCount; i++) {
             _logTransition("acked", false, ackedCodes[i], ackedChannels[i], "");
         }
+        if (ackedCount > 0 && _onChange != nullptr) _onChange(); // refresh issues shadow
         return ackedCount;
     }
+
+    uint32_t activeCount()
+    {
+        if (!acquireMutex(&_registryMutex)) {
+            LOG_ERROR("Failed to acquire registry mutex for activeCount");
+            return 0;
+        }
+        uint32_t count = 0;
+        for (uint8_t i = 0; i < ISSUE_MAX_INSTANCES; i++) {
+            if (IssueLogic::isActive(_instances[i].state)) count++;
+        }
+        releaseMutex(&_registryMutex);
+        return count;
+    }
+
+    void setChangeCallback(ChangeCallback cb) { _onChange = cb; }
 
     TaskInfo getTaskInfo()
     {
@@ -490,6 +513,7 @@ namespace IssueRegistry
 
         if (raised) _logTransition("raised", true, code, channel, logMessage);
         if (cleared) _logTransition("cleared", false, code, channel, logMessage);
+        if ((raised || cleared) && _onChange != nullptr) _onChange(); // refresh issues shadow
     }
 
     static IssueInstance* _findInstance(IssueLogic::Code code, uint8_t channel)

--- a/source/src/issueregistry.cpp
+++ b/source/src/issueregistry.cpp
@@ -125,6 +125,16 @@ namespace IssueRegistry
 
     bool issuesToJson(JsonDocument &doc)
     {
+        // Always present, even when empty, so callers get a valid shape.
+        JsonArray issues = doc["issues"].to<JsonArray>();
+
+        // NULL mutex = registry not initialized yet (early boot, before begin())
+        // or disabled (PSRAM alloc failed). Report an empty set, not an error:
+        // acquireMutex would just fail on the NULL handle. (begin() now runs before
+        // the web server, so this window is essentially closed; this also covers
+        // the permanent alloc-failure case gracefully.)
+        if (_registryMutex == NULL) return true;
+
         if (!acquireMutex(&_registryMutex)) {
             LOG_ERROR("Failed to acquire registry mutex for issuesToJson");
             return false;
@@ -132,7 +142,6 @@ namespace IssueRegistry
 
         // The table is tiny (a few KB): building the document under the mutex is
         // memory-only work; network serialization happens outside, on the copy.
-        JsonArray issues = doc["issues"].to<JsonArray>();
         for (uint8_t i = 0; i < ISSUE_MAX_INSTANCES; i++) {
             const IssueInstance &inst = _instances[i];
             if (!IssueLogic::isVisible(inst.state)) continue;

--- a/source/src/main.cpp
+++ b/source/src/main.cpp
@@ -163,6 +163,15 @@ void setup()
   if (CustomTime::begin()) LOG_INFO("Initial time sync successful");
   else LOG_ERROR("Initial time sync failed! Will retry later.");
 
+  // Before the web server: the /api/v1/system/issues endpoint reads the registry
+  // mutex, so the registry must exist before requests can arrive (else early polls
+  // hit a NULL mutex -> HTTP 500). Deps are ready here: hw profile (initHardwareProfile)
+  // and ADE7953 (channel facts) init earlier; time is up for issue timestamps. The
+  // task's cloud/influx checks read safe default flags until those modules begin().
+  LOG_DEBUG("Setting up issue registry...");
+  IssueRegistry::begin();
+  LOG_INFO("Issue registry setup done");
+
   LOG_DEBUG("Setting up server...");
   CustomServer::begin();
   LOG_INFO("Server setup done");
@@ -184,10 +193,6 @@ void setup()
   LOG_DEBUG("Setting up InfluxDB client...");
   InfluxDbClient::begin();
   LOG_INFO("InfluxDB client setup done");
-
-  LOG_DEBUG("Setting up issue registry...");
-  IssueRegistry::begin();
-  LOG_INFO("Issue registry setup done");
 
   LOG_DEBUG("Starting maintenance task...");
   startMaintenanceTask();

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -2,6 +2,7 @@
 // Copyright (C) 2025 Jibril Sharafi
 
 #include "mqtt.h"
+#include "shadow.h"
 #include "taskprofiler.h"
 #include "duration_format.h"
 
@@ -207,6 +208,7 @@ namespace Mqtt
 
         _setupTopics();
         _loadConfigFromPreferences();
+        Shadow::begin();
         _initializeLogQueue();
         _initializeMeterQueue();
         
@@ -380,6 +382,26 @@ namespace Mqtt
     TaskInfo getMqttOtaTaskInfo()
     {
         return getTaskInfoSafely(_otaTaskHandle, OTA_TASK_STACK_SIZE);
+    }
+
+    // Shadow module helpers
+    // =====================
+
+    bool subscribeReservedThings(const char* finalTopic) {
+        char topic[MQTT_TOPIC_BUFFER_SIZE];
+        _constructMqttTopicReservedThings(finalTopic, topic, sizeof(topic));
+        if (!_clientMqtt.subscribe(topic, MQTT_TOPIC_SUBSCRIBE_QOS)) {
+            LOG_WARNING("Failed to subscribe to %s", topic);
+            return false;
+        }
+        LOG_DEBUG("Subscribed to %s", topic);
+        return true;
+    }
+
+    bool publishReservedThings(JsonDocument& jsonDocument, const char* finalTopic, bool retain) {
+        char topic[MQTT_TOPIC_BUFFER_SIZE];
+        _constructMqttTopicReservedThings(finalTopic, topic, sizeof(topic));
+        return _publishJsonStreaming(jsonDocument, topic, retain);
     }
 
     // Private functions
@@ -756,6 +778,7 @@ namespace Mqtt
     static void _subscribeToTopics() {
         _subscribeCommand();
         _subscribeAwsIotJobs();
+        Shadow::onMqttConnected(); // subscribe shadow deltas + queue initial reports
 
         LOG_DEBUG("Subscribed to topics");
     }
@@ -830,7 +853,8 @@ namespace Mqtt
 
         LOG_DEBUG("Received MQTT message from %s", topic);
 
-        if (endsWith(topic, MQTT_TOPIC_SUBSCRIBE_COMMAND)) _handleCommandMessage(message);
+        if (Shadow::routeMessage(topic, message)) { /* handled by shadow module (copy + flag only) */ }
+        else if (endsWith(topic, MQTT_TOPIC_SUBSCRIBE_COMMAND)) _handleCommandMessage(message);
         else if (strstr(topic, MQTT_TOPIC_SUBSCRIBE_JOBS)) _handleAwsIotJobMessage(message, topic);
         else LOG_WARNING("Unknown MQTT topic received: %s", topic);
         
@@ -1914,6 +1938,7 @@ namespace Mqtt
         _checkIfPublishSystemDynamicNeeded();
         _checkIfPublishStatisticsNeeded();
         _checkPublishMqtt();
+        Shadow::checkPublish(); // drain shadow deltas/local-edits/reports (MQTT task body)
     }
 
     // Utilities

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -798,10 +798,10 @@ namespace Mqtt
 
     static void _subscribeToTopics() {
         _subscribeAwsIotJobs();
-        // Gated OFF until AWS IoT Commands is provisioned account-side - see
-        // MQTT_IOT_COMMANDS_SUBSCRIBE_ENABLED. Subscribing to the unprovisioned
-        // "$aws/commands/..." reserved topic triggers a broker CLIENT_ERROR
-        // disconnect (connect/drop storm).
+        // IoT Commands request topic (payload-format pinned to "json"; see
+        // MQTT_IOT_COMMANDS_SUBSCRIBE_ENABLED). The earlier '+' at the payload-format
+        // position was an unsupported reserved-topic subscribe -> broker CLIENT_ERROR
+        // reconnect storm; the corrected topic is safe even before a dispatcher exists.
         if (MQTT_IOT_COMMANDS_SUBSCRIBE_ENABLED) _subscribeIotCommands();
         Shadow::onMqttConnected(); // subscribe shadow deltas + queue initial reports
 
@@ -809,11 +809,15 @@ namespace Mqtt
     }
 
     static void _subscribeIotCommands() {
-        // AWS IoT Commands: wildcard request topic (executionId + payload-format
-        // are parsed from the received topic). Policy AllowSubscribe covers
+        // AWS IoT Commands request topic. '+' is the execution-id wildcard only;
+        // the payload-format segment must be a concrete value ("json"), NOT a '+'
+        // wildcard. A '+' there is an unsupported reserved-topic subscribe and the
+        // broker drops the whole session with CLIENT_ERROR (the ~1.2 s reconnect
+        // storm we hit). The cloud dispatcher must create commands with contentType
+        // application/json to match. Policy AllowSubscribe covers
         // $aws/commands/things/<thing>/*.
         char topic[MQTT_TOPIC_BUFFER_SIZE];
-        snprintf(topic, sizeof(topic), "%s/commands/things/%s/executions/+/request/+", AWS_TOPIC, DEVICE_ID);
+        snprintf(topic, sizeof(topic), "%s/commands/things/%s/executions/+/request/json", AWS_TOPIC, DEVICE_ID);
         if (_clientMqtt.subscribe(topic, MQTT_TOPIC_SUBSCRIBE_QOS)) {
             LOG_DEBUG("Subscribed to IoT Commands: %s", topic);
         } else {

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -798,7 +798,11 @@ namespace Mqtt
 
     static void _subscribeToTopics() {
         _subscribeAwsIotJobs();
-        _subscribeIotCommands();
+        // Gated OFF until AWS IoT Commands is provisioned account-side - see
+        // MQTT_IOT_COMMANDS_SUBSCRIBE_ENABLED. Subscribing to the unprovisioned
+        // "$aws/commands/..." reserved topic triggers a broker CLIENT_ERROR
+        // disconnect (connect/drop storm).
+        if (MQTT_IOT_COMMANDS_SUBSCRIBE_ENABLED) _subscribeIotCommands();
         Shadow::onMqttConnected(); // subscribe shadow deltas + queue initial reports
 
         LOG_DEBUG("Subscribed to topics");

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -812,6 +812,15 @@ namespace Mqtt
         LOG_DEBUG("Constructing MQTT topic for %s | %s", finalTopic, topicBuffer);
     }
 
+    // AWS IoT Commands execution topic: $aws/commands/things/<thing>/executions/
+    // <executionId>/<verb>. executionId is "+" for the subscribe wildcard; verb is
+    // "request/json" or "response/json".
+    static void _constructCommandTopic(const char* executionId, const char* verb,
+                                       char* topicBuffer, size_t topicBufferSize) {
+        snprintf(topicBuffer, topicBufferSize, "%s/commands/things/%s/executions/%s/%s",
+                 AWS_TOPIC, DEVICE_ID, executionId, verb);
+    }
+
     static void _setupTopics() {
         _setTopicMeter();
         _setTopicSystemDynamic();
@@ -849,7 +858,7 @@ namespace Mqtt
         // application/json to match. Policy AllowSubscribe covers
         // $aws/commands/things/<thing>/*.
         char topic[MQTT_TOPIC_BUFFER_SIZE];
-        snprintf(topic, sizeof(topic), "%s/commands/things/%s/executions/+/request/json", AWS_TOPIC, DEVICE_ID);
+        _constructCommandTopic("+", "request/json", topic, sizeof(topic));
         if (_clientMqtt.subscribe(topic, MQTT_TOPIC_SUBSCRIBE_QOS)) {
             LOG_DEBUG("Subscribed to IoT Commands: %s", topic);
         } else {
@@ -939,8 +948,7 @@ namespace Mqtt
     static void _publishCommandStatus(const char* executionId, const char* status,
                                        const char* reasonCode, const char* reasonDescription) {
         char topic[MQTT_TOPIC_BUFFER_SIZE];
-        snprintf(topic, sizeof(topic), "%s/commands/things/%s/executions/%s/response/json",
-                 AWS_TOPIC, DEVICE_ID, executionId);
+        _constructCommandTopic(executionId, "response/json", topic, sizeof(topic));
 
         SpiRamAllocator allocator;
         JsonDocument doc(&allocator);
@@ -1095,8 +1103,7 @@ namespace Mqtt
     void injectCommandExecution(const char* executionId, const char* payload) {
         if (executionId == nullptr || payload == nullptr) return;
         char topic[MQTT_TOPIC_BUFFER_SIZE];
-        snprintf(topic, sizeof(topic), "%s/commands/things/%s/executions/%s/request/json",
-                 AWS_TOPIC, DEVICE_ID, executionId);
+        _constructCommandTopic(executionId, "request/json", topic, sizeof(topic));
         _queueCommand(topic, payload);
         LOG_INFO("Injected synthetic command execution %s", executionId);
     }

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -421,8 +421,41 @@ namespace Mqtt
         _mqttLogLevelInt = (uint8_t)level;
         _updateMqttMinLogLevel();
         releaseMutex(&_configMutex);
-        // Intentionally NOT persisted: this is the transient verbose window; a
-        // reboot returns to the saved baseline.
+        // Intentionally NOT persisted here: the runtime int stays transient. The
+        // separate transient marker (saveTransientLogLevel) is what survives a
+        // reboot; the persisted baseline key is never touched by a transient.
+    }
+
+    void saveTransientLogLevel(int level) {
+        if (level < 0 || level > 5) return;
+        Preferences prefs;
+        if (!prefs.begin(PREFERENCES_NAMESPACE_MQTT, false)) {
+            LOG_WARNING("Failed to open preferences to save transient log level");
+            return;
+        }
+        // Write only on change: a long cloud-held verbose window re-asserts the
+        // same level every <5 min, and we must not wear flash for a no-op.
+        if (prefs.getUChar(MQTT_PREFERENCES_TRANSIENT_LOG_LEVEL_KEY, 0xFF) != (uint8_t)level) {
+            prefs.putUChar(MQTT_PREFERENCES_TRANSIENT_LOG_LEVEL_KEY, (uint8_t)level);
+        }
+        prefs.end();
+    }
+
+    void clearTransientLogLevel() {
+        Preferences prefs;
+        if (!prefs.begin(PREFERENCES_NAMESPACE_MQTT, false)) return;
+        if (prefs.isKey(MQTT_PREFERENCES_TRANSIENT_LOG_LEVEL_KEY)) {
+            prefs.remove(MQTT_PREFERENCES_TRANSIENT_LOG_LEVEL_KEY);
+        }
+        prefs.end();
+    }
+
+    int getTransientLogLevel() {
+        Preferences prefs;
+        if (!prefs.begin(PREFERENCES_NAMESPACE_MQTT, true)) return -1;
+        uint8_t v = prefs.getUChar(MQTT_PREFERENCES_TRANSIENT_LOG_LEVEL_KEY, 0xFF);
+        prefs.end();
+        return (v == 0xFF) ? -1 : (int)v;
     }
 
     bool getSendPowerData() { return _sendPowerDataEnabled; }

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -404,6 +404,30 @@ namespace Mqtt
         return _publishJsonStreaming(jsonDocument, topic, retain);
     }
 
+    int getMqttLogLevel() { return _mqttLogLevelInt; }
+
+    void setMqttLogLevel(const char* level) { _setMqttLogLevel(level); } // validates + persists
+
+    void setRuntimeLogLevel(int level) {
+        if (level < 0 || level > 5) {
+            LOG_WARNING("Invalid runtime log level %d", level);
+            return;
+        }
+        if (!acquireMutex(&_configMutex, CONFIG_MUTEX_TIMEOUT_MS)) {
+            LOG_ERROR("Failed to acquire config mutex for runtime log level");
+            return;
+        }
+        _mqttLogLevelInt = (uint8_t)level;
+        _updateMqttMinLogLevel();
+        releaseMutex(&_configMutex);
+        // Intentionally NOT persisted: this is the transient verbose window; a
+        // reboot returns to the saved baseline.
+    }
+
+    bool getSendPowerData() { return _sendPowerDataEnabled; }
+
+    void setSendPowerData(bool enabled) { _setSendPowerDataEnabled(enabled); } // persists
+
     // Private functions
     // =================
     // =================

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -123,9 +123,8 @@ namespace Mqtt
     static void _subscribeCallback(const char* topic, byte *payload, uint32_t length);
     static void _handleCommandExecution(const char* topic, const char* message);
     static void _publishCommandStatus(const char* executionId, const char* status, const char* reasonCode, const char* reasonDescription);
-#ifdef ENV_DEV
-    static void _drainInjectedCommand();
-#endif
+    static void _queueCommand(const char* topic, const char* payload);
+    static void _drainPendingCommand();
     static void _handleAwsIotJobMessage(const char* message, const char* topic);
     
     // AWS IoT Jobs OTA functions
@@ -919,7 +918,7 @@ namespace Mqtt
         // also catches AWS's own .../response/rejected/json echo of our status publish,
         // which has no 'operation', gets re-rejected, and echoes again -> infinite
         // publish loop hammering the broker.
-        else if (strstr(topic, "/commands/things/") != nullptr && endsWith(topic, "/request/json")) _handleCommandExecution(topic, message);
+        else if (strstr(topic, "/commands/things/") != nullptr && endsWith(topic, "/request/json")) _queueCommand(topic, message);
         else if (strstr(topic, "/commands/things/") != nullptr) {
             // AWS echoed our own command-status publish back (e.g. rejecting a status
             // for an unknown/expired execution). Never reprocess it - just note it.
@@ -1033,58 +1032,73 @@ namespace Mqtt
         }
     }
 
-#ifdef ENV_DEV
-    // Dev-only synthetic command injection: the caller's task stashes the request
-    // (reusing _configMutex for the brief pointer handoff), the MQTT task drains
-    // it through the real handler so the status publish + reboot stay single-task.
-    static char* _injectedCmdTopic = nullptr;
-    static char* _injectedCmdPayload = nullptr;
+    // Command handoff. Both the broker RX path (_subscribeCallback) and the dev
+    // inject copy the request out + stash it here; the MQTT task body drains it
+    // through _handleCommandExecution. So the apply (per-channel NVS writes, up to
+    // ~1 s) and the status publishes run in the task body, NEVER inside the
+    // PubSubClient callback - same rule as shadow deltas (#138). Publishing inside
+    // the callback would also reuse PubSubClient's single buffer and corrupt the
+    // QoS1 PUBACK it writes right after the callback returns. Single slot is safe:
+    // loop() delivers one PUBLISH per call and we drain every iteration. Overwrite
+    // is warned, never silent, so a dropped command is always visible.
+    static char* _pendingCmdTopic = nullptr;
+    static char* _pendingCmdPayload = nullptr;
 
-    void injectCommandExecution(const char* executionId, const char* payload) {
-        if (executionId == nullptr || payload == nullptr) return;
-        char topic[MQTT_TOPIC_BUFFER_SIZE];
-        snprintf(topic, sizeof(topic), "%s/commands/things/%s/executions/%s/request/json",
-                 AWS_TOPIC, DEVICE_ID, executionId);
-
+    static void _queueCommand(const char* topic, const char* payload) {
+        if (topic == nullptr || payload == nullptr) return;
         size_t tlen = strlen(topic) + 1, plen = strlen(payload) + 1;
         char* t = (char*)ps_malloc(tlen);
         char* p = (char*)ps_malloc(plen);
         if (t == nullptr || p == nullptr) {
             if (t) free(t);
             if (p) free(p);
-            LOG_ERROR("Failed to allocate injected command buffers");
+            LOG_ERROR("Failed to allocate pending command buffers");
             return;
         }
         memcpy(t, topic, tlen);
         memcpy(p, payload, plen);
 
         if (acquireMutex(&_configMutex, CONFIG_MUTEX_TIMEOUT_MS)) {
-            if (_injectedCmdTopic) free(_injectedCmdTopic);
-            if (_injectedCmdPayload) free(_injectedCmdPayload);
-            _injectedCmdTopic = t;
-            _injectedCmdPayload = p;
+            if (_pendingCmdTopic != nullptr || _pendingCmdPayload != nullptr) {
+                LOG_WARNING("Overwriting an undrained pending command; previous one dropped");
+                if (_pendingCmdTopic) free(_pendingCmdTopic);
+                if (_pendingCmdPayload) free(_pendingCmdPayload);
+            }
+            _pendingCmdTopic = t;
+            _pendingCmdPayload = p;
             releaseMutex(&_configMutex);
-            LOG_INFO("Injected synthetic command execution %s", executionId);
         } else {
             free(t);
             free(p);
-            LOG_ERROR("Failed to acquire mutex staging injected command");
+            LOG_ERROR("Failed to acquire mutex queuing command");
         }
     }
 
-    static void _drainInjectedCommand() {
+    static void _drainPendingCommand() {
         char* t = nullptr;
         char* p = nullptr;
         if (acquireMutex(&_configMutex, CONFIG_MUTEX_TIMEOUT_MS)) {
-            t = _injectedCmdTopic;
-            _injectedCmdTopic = nullptr;
-            p = _injectedCmdPayload;
-            _injectedCmdPayload = nullptr;
+            t = _pendingCmdTopic;
+            _pendingCmdTopic = nullptr;
+            p = _pendingCmdPayload;
+            _pendingCmdPayload = nullptr;
             releaseMutex(&_configMutex);
         }
         if (t != nullptr && p != nullptr) _handleCommandExecution(t, p);
         if (t) free(t);
         if (p) free(p);
+    }
+
+#ifdef ENV_DEV
+    // Dev-only synthetic command injection: build the real request topic and route
+    // it through the same queue + task-body drain the broker path uses.
+    void injectCommandExecution(const char* executionId, const char* payload) {
+        if (executionId == nullptr || payload == nullptr) return;
+        char topic[MQTT_TOPIC_BUFFER_SIZE];
+        snprintf(topic, sizeof(topic), "%s/commands/things/%s/executions/%s/request/json",
+                 AWS_TOPIC, DEVICE_ID, executionId);
+        _queueCommand(topic, payload);
+        LOG_INFO("Injected synthetic command execution %s", executionId);
     }
 #endif
 
@@ -2048,9 +2062,7 @@ namespace Mqtt
         _checkIfPublishStatisticsNeeded();
         _checkPublishMqtt();
         Shadow::checkPublish(); // drain shadow deltas/local-edits/reports (MQTT task body)
-#ifdef ENV_DEV
-        _drainInjectedCommand(); // dev-only synthetic command injection
-#endif
+        _drainPendingCommand(); // process queued IoT Command (broker RX or dev inject) off the callback
     }
 
     // Utilities

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -3,6 +3,7 @@
 
 #include "mqtt.h"
 #include "shadow.h"
+#include "shadow_logic.h"
 #include "taskprofiler.h"
 #include "duration_format.h"
 
@@ -55,9 +56,7 @@ namespace Mqtt
     
     // Topic buffers
     static char _mqttTopicMeter[MQTT_TOPIC_BUFFER_SIZE];
-    static char _mqttTopicSystemStatic[MQTT_TOPIC_BUFFER_SIZE];
     static char _mqttTopicSystemDynamic[MQTT_TOPIC_BUFFER_SIZE];
-    static char _mqttTopicChannel[MQTT_TOPIC_BUFFER_SIZE];
     static char _mqttTopicStatistics[MQTT_TOPIC_BUFFER_SIZE];
     static char _mqttTopicCrash[MQTT_TOPIC_BUFFER_SIZE];
     static char _mqttTopicLog[MQTT_TOPIC_BUFFER_SIZE];
@@ -110,26 +109,24 @@ namespace Mqtt
 
     // Publish topics
     static void _setTopicMeter();
-    static void _setTopicSystemStatic();
     static void _setTopicSystemDynamic();
-    static void _setTopicChannel();
     static void _setTopicStatistics();
     static void _setTopicCrash();
     static void _setTopicLog();
 
     // Subscription management
     static void _subscribeToTopics();
-    static bool _subscribeToTopic(const char* topicSuffix);
-    static void _subscribeCommand();
     static void _subscribeAwsIotJobs();
-    
+    static void _subscribeIotCommands();
+
     // Subscription callback handler
     static void _subscribeCallback(const char* topic, byte *payload, uint32_t length);
-    static void _handleCommandMessage(const char* message);
+    static void _handleCommandExecution(const char* topic, const char* message);
+    static void _publishCommandStatus(const char* executionId, const char* status, const char* reasonCode, const char* reasonDescription);
+#ifdef ENV_DEV
+    static void _drainInjectedCommand();
+#endif
     static void _handleAwsIotJobMessage(const char* message, const char* topic);
-    static void _handleRestartMessage();
-    static void _handleSetSendPowerDataMessage(JsonDocument &dataDoc);
-    static void _handleSetMqttLogLevelMessage(JsonDocument &dataDoc);
     
     // AWS IoT Jobs OTA functions
     static bool _validateAwsIotJobMessage(const char* message, const char* topic);
@@ -148,9 +145,7 @@ namespace Mqtt
 
     // Publishing functions
     static void _publishMeter();
-    static void _publishSystemStatic();
     static void _publishSystemDynamic();
-    static void _publishChannel();
     static void _publishStatistics();
     static void _publishCrash();
     static void _publishLog(const LogEntry& entry);
@@ -201,7 +196,10 @@ namespace Mqtt
         }
 
         // Static and permanent config
-        _clientMqtt.setBufferSize(MQTT_BUFFER_SIZE);
+        if (!_clientMqtt.setBufferSize(MQTT_BUFFER_SIZE)) {
+            LOG_ERROR("Failed to allocate %d-byte MQTT buffer; cloud connection may be unstable", MQTT_BUFFER_SIZE);
+        }
+        LOG_DEBUG("MQTT buffer set to %d bytes; free internal heap now %u bytes", MQTT_BUFFER_SIZE, (unsigned)ESP.getFreeHeap());
         _clientMqtt.setKeepAlive(MQTT_OVERRIDE_KEEPALIVE);
         _clientMqtt.setServer(AWS_IOT_CORE_ENDPOINT, AWS_IOT_CORE_PORT);
         _clientMqtt.setCallback(_subscribeCallback);
@@ -343,7 +341,10 @@ namespace Mqtt
     // Public methods for requesting MQTT publications
     // ===============================================
 
-    void requestChannelPublish() {_publishMqtt.channel = true; }
+    // Channel config now lives in the channels shadow; a channel change (REST,
+    // auto-polarity, etc.) refreshes the shadow's reported state instead of
+    // publishing the retired `channel` topic.
+    void requestChannelPublish() { Shadow::requestReport("channels"); }
     void requestCrashPublish() {_publishMqtt.crash = true; }
 
     // Public methods for pushing data to queues
@@ -781,9 +782,7 @@ namespace Mqtt
 
     static void _setupTopics() {
         _setTopicMeter();
-        _setTopicSystemStatic();
         _setTopicSystemDynamic();
-        _setTopicChannel();
         _setTopicStatistics();
         _setTopicCrash();
         _setTopicLog();
@@ -792,35 +791,31 @@ namespace Mqtt
     }
 
     static void _setTopicMeter() { _constructMqttTopicWithRule(AWS_IOT_CORE_RULE_METER, MQTT_TOPIC_METER, _mqttTopicMeter, sizeof(_mqttTopicMeter)); }
-    static void _setTopicSystemStatic() { _constructMqttTopic(MQTT_TOPIC_SYSTEM_STATIC, _mqttTopicSystemStatic, sizeof(_mqttTopicSystemStatic)); }
     static void _setTopicSystemDynamic() { _constructMqttTopic(MQTT_TOPIC_SYSTEM_DYNAMIC, _mqttTopicSystemDynamic, sizeof(_mqttTopicSystemDynamic)); }
-    static void _setTopicChannel() { _constructMqttTopic(MQTT_TOPIC_CHANNEL, _mqttTopicChannel, sizeof(_mqttTopicChannel)); }
     static void _setTopicStatistics() { _constructMqttTopic(MQTT_TOPIC_STATISTICS, _mqttTopicStatistics, sizeof(_mqttTopicStatistics)); }
     static void _setTopicCrash() { _constructMqttTopic(MQTT_TOPIC_CRASH, _mqttTopicCrash, sizeof(_mqttTopicCrash)); }
     static void _setTopicLog() { _constructMqttTopicWithRule(AWS_IOT_CORE_RULE_LOG, MQTT_TOPIC_LOG, _mqttTopicLog, sizeof(_mqttTopicLog)); }
 
     static void _subscribeToTopics() {
-        _subscribeCommand();
         _subscribeAwsIotJobs();
+        _subscribeIotCommands();
         Shadow::onMqttConnected(); // subscribe shadow deltas + queue initial reports
 
         LOG_DEBUG("Subscribed to topics");
     }
 
-    static bool _subscribeToTopic(const char* topicSuffix) {
+    static void _subscribeIotCommands() {
+        // AWS IoT Commands: wildcard request topic (executionId + payload-format
+        // are parsed from the received topic). Policy AllowSubscribe covers
+        // $aws/commands/things/<thing>/*.
         char topic[MQTT_TOPIC_BUFFER_SIZE];
-        _constructMqttTopic(topicSuffix, topic, sizeof(topic));
-        
-        if (!_clientMqtt.subscribe(topic, MQTT_TOPIC_SUBSCRIBE_QOS)) {
-            LOG_WARNING("Failed to subscribe to %s", topicSuffix);
-            return false;
+        snprintf(topic, sizeof(topic), "%s/commands/things/%s/executions/+/request/+", AWS_TOPIC, DEVICE_ID);
+        if (_clientMqtt.subscribe(topic, MQTT_TOPIC_SUBSCRIBE_QOS)) {
+            LOG_DEBUG("Subscribed to IoT Commands: %s", topic);
+        } else {
+            LOG_WARNING("Failed to subscribe to IoT Commands: %s", topic);
         }
-
-        LOG_DEBUG("Subscribed to topic: %s", topicSuffix);
-        return true;
     }
-
-    static void _subscribeCommand() { _subscribeToTopic(MQTT_TOPIC_SUBSCRIBE_COMMAND); }
 
     static void _subscribeAwsIotJobs() {
         char jobNotifyTopic[MQTT_TOPIC_BUFFER_SIZE];
@@ -878,7 +873,7 @@ namespace Mqtt
         LOG_DEBUG("Received MQTT message from %s", topic);
 
         if (Shadow::routeMessage(topic, message)) { /* handled by shadow module (copy + flag only) */ }
-        else if (endsWith(topic, MQTT_TOPIC_SUBSCRIBE_COMMAND)) _handleCommandMessage(message);
+        else if (strstr(topic, "/commands/things/") != nullptr && strstr(topic, "/executions/") != nullptr) _handleCommandExecution(topic, message);
         else if (strstr(topic, MQTT_TOPIC_SUBSCRIBE_JOBS)) _handleAwsIotJobMessage(message, topic);
         else LOG_WARNING("Unknown MQTT topic received: %s", topic);
         
@@ -886,79 +881,159 @@ namespace Mqtt
         free(message);
     }
 
-    static void _handleCommandMessage(const char* message)
-    {
-        // Expected JSON format: {"command": "command_name", "data": {...}}
+    // AWS IoT Commands (transient operations)
+    // =======================================
+
+    static void _publishCommandStatus(const char* executionId, const char* status,
+                                       const char* reasonCode, const char* reasonDescription) {
+        char topic[MQTT_TOPIC_BUFFER_SIZE];
+        snprintf(topic, sizeof(topic), "%s/commands/things/%s/executions/%s/response/json",
+                 AWS_TOPIC, DEVICE_ID, executionId);
+
+        SpiRamAllocator allocator;
+        JsonDocument doc(&allocator);
+        doc["status"] = status;
+        if (reasonCode != nullptr) {
+            doc["statusReason"]["reasonCode"] = reasonCode;
+            if (reasonDescription != nullptr) doc["statusReason"]["reasonDescription"] = reasonDescription;
+        }
+
+        if (_publishJsonStreaming(doc, topic)) LOG_DEBUG("Command %s status '%s' published", executionId, status);
+        else LOG_WARNING("Failed to publish command %s status '%s'", executionId, status);
+    }
+
+    // Parses the executionId from the topic, validates, dispatches the operation
+    // and publishes IN_PROGRESS then a terminal status. Runs on the MQTT task
+    // (from the RX callback or the dev injection drain) so publishing is safe.
+    static void _handleCommandExecution(const char* topic, const char* message) {
+        char executionId[NAME_BUFFER_SIZE];
+        if (!ShadowLogic::extractExecutionId(topic, executionId, sizeof(executionId))) {
+            LOG_WARNING("Could not extract executionId from command topic: %s", topic);
+            return;
+        }
+
         SpiRamAllocator allocator;
         JsonDocument doc(&allocator);
         DeserializationError error = deserializeJson(doc, message);
         if (error) {
-            LOG_ERROR("Failed to parse command JSON message (%s): %s", error.c_str(), message);
+            LOG_ERROR("Failed to parse command %s payload (%s)", executionId, error.c_str());
+            _publishCommandStatus(executionId, "FAILED", "bad_payload", "Could not parse command JSON");
             return;
         }
 
-        if (!doc["command"].is<const char*>()) {
-            LOG_ERROR("Invalid command message: missing or invalid 'command' field");
+        const char* operation = doc["operation"].as<const char*>();
+        if (operation == nullptr) {
+            LOG_WARNING("Command %s missing 'operation'", executionId);
+            _publishCommandStatus(executionId, "REJECTED", "missing_operation", "No 'operation' field");
             return;
         }
 
-        const char* command = doc["command"].as<const char*>();
-        SpiRamAllocator allocatorData;
-        JsonDocument docCommandMessage(&allocatorData);
-        docCommandMessage = doc["data"].as<JsonObject>();
-
-        LOG_DEBUG("Processing MQTT command: %s", command);
-
-        if (strcmp(command, "restart") == 0) {
-            _handleRestartMessage();
-        } else if (strcmp(command, "set_send_power_data") == 0) {
-            _handleSetSendPowerDataMessage(docCommandMessage);
-        } else if (strcmp(command, "set_mqtt_log_level") == 0) {
-            _handleSetMqttLogLevelMessage(docCommandMessage);
-        } else {
-            LOG_WARNING("Unknown command received: %s", command);
+        // Staleness guard. MQTT 3.1.1 carries no server timestamp, so this relies
+        // on the command payload providing 'created_at' (unix seconds); absent it,
+        // the guard is skipped (logged) - see the cloud contract in doc 07.
+        uint64_t createdAt = doc["created_at"] | 0ULL;
+        if (ShadowLogic::isCommandStale(createdAt, CustomTime::getUnixTime(), COMMAND_MAX_AGE_SECONDS)) {
+            LOG_WARNING("Command %s (%s) is stale (created %llu); rejecting", executionId, operation, createdAt);
+            _publishCommandStatus(executionId, "REJECTED", "stale_command", "Command older than the staleness window");
+            return;
         }
-    }
+        if (createdAt == 0) LOG_DEBUG("Command %s has no created_at; staleness guard skipped", executionId);
 
-    static void _handleRestartMessage()
-    {
-        setRestartSystem("Restart requested from MQTT");
-    }
+        LOG_INFO("Processing command %s: %s", executionId, operation);
+        _publishCommandStatus(executionId, "IN_PROGRESS", nullptr, nullptr);
 
-    static void _handleSetSendPowerDataMessage(JsonDocument &dataDoc)
-    {
-        // Expected data format: {"sendPowerData": true}
-        if (dataDoc["sendPowerData"].is<bool>()) {
-            bool sendPowerData = dataDoc["sendPowerData"].as<bool>();
-            _setSendPowerDataEnabled(sendPowerData);
-        } else {
-            char buffer[STATUS_BUFFER_SIZE];
-            safeSerializeJson(dataDoc, buffer, sizeof(buffer), true);
-            LOG_ERROR("Invalid send power data JSON message: %s", buffer);
-        }
-    }
-
-    static void _handleSetMqttLogLevelMessage(JsonDocument &dataDoc)
-    {
-        // Expected data format: {"level": "INFO"}
-        if (dataDoc["level"].is<const char*>()) {
-            const char* level = dataDoc["level"].as<const char*>();
-            
-            // Validate log level
-            if (strcmp(level, "VERBOSE") == 0 || strcmp(level, "DEBUG") == 0 || 
-                strcmp(level, "INFO") == 0 || strcmp(level, "WARNING") == 0 || 
-                strcmp(level, "ERROR") == 0 || strcmp(level, "FATAL") == 0) {
-                _setMqttLogLevel(level);
-                LOG_INFO("MQTT log level set to %s", level);
-            } else {
-                LOG_ERROR("Invalid log level: %s. Valid levels: VERBOSE, DEBUG, INFO, WARNING, ERROR, FATAL", level);
+        if (strcmp(operation, "restart") == 0) {
+            _publishCommandStatus(executionId, "SUCCEEDED", nullptr, nullptr);
+            delay(2000); // let the status flush before the reboot (same pattern as OTA)
+            setRestartSystem("Command: restart");
+        } else if (strcmp(operation, "factory_reset") == 0) {
+            const char* confirm = doc["confirm"].as<const char*>();
+            if (confirm == nullptr || strcmp(confirm, DEVICE_ID) != 0) {
+                LOG_WARNING("Command %s factory_reset confirm mismatch", executionId);
+                _publishCommandStatus(executionId, "REJECTED", "confirm_mismatch", "confirm must equal the device id");
+                return;
             }
+            _publishCommandStatus(executionId, "SUCCEEDED", nullptr, nullptr);
+            delay(2000);
+            setRestartSystem("Command: factory_reset", true); // wipe user NVS, keep factory, reboot
+        } else if (strcmp(operation, "energy_reset") == 0) {
+            JsonVariantConst channels = doc["channels"];
+            if (channels.is<const char*>() && strcmp(channels.as<const char*>(), "all") == 0) {
+                Ade7953::resetEnergyValues();
+                LOG_INFO("Command %s: reset energy for all channels", executionId);
+            } else if (channels.is<JsonArrayConst>()) {
+                for (JsonVariantConst ch : channels.as<JsonArrayConst>()) {
+                    if (!ch.is<int>()) continue;
+                    uint8_t idx = (uint8_t)ch.as<int>();
+                    if (isChannelValid(idx)) Ade7953::resetChannelEnergyValues(idx);
+                    else LOG_WARNING("Command %s: invalid channel %u in energy_reset", executionId, idx);
+                }
+                LOG_INFO("Command %s: reset energy for listed channels", executionId);
+            } else {
+                _publishCommandStatus(executionId, "REJECTED", "bad_channels", "channels must be an array of indices or \"all\"");
+                return;
+            }
+            _publishCommandStatus(executionId, "SUCCEEDED", nullptr, nullptr);
         } else {
-            char buffer[STATUS_BUFFER_SIZE];
-            safeSerializeJson(dataDoc, buffer, sizeof(buffer), true);
-            LOG_ERROR("Invalid set MQTT log level JSON message: %s", buffer);
+            LOG_WARNING("Unknown command operation: %s", operation);
+            _publishCommandStatus(executionId, "REJECTED", "unknown_operation", operation);
         }
     }
+
+#ifdef ENV_DEV
+    // Dev-only synthetic command injection: the caller's task stashes the request
+    // (reusing _configMutex for the brief pointer handoff), the MQTT task drains
+    // it through the real handler so the status publish + reboot stay single-task.
+    static char* _injectedCmdTopic = nullptr;
+    static char* _injectedCmdPayload = nullptr;
+
+    void injectCommandExecution(const char* executionId, const char* payload) {
+        if (executionId == nullptr || payload == nullptr) return;
+        char topic[MQTT_TOPIC_BUFFER_SIZE];
+        snprintf(topic, sizeof(topic), "%s/commands/things/%s/executions/%s/request/json",
+                 AWS_TOPIC, DEVICE_ID, executionId);
+
+        size_t tlen = strlen(topic) + 1, plen = strlen(payload) + 1;
+        char* t = (char*)ps_malloc(tlen);
+        char* p = (char*)ps_malloc(plen);
+        if (t == nullptr || p == nullptr) {
+            if (t) free(t);
+            if (p) free(p);
+            LOG_ERROR("Failed to allocate injected command buffers");
+            return;
+        }
+        memcpy(t, topic, tlen);
+        memcpy(p, payload, plen);
+
+        if (acquireMutex(&_configMutex, CONFIG_MUTEX_TIMEOUT_MS)) {
+            if (_injectedCmdTopic) free(_injectedCmdTopic);
+            if (_injectedCmdPayload) free(_injectedCmdPayload);
+            _injectedCmdTopic = t;
+            _injectedCmdPayload = p;
+            releaseMutex(&_configMutex);
+            LOG_INFO("Injected synthetic command execution %s", executionId);
+        } else {
+            free(t);
+            free(p);
+            LOG_ERROR("Failed to acquire mutex staging injected command");
+        }
+    }
+
+    static void _drainInjectedCommand() {
+        char* t = nullptr;
+        char* p = nullptr;
+        if (acquireMutex(&_configMutex, CONFIG_MUTEX_TIMEOUT_MS)) {
+            t = _injectedCmdTopic;
+            _injectedCmdTopic = nullptr;
+            p = _injectedCmdPayload;
+            _injectedCmdPayload = nullptr;
+            releaseMutex(&_configMutex);
+        }
+        if (t != nullptr && p != nullptr) _handleCommandExecution(t, p);
+        if (t) free(t);
+        if (p) free(p);
+    }
+#endif
 
     // AWS IoT Jobs OTA functions
     // ==========================
@@ -1322,26 +1397,6 @@ namespace Mqtt
         if (_publishMeterJson()) _lastMillisMeterPublished = millis64();
     }
     
-    static void _publishSystemStatic() {
-        SpiRamAllocator allocator;
-        JsonDocument doc(&allocator);
-        doc["unixTime"] = CustomTime::getUnixTimeMilliseconds();
-
-        SpiRamAllocator allocatorSystemStatic;
-        JsonDocument docSystemStatic(&allocatorSystemStatic);
-        SystemStaticInfo systemStaticInfo;
-        populateSystemStaticInfo(systemStaticInfo);
-        systemStaticInfoToJson(systemStaticInfo, docSystemStatic);
-        doc["data"] = docSystemStatic;
-
-        if (_publishJsonStreaming(doc, _mqttTopicSystemStatic, true)) { // retain static info since it is idempotent
-            _publishMqtt.systemStatic = false; 
-            LOG_DEBUG("System static info published to MQTT");
-        } else {
-            LOG_ERROR("Failed to publish system static info");
-        }
-    }
-
     static void _publishSystemDynamic() {
         SpiRamAllocator allocator;
         JsonDocument doc(&allocator);
@@ -1360,25 +1415,6 @@ namespace Mqtt
             LOG_DEBUG("System dynamic info published to MQTT");
         } else {
             LOG_ERROR("Failed to publish system dynamic info");
-        }
-    }
-
-    static void _publishChannel() {
-        SpiRamAllocator allocator;
-        JsonDocument doc(&allocator);
-        doc["unixTime"] = CustomTime::getUnixTimeMilliseconds();
-
-        SpiRamAllocator allocatorData;
-        JsonDocument docChannelData(&allocatorData);
-        Ade7953::getAllChannelDataAsJson(docChannelData);
-
-        doc["data"] = docChannelData;
-
-        if (_publishJsonStreaming(doc, _mqttTopicChannel, true)) { // retain channel info since it is idempotent
-            _publishMqtt.channel = false;
-            LOG_DEBUG("Channel data published to MQTT");
-        } else {
-            LOG_ERROR("Failed to publish channel data");
         }
     }
 
@@ -1444,9 +1480,7 @@ namespace Mqtt
 
     static void _checkPublishMqtt() {
         if (_publishMqtt.meter) {_publishMeter();}
-        if (_publishMqtt.systemStatic) {_publishSystemStatic();}
         if (_publishMqtt.systemDynamic) {_publishSystemDynamic();}
-        if (_publishMqtt.channel) {_publishChannel();}
         if (_publishMqtt.statistics) {_publishStatistics();}
         if (_publishMqtt.crash) {_publishCrash();}
         if (_publishMqtt.requestOta) {_publishOtaJobsRequest();}
@@ -1530,10 +1564,8 @@ namespace Mqtt
             _subscribeToTopics();
 
             // Publish data on connection (except meter and crash)
-            _publishMqtt.systemStatic = true;
             _publishMqtt.systemDynamic = true;
             _publishMqtt.statistics = true;
-            _publishMqtt.channel = true;
             _publishMqtt.requestOta = true;
 
             return true;
@@ -1963,6 +1995,9 @@ namespace Mqtt
         _checkIfPublishStatisticsNeeded();
         _checkPublishMqtt();
         Shadow::checkPublish(); // drain shadow deltas/local-edits/reports (MQTT task body)
+#ifdef ENV_DEV
+        _drainInjectedCommand(); // dev-only synthetic command injection
+#endif
     }
 
     // Utilities

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -914,7 +914,17 @@ namespace Mqtt
         LOG_DEBUG("Received MQTT message from %s", topic);
 
         if (Shadow::routeMessage(topic, message)) { /* handled by shadow module (copy + flag only) */ }
-        else if (strstr(topic, "/commands/things/") != nullptr && strstr(topic, "/executions/") != nullptr) _handleCommandExecution(topic, message);
+        // Only the subscribed request topic (.../executions/<id>/request/json) is an
+        // inbound command. Match it precisely - matching any "/commands/things/" topic
+        // also catches AWS's own .../response/rejected/json echo of our status publish,
+        // which has no 'operation', gets re-rejected, and echoes again -> infinite
+        // publish loop hammering the broker.
+        else if (strstr(topic, "/commands/things/") != nullptr && endsWith(topic, "/request/json")) _handleCommandExecution(topic, message);
+        else if (strstr(topic, "/commands/things/") != nullptr) {
+            // AWS echoed our own command-status publish back (e.g. rejecting a status
+            // for an unknown/expired execution). Never reprocess it - just note it.
+            LOG_DEBUG("Ignoring non-request command topic: %s", topic);
+        }
         else if (strstr(topic, MQTT_TOPIC_SUBSCRIBE_JOBS)) _handleAwsIotJobMessage(message, topic);
         else LOG_WARNING("Unknown MQTT topic received: %s", topic);
         
@@ -925,6 +935,8 @@ namespace Mqtt
     // AWS IoT Commands (transient operations)
     // =======================================
 
+    // reasonCode MUST match the AWS IoT Commands pattern [A-Z0-9_-]+ (uppercase);
+    // a lowercase code makes AWS reject the status update. reasonDescription is free text.
     static void _publishCommandStatus(const char* executionId, const char* status,
                                        const char* reasonCode, const char* reasonDescription) {
         char topic[MQTT_TOPIC_BUFFER_SIZE];
@@ -958,14 +970,14 @@ namespace Mqtt
         DeserializationError error = deserializeJson(doc, message);
         if (error) {
             LOG_ERROR("Failed to parse command %s payload (%s)", executionId, error.c_str());
-            _publishCommandStatus(executionId, "FAILED", "bad_payload", "Could not parse command JSON");
+            _publishCommandStatus(executionId, "FAILED", "BAD_PAYLOAD", "Could not parse command JSON");
             return;
         }
 
         const char* operation = doc["operation"].as<const char*>();
         if (operation == nullptr) {
             LOG_WARNING("Command %s missing 'operation'", executionId);
-            _publishCommandStatus(executionId, "REJECTED", "missing_operation", "No 'operation' field");
+            _publishCommandStatus(executionId, "REJECTED", "MISSING_OPERATION", "No 'operation' field");
             return;
         }
 
@@ -975,7 +987,7 @@ namespace Mqtt
         uint64_t createdAt = doc["created_at"] | 0ULL;
         if (ShadowLogic::isCommandStale(createdAt, CustomTime::getUnixTime(), COMMAND_MAX_AGE_SECONDS)) {
             LOG_WARNING("Command %s (%s) is stale (created %llu); rejecting", executionId, operation, createdAt);
-            _publishCommandStatus(executionId, "REJECTED", "stale_command", "Command older than the staleness window");
+            _publishCommandStatus(executionId, "REJECTED", "STALE_COMMAND", "Command older than the staleness window");
             return;
         }
         if (createdAt == 0) LOG_DEBUG("Command %s has no created_at; staleness guard skipped", executionId);
@@ -991,7 +1003,7 @@ namespace Mqtt
             const char* confirm = doc["confirm"].as<const char*>();
             if (confirm == nullptr || strcmp(confirm, DEVICE_ID) != 0) {
                 LOG_WARNING("Command %s factory_reset confirm mismatch", executionId);
-                _publishCommandStatus(executionId, "REJECTED", "confirm_mismatch", "confirm must equal the device id");
+                _publishCommandStatus(executionId, "REJECTED", "CONFIRM_MISMATCH", "confirm must equal the device id");
                 return;
             }
             _publishCommandStatus(executionId, "SUCCEEDED", nullptr, nullptr);
@@ -1011,13 +1023,13 @@ namespace Mqtt
                 }
                 LOG_INFO("Command %s: reset energy for listed channels", executionId);
             } else {
-                _publishCommandStatus(executionId, "REJECTED", "bad_channels", "channels must be an array of indices or \"all\"");
+                _publishCommandStatus(executionId, "REJECTED", "BAD_CHANNELS", "channels must be an array of indices or \"all\"");
                 return;
             }
             _publishCommandStatus(executionId, "SUCCEEDED", nullptr, nullptr);
         } else {
             LOG_WARNING("Unknown command operation: %s", operation);
-            _publishCommandStatus(executionId, "REJECTED", "unknown_operation", operation);
+            _publishCommandStatus(executionId, "REJECTED", "UNKNOWN_OPERATION", operation);
         }
     }
 

--- a/source/src/shadow.cpp
+++ b/source/src/shadow.cpp
@@ -24,20 +24,28 @@ namespace Shadow {
 #define SHADOW_MAX_COUNT 5
 #define SHADOW_NAME_PREFIX "shadow/name/"
 #define SHADOW_INFO_REFRESH_INTERVAL_US (24ULL * 60ULL * 60ULL * 1000000ULL) // 24 h
+// Drift-detect cadence: each writable shadow's reported state is rebuilt and
+// compared to its last publish on this interval; any change (REST, command,
+// internal, the log-level revert timer) is republished. Replaces per-call-site
+// notify hooks, which can't cover lib-owned fields like the log levels.
+#define SHADOW_DRIFT_CHECK_INTERVAL_MS 3000
 
 // Per-shadow runtime state.
 //  - reportPending: benign volatile flag; any task may set it true, the MQTT
 //    task clears it in checkPublish(). No mutex needed (idempotent set; a lost
 //    race just defers one publish by one loop).
-//  - pendingDelta / pendingLocalEdit: ps_malloc'd payload copies handed from the
-//    RX callback / web task to the MQTT task. Pointer ownership is swapped under
-//    _mutex (the only genuinely cross-task shared state here).
+//  - pendingDelta: ps_malloc'd payload copy handed from the RX callback to the
+//    MQTT task. Pointer ownership is swapped under _mutex (the only genuinely
+//    cross-task shared state here).
+//  - version / lastReported: MQTT-task-only (touched only in the checkPublish
+//    drain), so no mutex. lastReported holds the serialized reported state at the
+//    last publish; the drift check diffs against it to catch local changes.
 struct ShadowEntry {
     Descriptor    desc;
     uint32_t      version;
     volatile bool reportPending;
     char*         pendingDelta;
-    char*         pendingLocalEdit;
+    char*         lastReported;
 };
 
 static ShadowEntry _shadows[SHADOW_MAX_COUNT];
@@ -238,6 +246,16 @@ static void _publishReported(uint8_t idx) {
     _topicUpdate(_shadows[idx].desc.name, topic, sizeof(topic));
     if (Mqtt::publishReservedThings(doc, topic)) {
         LOG_DEBUG("Published reported state for shadow '%s'", _shadows[idx].desc.name);
+        // Refresh the drift baseline so the periodic check only republishes on a
+        // real change from here on (MQTT-task-only field, no mutex).
+        JsonObjectConst reported = doc["state"]["reported"].as<JsonObjectConst>();
+        size_t len = measureJson(reported) + 1;
+        char* snap = (char*)ps_malloc(len);
+        if (snap != nullptr) {
+            serializeJson(reported, snap, len);
+            if (_shadows[idx].lastReported != nullptr) free(_shadows[idx].lastReported);
+            _shadows[idx].lastReported = snap;
+        }
     } else {
         LOG_WARNING("Failed to publish reported state for shadow '%s'", _shadows[idx].desc.name);
     }
@@ -299,50 +317,40 @@ static void _applyDelta(uint8_t idx, const char* payload) {
     }
 }
 
-static void _publishLocalEditDoc(uint8_t idx, const char* payload) {
-    SpiRamAllocator inAllocator;
-    JsonDocument changed(&inAllocator);
-    if (deserializeJson(changed, payload)) {
-        LOG_WARNING("Failed to parse staged local edit for shadow '%s'", _shadows[idx].desc.name);
-        return;
-    }
-
-    SpiRamAllocator outAllocator;
-    JsonDocument outDoc(&outAllocator);
-    JsonObject reported = outDoc["state"]["reported"].to<JsonObject>();
-    JsonObject desired = outDoc["state"]["desired"].to<JsonObject>();
-    for (JsonPairConst kv : changed.as<JsonObjectConst>()) {
-        reported[kv.key()] = kv.value(); // local value wins
-        desired[kv.key()] = nullptr;     // clear any pending cloud intent
-    }
-    // No version: a local edit is an unconditional report+clear (never 409).
-    _addClientToken(outDoc);
-
-    char topic[MQTT_TOPIC_BUFFER_SIZE];
-    _topicUpdate(_shadows[idx].desc.name, topic, sizeof(topic));
-    if (Mqtt::publishReservedThings(outDoc, topic)) {
-        LOG_DEBUG("Published local edit for shadow '%s'", _shadows[idx].desc.name);
-    } else {
-        LOG_WARNING("Failed to publish local edit for shadow '%s'", _shadows[idx].desc.name);
-    }
-}
-
 // ============================================================================
 // Drain (MQTT task body)
 // ============================================================================
+
+// Republish a writable shadow if its reported state changed since the last
+// publish (any source: REST, command, internal logic, the log-level revert
+// timer). Build a fresh report, compare its serialized reported object to the
+// stored baseline; on a difference, publish (which refreshes the baseline).
+static void _reportIfDrifted(uint8_t idx) {
+    SpiRamAllocator allocator;
+    JsonDocument doc(&allocator);
+    _shadows[idx].desc.report(doc);
+
+    JsonObjectConst reported = doc["state"]["reported"].as<JsonObjectConst>();
+    size_t len = measureJson(reported) + 1;
+    char* cur = (char*)ps_malloc(len);
+    if (cur == nullptr) return; // out of PSRAM; retry next tick
+    serializeJson(reported, cur, len);
+
+    bool changed = _shadows[idx].lastReported == nullptr ||
+                   strcmp(cur, _shadows[idx].lastReported) != 0;
+    free(cur);
+    if (changed) _publishReported(idx); // rebuilds, publishes, refreshes baseline
+}
 
 void checkPublish() {
     _checkSystemLogLevelRevert(); // transient mqtt_log_level revert (flag set by timer task)
     for (uint8_t i = 0; i < _count; i++) {
         char* delta = nullptr;
-        char* localEdit = nullptr;
         bool report = false;
 
         if (acquireMutex(&_mutex)) {
             delta = _shadows[i].pendingDelta;
             _shadows[i].pendingDelta = nullptr;
-            localEdit = _shadows[i].pendingLocalEdit;
-            _shadows[i].pendingLocalEdit = nullptr;
             releaseMutex(&_mutex);
         }
         // reportPending is a benign volatile flag; read+clear without the mutex.
@@ -353,11 +361,18 @@ void checkPublish() {
             _applyDelta(i, delta);
             free(delta);
         }
-        if (localEdit != nullptr) {
-            _publishLocalEditDoc(i, localEdit);
-            free(localEdit);
-        }
         if (report) _publishReported(i);
+    }
+
+    // Drift detect (gated): republish any writable shadow whose reported state
+    // changed since its last publish, regardless of source. One periodic diff
+    // replaces per-call-site notify hooks and covers lib-owned fields too.
+    static uint64_t lastDriftCheck = 0;
+    if ((millis64() - lastDriftCheck) > SHADOW_DRIFT_CHECK_INTERVAL_MS) {
+        lastDriftCheck = millis64();
+        for (uint8_t i = 0; i < _count; i++) {
+            if (_shadows[i].desc.writable) _reportIfDrifted(i);
+        }
     }
 }
 
@@ -374,31 +389,6 @@ void requestReport(const char* name) {
     int idx = _findShadow(name, strlen(name));
     if (idx >= 0) _shadows[idx].reportPending = true; // benign volatile set
     else LOG_WARNING("requestReport for unknown shadow '%s'", name);
-}
-
-void publishLocalEdit(const char* name, JsonObjectConst changedFields) {
-    int idx = _findShadow(name, strlen(name));
-    if (idx < 0) {
-        LOG_WARNING("publishLocalEdit for unknown shadow '%s'", name);
-        return;
-    }
-
-    size_t len = measureJson(changedFields) + 1;
-    char* copy = (char*)ps_malloc(len);
-    if (copy == nullptr) {
-        LOG_ERROR("Failed to allocate local edit buffer for shadow '%s'", name);
-        return;
-    }
-    serializeJson(changedFields, copy, len);
-
-    if (acquireMutex(&_mutex)) {
-        if (_shadows[idx].pendingLocalEdit != nullptr) free(_shadows[idx].pendingLocalEdit);
-        _shadows[idx].pendingLocalEdit = copy;
-        releaseMutex(&_mutex);
-    } else {
-        free(copy);
-        LOG_ERROR("Failed to acquire shadow mutex staging local edit for '%s'", name);
-    }
 }
 
 #ifdef ENV_DEV

--- a/source/src/shadow.cpp
+++ b/source/src/shadow.cpp
@@ -595,6 +595,17 @@ static void _reportSystem(JsonDocument& doc) {
     rep["log_level_save"] = AdvancedLogger::logLevelToString(AdvancedLogger::getSaveLevel());
 }
 
+// Parse a string log-level delta field. Returns the level (>=0) to apply, or -1
+// if the field is absent or invalid (warns on an unknown level). Shared by the
+// three log-level fields below, which differ only in their setter/getter.
+static int _parseLogLevelDelta(JsonObjectConst delta, const char* key) {
+    JsonVariantConst v = delta[key];
+    if (v.isNull()) return -1;
+    int level = ShadowLogic::logLevelFromString(v.as<const char*>());
+    if (level < 0) LOG_WARNING("Rejected %s: unknown level", key);
+    return level;
+}
+
 static bool _applySystem(JsonObjectConst delta, JsonObject reported) {
     bool applied = false;
 
@@ -626,40 +637,25 @@ static bool _applySystem(JsonObjectConst delta, JsonObject reported) {
         }
     }
 
-    v = delta["mqtt_log_level"];
-    if (!v.isNull()) {
-        int level = ShadowLogic::logLevelFromString(v.as<const char*>());
-        if (level < 0) {
-            LOG_WARNING("Rejected mqtt_log_level: unknown level");
-        } else {
-            _applyMqttLogLevel(level);
-            reported["mqtt_log_level"] = ShadowLogic::logLevelToString(Mqtt::getMqttLogLevel());
-            applied = true;
-        }
+    int level = _parseLogLevelDelta(delta, "mqtt_log_level");
+    if (level >= 0) {
+        _applyMqttLogLevel(level);
+        reported["mqtt_log_level"] = ShadowLogic::logLevelToString(Mqtt::getMqttLogLevel());
+        applied = true;
     }
 
-    v = delta["log_level_print"];
-    if (!v.isNull()) {
-        int level = ShadowLogic::logLevelFromString(v.as<const char*>());
-        if (level < 0) {
-            LOG_WARNING("Rejected log_level_print: unknown level");
-        } else {
-            AdvancedLogger::setPrintLevel((LogLevel)level); // persists (lib-internal)
-            reported["log_level_print"] = AdvancedLogger::logLevelToString(AdvancedLogger::getPrintLevel());
-            applied = true;
-        }
+    level = _parseLogLevelDelta(delta, "log_level_print");
+    if (level >= 0) {
+        AdvancedLogger::setPrintLevel((LogLevel)level); // persists (lib-internal)
+        reported["log_level_print"] = AdvancedLogger::logLevelToString(AdvancedLogger::getPrintLevel());
+        applied = true;
     }
 
-    v = delta["log_level_save"];
-    if (!v.isNull()) {
-        int level = ShadowLogic::logLevelFromString(v.as<const char*>());
-        if (level < 0) {
-            LOG_WARNING("Rejected log_level_save: unknown level");
-        } else {
-            AdvancedLogger::setSaveLevel((LogLevel)level); // persists (lib-internal)
-            reported["log_level_save"] = AdvancedLogger::logLevelToString(AdvancedLogger::getSaveLevel());
-            applied = true;
-        }
+    level = _parseLogLevelDelta(delta, "log_level_save");
+    if (level >= 0) {
+        AdvancedLogger::setSaveLevel((LogLevel)level); // persists (lib-internal)
+        reported["log_level_save"] = AdvancedLogger::logLevelToString(AdvancedLogger::getSaveLevel());
+        applied = true;
     }
 
     return applied;

--- a/source/src/shadow.cpp
+++ b/source/src/shadow.cpp
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#include "shadow.h"
+
+#include <Preferences.h>
+#include <esp_random.h>
+#include <esp_timer.h>
+
+#include "awsconfig.h"
+#include "factory_keys.h"
+#include "globals.h"
+#include "hardware_profile.h"
+#include "mqtt.h"
+#include "shadow_logic.h"
+#include "utils.h"
+
+namespace Shadow {
+
+// Up to 5 named shadows: info, issues, system, meter, channels.
+#define SHADOW_MAX_COUNT 5
+#define SHADOW_NAME_PREFIX "shadow/name/"
+#define SHADOW_INFO_REFRESH_INTERVAL_US (24ULL * 60ULL * 60ULL * 1000000ULL) // 24 h
+
+// Per-shadow runtime state.
+//  - reportPending: benign volatile flag; any task may set it true, the MQTT
+//    task clears it in checkPublish(). No mutex needed (idempotent set; a lost
+//    race just defers one publish by one loop).
+//  - pendingDelta / pendingLocalEdit: ps_malloc'd payload copies handed from the
+//    RX callback / web task to the MQTT task. Pointer ownership is swapped under
+//    _mutex (the only genuinely cross-task shared state here).
+struct ShadowEntry {
+    Descriptor    desc;
+    uint32_t      version;
+    volatile bool reportPending;
+    char*         pendingDelta;
+    char*         pendingLocalEdit;
+};
+
+static ShadowEntry _shadows[SHADOW_MAX_COUNT];
+static uint8_t _count = 0;
+static SemaphoreHandle_t _mutex = nullptr;
+static esp_timer_handle_t _infoRefreshTimer = nullptr;
+
+// Report/apply callbacks (defined further down, registered in begin()).
+static void _reportInfo(JsonDocument& doc);
+
+// ============================================================================
+// Registration
+// ============================================================================
+
+static void _registerShadow(const Descriptor& desc) {
+    if (_count >= SHADOW_MAX_COUNT) {
+        LOG_ERROR("Shadow table full, cannot register '%s'", desc.name);
+        return;
+    }
+    if (desc.writable && desc.apply == nullptr) {
+        LOG_ERROR("Writable shadow '%s' has no apply callback", desc.name);
+        return;
+    }
+    _shadows[_count] = {desc, 0, false, nullptr, nullptr};
+    _count++;
+    LOG_DEBUG("Registered shadow '%s' (%s)", desc.name, desc.writable ? "writable" : "reported-only");
+}
+
+static int _findShadow(const char* name, size_t nameLen) {
+    for (uint8_t i = 0; i < _count; i++) {
+        if (strlen(_shadows[i].desc.name) == nameLen &&
+            strncmp(_shadows[i].desc.name, name, nameLen) == 0) {
+            return (int)i;
+        }
+    }
+    return -1;
+}
+
+static void _infoRefreshCallback(void* arg) {
+    (void)arg;
+    requestReport("info"); // flag only; MQTT task publishes
+}
+
+void begin() {
+    if (!createMutexIfNeeded(&_mutex)) {
+        LOG_ERROR("Failed to create shadow mutex");
+        return;
+    }
+
+    _count = 0;
+    _registerShadow({"info", false, _reportInfo, nullptr});
+
+    // Low-priority periodic refresh so identity shadow's lastUpdated stays fresh
+    // even though the values rarely change. Callback only sets a flag.
+    if (_infoRefreshTimer == nullptr) {
+        const esp_timer_create_args_t timerArgs = {
+            .callback = _infoRefreshCallback,
+            .arg = nullptr,
+            .dispatch_method = ESP_TIMER_TASK,
+            .name = "shadow_info_refresh",
+            .skip_unhandled_events = true};
+        if (esp_timer_create(&timerArgs, &_infoRefreshTimer) == ESP_OK) {
+            esp_timer_start_periodic(_infoRefreshTimer, SHADOW_INFO_REFRESH_INTERVAL_US);
+        } else {
+            LOG_WARNING("Failed to create info shadow refresh timer");
+        }
+    }
+
+    LOG_DEBUG("Shadow module initialized with %u shadow(s)", _count);
+}
+
+// ============================================================================
+// Topic helpers
+// ============================================================================
+
+static void _topicUpdate(const char* name, char* out, size_t outSize) {
+    snprintf(out, outSize, SHADOW_NAME_PREFIX "%s/update", name);
+}
+
+// ============================================================================
+// Connect: subscribe writable shadows, queue initial reports
+// ============================================================================
+
+void onMqttConnected() {
+    char suffix[MQTT_TOPIC_BUFFER_SIZE];
+    for (uint8_t i = 0; i < _count; i++) {
+        if (_shadows[i].desc.writable) {
+            snprintf(suffix, sizeof(suffix), SHADOW_NAME_PREFIX "%s/update/delta", _shadows[i].desc.name);
+            Mqtt::subscribeReservedThings(suffix);
+            snprintf(suffix, sizeof(suffix), SHADOW_NAME_PREFIX "%s/update/rejected", _shadows[i].desc.name);
+            Mqtt::subscribeReservedThings(suffix);
+        }
+        // Publish-reported-first on every (re)connect. A still-pending cloud
+        // desired survives (we send no desired here) -> AWS re-sends the delta.
+        _shadows[i].reportPending = true;
+    }
+    LOG_DEBUG("Shadow subscriptions set; initial reports queued for %u shadow(s)", _count);
+}
+
+// ============================================================================
+// Inbound routing (RX callback context: copy + flag only, never apply/publish)
+// ============================================================================
+
+bool routeMessage(const char* topic, const char* payload) {
+    const char* marker = strstr(topic, "/" SHADOW_NAME_PREFIX);
+    if (marker == nullptr) return false; // not a shadow topic
+
+    const char* nameStart = marker + strlen("/" SHADOW_NAME_PREFIX);
+    const char* nameEnd = strchr(nameStart, '/');
+    if (nameEnd == nullptr) {
+        LOG_WARNING("Malformed shadow topic: %s", topic);
+        return true; // it is a shadow topic, just unusable - do not fall through
+    }
+
+    int idx = _findShadow(nameStart, (size_t)(nameEnd - nameStart));
+    if (idx < 0) {
+        LOG_WARNING("Delta for unknown shadow in topic: %s", topic);
+        return true;
+    }
+
+    if (endsWith(topic, "/update/delta")) {
+        size_t len = strlen(payload) + 1;
+        char* copy = (char*)ps_malloc(len);
+        if (copy == nullptr) {
+            LOG_ERROR("Failed to allocate shadow delta buffer (%zu bytes)", len);
+            return true;
+        }
+        memcpy(copy, payload, len);
+        if (acquireMutex(&_mutex)) {
+            if (_shadows[idx].pendingDelta != nullptr) free(_shadows[idx].pendingDelta); // newer delta wins
+            _shadows[idx].pendingDelta = copy;
+            releaseMutex(&_mutex);
+            LOG_DEBUG("Queued delta for shadow '%s' (%zu bytes)", _shadows[idx].desc.name, len - 1);
+        } else {
+            free(copy);
+            LOG_ERROR("Failed to acquire shadow mutex queuing delta for '%s'", _shadows[idx].desc.name);
+        }
+    } else if (endsWith(topic, "/update/rejected")) {
+        // 409 (version conflict) recovery is a reported-first re-publish (carries
+        // no version); for any rejection that is a safe resync. Log the payload.
+        LOG_WARNING("Shadow '%s' update rejected: %s", _shadows[idx].desc.name, payload);
+        _shadows[idx].reportPending = true;
+    } else {
+        LOG_DEBUG("Ignoring shadow topic (not delta/rejected): %s", topic);
+    }
+    return true;
+}
+
+// ============================================================================
+// Publishing primitives (MQTT task context only)
+// ============================================================================
+
+static void _publishReported(uint8_t idx) {
+    SpiRamAllocator allocator;
+    JsonDocument doc(&allocator);
+    _shadows[idx].desc.report(doc); // fills doc["state"]["reported"]
+
+    char topic[MQTT_TOPIC_BUFFER_SIZE];
+    _topicUpdate(_shadows[idx].desc.name, topic, sizeof(topic));
+    if (Mqtt::publishReservedThings(doc, topic)) {
+        LOG_DEBUG("Published reported state for shadow '%s'", _shadows[idx].desc.name);
+    } else {
+        LOG_WARNING("Failed to publish reported state for shadow '%s'", _shadows[idx].desc.name);
+    }
+}
+
+static void _addClientToken(JsonDocument& doc) {
+    char token[24];
+    if (ShadowLogic::formatClientToken(token, sizeof(token), esp_random(), esp_random()) > 0) {
+        doc["clientToken"] = token; // copied (mutable buffer)
+    }
+}
+
+static void _applyDelta(uint8_t idx, const char* payload) {
+    if (_shadows[idx].desc.apply == nullptr) {
+        LOG_WARNING("Delta for reported-only shadow '%s' ignored", _shadows[idx].desc.name);
+        return;
+    }
+
+    SpiRamAllocator inAllocator;
+    JsonDocument inDoc(&inAllocator);
+    DeserializationError error = deserializeJson(inDoc, payload);
+    if (error) {
+        LOG_ERROR("Failed to parse delta for shadow '%s' (%s)", _shadows[idx].desc.name, error.c_str());
+        return;
+    }
+
+    uint32_t version = inDoc["version"] | 0u;
+    _shadows[idx].version = version; // MQTT-task-only field
+
+    JsonObjectConst delta = inDoc["state"].as<JsonObjectConst>();
+    if (delta.isNull()) {
+        LOG_WARNING("Delta for shadow '%s' has no 'state' object", _shadows[idx].desc.name);
+        return;
+    }
+
+    SpiRamAllocator outAllocator;
+    JsonDocument outDoc(&outAllocator);
+    JsonObject reported = outDoc["state"]["reported"].to<JsonObject>();
+    JsonObject desired = outDoc["state"]["desired"].to<JsonObject>();
+
+    _shadows[idx].desc.apply(delta, reported, desired);
+
+    // Ack/clear invariant: every top-level field the cloud sent must be nulled
+    // in desired. The apply callback may have nulled keys granularly (nested
+    // object) - leave those; null any it did not touch.
+    for (JsonPairConst kv : delta) {
+        if (!desired[kv.key()].is<JsonObject>()) desired[kv.key()] = nullptr;
+    }
+
+    if (ShadowLogic::shouldSendVersion(version)) outDoc["version"] = version;
+    _addClientToken(outDoc);
+
+    char topic[MQTT_TOPIC_BUFFER_SIZE];
+    _topicUpdate(_shadows[idx].desc.name, topic, sizeof(topic));
+    if (Mqtt::publishReservedThings(outDoc, topic)) {
+        LOG_INFO("Applied delta for shadow '%s' (version %lu)", _shadows[idx].desc.name, (unsigned long)version);
+    } else {
+        LOG_WARNING("Failed to publish delta ack for shadow '%s'", _shadows[idx].desc.name);
+    }
+}
+
+static void _publishLocalEditDoc(uint8_t idx, const char* payload) {
+    SpiRamAllocator inAllocator;
+    JsonDocument changed(&inAllocator);
+    if (deserializeJson(changed, payload)) {
+        LOG_WARNING("Failed to parse staged local edit for shadow '%s'", _shadows[idx].desc.name);
+        return;
+    }
+
+    SpiRamAllocator outAllocator;
+    JsonDocument outDoc(&outAllocator);
+    JsonObject reported = outDoc["state"]["reported"].to<JsonObject>();
+    JsonObject desired = outDoc["state"]["desired"].to<JsonObject>();
+    for (JsonPairConst kv : changed.as<JsonObjectConst>()) {
+        reported[kv.key()] = kv.value(); // local value wins
+        desired[kv.key()] = nullptr;     // clear any pending cloud intent
+    }
+    // No version: a local edit is an unconditional report+clear (never 409).
+    _addClientToken(outDoc);
+
+    char topic[MQTT_TOPIC_BUFFER_SIZE];
+    _topicUpdate(_shadows[idx].desc.name, topic, sizeof(topic));
+    if (Mqtt::publishReservedThings(outDoc, topic)) {
+        LOG_DEBUG("Published local edit for shadow '%s'", _shadows[idx].desc.name);
+    } else {
+        LOG_WARNING("Failed to publish local edit for shadow '%s'", _shadows[idx].desc.name);
+    }
+}
+
+// ============================================================================
+// Drain (MQTT task body)
+// ============================================================================
+
+void checkPublish() {
+    for (uint8_t i = 0; i < _count; i++) {
+        char* delta = nullptr;
+        char* localEdit = nullptr;
+        bool report = false;
+
+        if (acquireMutex(&_mutex)) {
+            delta = _shadows[i].pendingDelta;
+            _shadows[i].pendingDelta = nullptr;
+            localEdit = _shadows[i].pendingLocalEdit;
+            _shadows[i].pendingLocalEdit = nullptr;
+            releaseMutex(&_mutex);
+        }
+        // reportPending is a benign volatile flag; read+clear without the mutex.
+        report = _shadows[i].reportPending;
+        if (report) _shadows[i].reportPending = false;
+
+        if (delta != nullptr) {
+            _applyDelta(i, delta);
+            free(delta);
+        }
+        if (localEdit != nullptr) {
+            _publishLocalEditDoc(i, localEdit);
+            free(localEdit);
+        }
+        if (report) _publishReported(i);
+    }
+}
+
+// ============================================================================
+// Public cross-task entry points
+// ============================================================================
+
+void requestReport(const char* name) {
+    int idx = _findShadow(name, strlen(name));
+    if (idx >= 0) _shadows[idx].reportPending = true; // benign volatile set
+    else LOG_WARNING("requestReport for unknown shadow '%s'", name);
+}
+
+void publishLocalEdit(const char* name, JsonObjectConst changedFields) {
+    int idx = _findShadow(name, strlen(name));
+    if (idx < 0) {
+        LOG_WARNING("publishLocalEdit for unknown shadow '%s'", name);
+        return;
+    }
+
+    size_t len = measureJson(changedFields) + 1;
+    char* copy = (char*)ps_malloc(len);
+    if (copy == nullptr) {
+        LOG_ERROR("Failed to allocate local edit buffer for shadow '%s'", name);
+        return;
+    }
+    serializeJson(changedFields, copy, len);
+
+    if (acquireMutex(&_mutex)) {
+        if (_shadows[idx].pendingLocalEdit != nullptr) free(_shadows[idx].pendingLocalEdit);
+        _shadows[idx].pendingLocalEdit = copy;
+        releaseMutex(&_mutex);
+    } else {
+        free(copy);
+        LOG_ERROR("Failed to acquire shadow mutex staging local edit for '%s'", name);
+    }
+}
+
+#ifdef ENV_DEV
+bool injectDelta(const char* name, const char* payload) {
+    char topic[MQTT_TOPIC_BUFFER_SIZE];
+    snprintf(topic, sizeof(topic), "%s/%s/" SHADOW_NAME_PREFIX "%s/update/delta", MQTT_THINGS, DEVICE_ID, name);
+    LOG_INFO("Injecting synthetic delta for shadow '%s'", name);
+    return routeMessage(topic, payload);
+}
+#endif
+
+// ============================================================================
+// info shadow (reported-only): static device identity
+// ============================================================================
+
+static void _reportInfo(JsonDocument& doc) {
+    JsonObject rep = doc["state"]["reported"].to<JsonObject>();
+
+    rep["firmware_version"] = FIRMWARE_BUILD_VERSION; // string literal: linked
+    rep["firmware_build_date"] = FIRMWARE_BUILD_DATE;
+
+    char md5[MD5_BUFFER_SIZE];
+    snprintf(md5, sizeof(md5), "%s", ESP.getSketchMD5().c_str());
+    rep["sketch_md5"] = md5; // mutable buffer: copied
+
+    char hwProfile[VERSION_BUFFER_SIZE];
+    uint8_t v = (globalHwProfile != nullptr) ? globalHwProfile->version : 0;
+    snprintf(hwProfile, sizeof(hwProfile), "v%u.%u", v / 10, v % 10);
+    rep["hardware_profile"] = hwProfile;
+
+    rep["community_mode"] = globalCommunityMode;
+    rep["device_id"] = DEVICE_ID;
+
+    char serial[NAME_BUFFER_SIZE] = {0};
+    char pcbRev[VERSION_BUFFER_SIZE] = {0};
+    uint64_t mfgTs = 0;
+    Preferences prefs;
+    if (prefs.begin(PREFERENCES_NAMESPACE_FACTORY, true)) {
+        prefs.getString(FACTORY_KEY_SERIAL_NUMBER, serial, sizeof(serial));
+        prefs.getString(FACTORY_KEY_PCB_REVISION, pcbRev, sizeof(pcbRev));
+        mfgTs = prefs.getULong64(FACTORY_KEY_MFG_TS, 0);
+        prefs.end();
+    }
+    // Assign the bare char[] (ArduinoJson copies it). A ternary with the
+    // "Unknown" literal would decay to const char* and be stored by pointer,
+    // leaving a dangling pointer into this stack frame once we return.
+    if (serial[0] == '\0') snprintf(serial, sizeof(serial), "Unknown");
+    if (pcbRev[0] == '\0') snprintf(pcbRev, sizeof(pcbRev), "Unknown");
+    rep["serial_number"] = serial;
+    rep["pcb_revision"] = pcbRev;
+    rep["manufacturing_unix"] = mfgTs;
+}
+
+} // namespace Shadow

--- a/source/src/shadow.cpp
+++ b/source/src/shadow.cpp
@@ -7,10 +7,13 @@
 #include <esp_random.h>
 #include <esp_timer.h>
 
+#include "ade7953.h"
 #include "awsconfig.h"
 #include "factory_keys.h"
 #include "globals.h"
 #include "hardware_profile.h"
+#include "issueregistry.h"
+#include "led.h"
 #include "mqtt.h"
 #include "shadow_logic.h"
 #include "utils.h"
@@ -44,6 +47,25 @@ static esp_timer_handle_t _infoRefreshTimer = nullptr;
 
 // Report/apply callbacks (defined further down, registered in begin()).
 static void _reportInfo(JsonDocument& doc);
+static void _reportIssues(JsonDocument& doc);
+static void _onIssuesChanged();
+static void _reportSystem(JsonDocument& doc);
+static bool _applySystem(JsonObjectConst delta, JsonObject reported, JsonObject desired);
+static void _reportMeter(JsonDocument& doc);
+static bool _applyMeter(JsonObjectConst delta, JsonObject reported, JsonObject desired);
+static void _reportChannels(JsonDocument& doc);
+static bool _applyChannels(JsonObjectConst delta, JsonObject reported, JsonObject desired);
+
+// system shadow: transient (VERBOSE/DEBUG) mqtt_log_level auto-revert. The timer
+// callback (esp_timer task) only flips a flag; the MQTT task does the revert +
+// report (PubSubClient is single-task). _logLevelBaseline is the persisted level
+// to restore to.
+#define SHADOW_LOG_LEVEL_REVERT_INTERVAL_US (5ULL * 60ULL * 1000000ULL) // 5 min
+static esp_timer_handle_t _logLevelRevertTimer = nullptr;
+static volatile bool _logLevelRevertPending = false;
+static int _logLevelBaseline = 2; // INFO
+static void _logLevelRevertCallback(void* arg);
+static void _checkSystemLogLevelRevert();
 
 // ============================================================================
 // Registration
@@ -86,6 +108,13 @@ void begin() {
 
     _count = 0;
     _registerShadow({"info", false, _reportInfo, nullptr});
+    _registerShadow({"issues", false, _reportIssues, nullptr});
+    _registerShadow({"system", true, _reportSystem, _applySystem});
+    _registerShadow({"meter", true, _reportMeter, _applyMeter});
+    _registerShadow({"channels", true, _reportChannels, _applyChannels});
+
+    // Refresh the issues shadow on every registry transition/ack (flag only).
+    IssueRegistry::setChangeCallback(_onIssuesChanged);
 
     // Low-priority periodic refresh so identity shadow's lastUpdated stays fresh
     // even though the values rarely change. Callback only sets a flag.
@@ -100,6 +129,19 @@ void begin() {
             esp_timer_start_periodic(_infoRefreshTimer, SHADOW_INFO_REFRESH_INTERVAL_US);
         } else {
             LOG_WARNING("Failed to create info shadow refresh timer");
+        }
+    }
+
+    // One-shot timer for the transient mqtt_log_level auto-revert (created idle).
+    if (_logLevelRevertTimer == nullptr) {
+        const esp_timer_create_args_t revertArgs = {
+            .callback = _logLevelRevertCallback,
+            .arg = nullptr,
+            .dispatch_method = ESP_TIMER_TASK,
+            .name = "shadow_loglevel_revert",
+            .skip_unhandled_events = true};
+        if (esp_timer_create(&revertArgs, &_logLevelRevertTimer) != ESP_OK) {
+            LOG_WARNING("Failed to create mqtt_log_level revert timer");
         }
     }
 
@@ -290,6 +332,7 @@ static void _publishLocalEditDoc(uint8_t idx, const char* payload) {
 // ============================================================================
 
 void checkPublish() {
+    _checkSystemLogLevelRevert(); // transient mqtt_log_level revert (flag set by timer task)
     for (uint8_t i = 0; i < _count; i++) {
         char* delta = nullptr;
         char* localEdit = nullptr;
@@ -402,6 +445,290 @@ static void _reportInfo(JsonDocument& doc) {
     rep["serial_number"] = serial;
     rep["pcb_revision"] = pcbRev;
     rep["manufacturing_unix"] = mfgTs;
+}
+
+// ============================================================================
+// issues shadow (reported-only): runtime issue registry mirror
+// ============================================================================
+
+static void _onIssuesChanged() {
+    requestReport("issues"); // flag only; the MQTT task publishes
+}
+
+static void _reportIssues(JsonDocument& doc) {
+    JsonObject rep = doc["state"]["reported"].to<JsonObject>();
+    rep["active_count"] = IssueRegistry::activeCount();
+
+    SpiRamAllocator allocator;
+    JsonDocument tmp(&allocator);
+    if (IssueRegistry::issuesToJson(tmp)) {
+        rep["issues"] = tmp["issues"]; // deep-copied into doc's pool
+    } else {
+        rep["issues"].to<JsonArray>(); // empty array if the registry was busy
+    }
+}
+
+// ============================================================================
+// system shadow (writable): behavioural config + mqtt_log_level auto-revert
+// ============================================================================
+
+// esp_timer task: flag only. PubSubClient is single-task, so the MQTT task does
+// the actual revert + report (in _checkSystemLogLevelRevert).
+static void _logLevelRevertCallback(void* arg) {
+    (void)arg;
+    _logLevelRevertPending = true;
+}
+
+static void _checkSystemLogLevelRevert() {
+    if (!_logLevelRevertPending) return;
+    _logLevelRevertPending = false;
+    Mqtt::setRuntimeLogLevel(_logLevelBaseline);
+    LOG_INFO("mqtt_log_level auto-reverted to baseline %s", ShadowLogic::logLevelToString(_logLevelBaseline));
+    requestReport("system");
+}
+
+static void _applyMqttLogLevel(int level) {
+    if (ShadowLogic::isTransientLogLevel(level)) {
+        // Capture the persisted baseline once: if the current runtime level is
+        // itself transient we are already inside a window, so keep the stored
+        // baseline rather than overwriting it with another transient.
+        int current = Mqtt::getMqttLogLevel();
+        if (!ShadowLogic::isTransientLogLevel(current)) _logLevelBaseline = current;
+        _logLevelRevertPending = false;       // (re)entering transient
+        Mqtt::setRuntimeLogLevel(level);       // runtime only, not persisted
+        if (_logLevelRevertTimer != nullptr) {
+            esp_timer_stop(_logLevelRevertTimer); // harmless if not running
+            esp_timer_start_once(_logLevelRevertTimer, SHADOW_LOG_LEVEL_REVERT_INTERVAL_US);
+        }
+        LOG_INFO("mqtt_log_level transient %s (auto-revert in 5 min to %s)",
+                 ShadowLogic::logLevelToString(level), ShadowLogic::logLevelToString(_logLevelBaseline));
+    } else {
+        if (_logLevelRevertTimer != nullptr) esp_timer_stop(_logLevelRevertTimer);
+        _logLevelBaseline = level;    // track the new baseline so a late timer flag is a no-op
+        _logLevelRevertPending = false;
+        Mqtt::setMqttLogLevel(ShadowLogic::logLevelToString(level)); // persisted baseline
+    }
+}
+
+static void _reportSystem(JsonDocument& doc) {
+    JsonObject rep = doc["state"]["reported"].to<JsonObject>();
+    rep["led_brightness"] = Led::getBrightness();
+    rep["send_power_data"] = Mqtt::getSendPowerData();
+    rep["mqtt_log_level"] = ShadowLogic::logLevelToString(Mqtt::getMqttLogLevel());
+    rep["log_level_print"] = AdvancedLogger::logLevelToString(AdvancedLogger::getPrintLevel());
+    rep["log_level_save"] = AdvancedLogger::logLevelToString(AdvancedLogger::getSaveLevel());
+}
+
+static bool _applySystem(JsonObjectConst delta, JsonObject reported, JsonObject desired) {
+    (void)desired; // every top-level delta key is auto-nulled by the envelope backstop
+    bool applied = false;
+
+    JsonVariantConst v = delta["led_brightness"];
+    if (!v.isNull()) {
+        if (v.is<int>()) {
+            int b = v.as<int>();
+            if (b >= 0 && b <= 0xFF && Led::isBrightnessValid((uint8_t)b)) {
+                Led::setBrightness((uint8_t)b); // persists
+                reported["led_brightness"] = Led::getBrightness();
+                applied = true;
+            } else {
+                LOG_WARNING("Rejected led_brightness %d (out of range)", b);
+            }
+        } else {
+            LOG_WARNING("Rejected led_brightness: not an integer");
+        }
+    }
+
+    v = delta["send_power_data"];
+    if (!v.isNull()) {
+        if (v.is<bool>()) {
+            bool e = v.as<bool>();
+            Mqtt::setSendPowerData(e); // persists
+            reported["send_power_data"] = e;
+            applied = true;
+        } else {
+            LOG_WARNING("Rejected send_power_data: not a boolean");
+        }
+    }
+
+    v = delta["mqtt_log_level"];
+    if (!v.isNull()) {
+        int level = ShadowLogic::logLevelFromString(v.as<const char*>());
+        if (level < 0) {
+            LOG_WARNING("Rejected mqtt_log_level: unknown level");
+        } else {
+            _applyMqttLogLevel(level);
+            reported["mqtt_log_level"] = ShadowLogic::logLevelToString(Mqtt::getMqttLogLevel());
+            applied = true;
+        }
+    }
+
+    v = delta["log_level_print"];
+    if (!v.isNull()) {
+        int level = ShadowLogic::logLevelFromString(v.as<const char*>());
+        if (level < 0) {
+            LOG_WARNING("Rejected log_level_print: unknown level");
+        } else {
+            AdvancedLogger::setPrintLevel((LogLevel)level); // persists (lib-internal)
+            reported["log_level_print"] = AdvancedLogger::logLevelToString(AdvancedLogger::getPrintLevel());
+            applied = true;
+        }
+    }
+
+    v = delta["log_level_save"];
+    if (!v.isNull()) {
+        int level = ShadowLogic::logLevelFromString(v.as<const char*>());
+        if (level < 0) {
+            LOG_WARNING("Rejected log_level_save: unknown level");
+        } else {
+            AdvancedLogger::setSaveLevel((LogLevel)level); // persists (lib-internal)
+            reported["log_level_save"] = AdvancedLogger::logLevelToString(AdvancedLogger::getSaveLevel());
+            applied = true;
+        }
+    }
+
+    return applied;
+}
+
+// ============================================================================
+// meter shadow (writable): ADE7953 calibration + sample time
+// ============================================================================
+
+// The 19 calibration keys (camelCase) as serialized by getConfigurationAsJson.
+static const char* const METER_CAL_KEYS[] = {
+    "aVGain", "aIGain", "bIGain", "aIRmsOs", "bIRmsOs",
+    "aWGain", "bWGain", "aWattOs", "bWattOs",
+    "aVarGain", "bVarGain", "aVarOs", "bVarOs",
+    "aVaGain", "bVaGain", "aVaOs", "bVaOs",
+    "phCalA", "phCalB"};
+static constexpr size_t METER_CAL_KEY_COUNT = sizeof(METER_CAL_KEYS) / sizeof(METER_CAL_KEYS[0]);
+
+static void _reportMeter(JsonDocument& doc) {
+    JsonObject rep = doc["state"]["reported"].to<JsonObject>();
+    SpiRamAllocator allocator;
+    JsonDocument cfg(&allocator);
+    Ade7953::getConfigurationAsJson(cfg);
+    for (JsonPairConst kv : cfg.as<JsonObjectConst>()) rep[kv.key()] = kv.value();
+    rep["sample_time"] = Ade7953::getSampleTime();
+}
+
+static bool _applyMeter(JsonObjectConst delta, JsonObject reported, JsonObject desired) {
+    (void)desired; // top-level delta keys auto-nulled by the envelope backstop
+    bool applied = false;
+
+    // Collect the calibration fields present in the delta into a partial config.
+    SpiRamAllocator allocator;
+    JsonDocument cfg(&allocator);
+    for (size_t i = 0; i < METER_CAL_KEY_COUNT; i++) {
+        JsonVariantConst v = delta[METER_CAL_KEYS[i]];
+        if (v.isNull()) continue;
+        if (v.is<int>()) {
+            cfg[METER_CAL_KEYS[i]] = v.as<int32_t>();
+        } else {
+            LOG_WARNING("Rejected meter calibration '%s': not an integer", METER_CAL_KEYS[i]);
+        }
+    }
+    if (cfg.size() > 0) { // at least one calibration field present
+        if (Ade7953::setConfigurationFromJson(cfg, /*partial=*/true)) {
+            for (JsonPairConst kv : cfg.as<JsonObjectConst>()) reported[kv.key()] = kv.value();
+            applied = true;
+        } else {
+            LOG_WARNING("Meter calibration apply rejected by ADE7953");
+        }
+    }
+
+    // sample_time is not part of the calibration struct - applied separately.
+    JsonVariantConst st = delta["sample_time"];
+    if (!st.isNull()) {
+        if (st.is<int>() && st.as<int>() > 0 && Ade7953::setSampleTime((uint64_t)st.as<int>())) {
+            reported["sample_time"] = Ade7953::getSampleTime();
+            applied = true;
+        } else {
+            LOG_WARNING("Rejected sample_time (not a positive integer >= minimum)");
+        }
+    }
+
+    return applied;
+}
+
+// ============================================================================
+// channels shadow (writable): per-channel config, object-keyed by index
+// ============================================================================
+
+// Overlay src onto dst, recursing into nested objects (e.g. ctSpecification) so
+// a delta touching one subfield does not drop the channel's other CT params.
+static void _deepMerge(JsonObject dst, JsonObjectConst src) {
+    for (JsonPairConst kv : src) {
+        if (kv.value().is<JsonObjectConst>()) {
+            JsonObject child = dst[kv.key()].is<JsonObject>() ? dst[kv.key()].as<JsonObject>()
+                                                              : dst[kv.key()].to<JsonObject>();
+            _deepMerge(child, kv.value().as<JsonObjectConst>());
+        } else {
+            dst[kv.key()] = kv.value();
+        }
+    }
+}
+
+static void _reportChannels(JsonDocument& doc) {
+    JsonObject rep = doc["state"]["reported"].to<JsonObject>();
+    char key[4]; // up to "16" + null
+    for (uint8_t i = 0; i < globalHwProfile->totalChannelCount; i++) {
+        SpiRamAllocator allocator;
+        JsonDocument ch(&allocator);
+        if (!Ade7953::getChannelDataAsJson(ch, i)) continue;
+        ch.remove("index"); // index is the object key, not a field
+        snprintf(key, sizeof(key), "%u", i);
+        rep[key] = ch; // object-keyed so the cloud can patch one channel
+    }
+}
+
+static bool _applyChannels(JsonObjectConst delta, JsonObject reported, JsonObject desired) {
+    (void)desired; // each top-level (channel) key auto-nulled by the envelope backstop
+    bool applied = false;
+    uint8_t channelCount = globalHwProfile->totalChannelCount;
+
+    for (JsonPairConst kv : delta) {
+        uint8_t idx = 0;
+        if (!ShadowLogic::parseChannelIndex(kv.key().c_str(), channelCount, &idx)) {
+            LOG_WARNING("Rejected channel key '%s' (not a valid index)", kv.key().c_str());
+            continue;
+        }
+        if (!kv.value().is<JsonObjectConst>()) {
+            LOG_WARNING("Rejected channel %u delta (value is not an object)", idx);
+            continue;
+        }
+
+        // Start from the current channel, overlay the changed subfields, apply.
+        SpiRamAllocator mergeAlloc;
+        JsonDocument merged(&mergeAlloc);
+        if (!Ade7953::getChannelDataAsJson(merged, idx)) {
+            LOG_WARNING("Failed to read channel %u for merge", idx);
+            continue;
+        }
+        JsonObject mergedObj = merged.as<JsonObject>();
+        _deepMerge(mergedObj, kv.value().as<JsonObjectConst>());
+        merged["index"] = idx; // setChannelDataFromJson keys off this; never let a delta change it
+
+        bool roleChanged = false;
+        if (!Ade7953::setChannelDataFromJson(merged, /*partial=*/true, &roleChanged)) {
+            LOG_WARNING("Channel %u apply rejected by ADE7953", idx);
+            continue;
+        }
+
+        // Echo the channel as actually applied (e.g. channel 0 stays active even
+        // if a delta tried to disable it), keyed by index, index field dropped.
+        SpiRamAllocator afterAlloc;
+        JsonDocument after(&afterAlloc);
+        if (Ade7953::getChannelDataAsJson(after, idx)) {
+            after.remove("index");
+            char key[4];
+            snprintf(key, sizeof(key), "%u", idx);
+            reported[key] = after;
+        }
+        applied = true;
+    }
+
+    return applied;
 }
 
 } // namespace Shadow

--- a/source/src/shadow.cpp
+++ b/source/src/shadow.cpp
@@ -61,11 +61,11 @@ static void _reportIssues(JsonDocument& doc);
 static void _reportWifi(JsonDocument& doc);
 static void _onIssuesChanged();
 static void _reportSystem(JsonDocument& doc);
-static bool _applySystem(JsonObjectConst delta, JsonObject reported, JsonObject desired);
+static bool _applySystem(JsonObjectConst delta, JsonObject reported);
 static void _reportMeter(JsonDocument& doc);
-static bool _applyMeter(JsonObjectConst delta, JsonObject reported, JsonObject desired);
+static bool _applyMeter(JsonObjectConst delta, JsonObject reported);
 static void _reportChannels(JsonDocument& doc);
-static bool _applyChannels(JsonObjectConst delta, JsonObject reported, JsonObject desired);
+static bool _applyChannels(JsonObjectConst delta, JsonObject reported);
 
 // system shadow: transient (VERBOSE/DEBUG) mqtt_log_level auto-revert. The timer
 // callback (esp_timer task) only flips a flag; the MQTT task does the revert +
@@ -324,13 +324,15 @@ static void _applyDelta(uint8_t idx, const char* payload) {
     JsonObject reported = outDoc["state"]["reported"].to<JsonObject>();
     JsonObject desired = outDoc["state"]["desired"].to<JsonObject>();
 
-    _shadows[idx].desc.apply(delta, reported, desired);
+    _shadows[idx].desc.apply(delta, reported);
 
-    // Ack/clear invariant: every top-level field the cloud sent must be nulled
-    // in desired. The apply callback may have nulled keys granularly (nested
-    // object) - leave those; null any it did not touch.
+    // Ack/clear: null every top-level field the cloud sent so the delta clears
+    // (the cloud owns any further desired lifecycle). Channels are object-keyed,
+    // so this nulls the whole channel object - intentional: keeping a partial
+    // desired would re-trigger a delta storm for any field the device cannot
+    // converge (e.g. channel 0 stays active even if a delta tried to disable it).
     for (JsonPairConst kv : delta) {
-        if (!desired[kv.key()].is<JsonObject>()) desired[kv.key()] = nullptr;
+        desired[kv.key()] = nullptr;
     }
 
     if (ShadowLogic::shouldSendVersion(version)) outDoc["version"] = version;
@@ -593,8 +595,7 @@ static void _reportSystem(JsonDocument& doc) {
     rep["log_level_save"] = AdvancedLogger::logLevelToString(AdvancedLogger::getSaveLevel());
 }
 
-static bool _applySystem(JsonObjectConst delta, JsonObject reported, JsonObject desired) {
-    (void)desired; // every top-level delta key is auto-nulled by the envelope backstop
+static bool _applySystem(JsonObjectConst delta, JsonObject reported) {
     bool applied = false;
 
     JsonVariantConst v = delta["led_brightness"];
@@ -690,8 +691,7 @@ static void _reportMeter(JsonDocument& doc) {
     rep["sample_time"] = Ade7953::getSampleTime();
 }
 
-static bool _applyMeter(JsonObjectConst delta, JsonObject reported, JsonObject desired) {
-    (void)desired; // top-level delta keys auto-nulled by the envelope backstop
+static bool _applyMeter(JsonObjectConst delta, JsonObject reported) {
     bool applied = false;
 
     // Collect the calibration fields present in the delta into a partial config.
@@ -760,8 +760,7 @@ static void _reportChannels(JsonDocument& doc) {
     }
 }
 
-static bool _applyChannels(JsonObjectConst delta, JsonObject reported, JsonObject desired) {
-    (void)desired; // each top-level (channel) key auto-nulled by the envelope backstop
+static bool _applyChannels(JsonObjectConst delta, JsonObject reported) {
     bool applied = false;
     uint8_t channelCount = globalHwProfile->totalChannelCount;
 

--- a/source/src/shadow.cpp
+++ b/source/src/shadow.cpp
@@ -366,6 +366,11 @@ void checkPublish() {
 // ============================================================================
 
 void requestReport(const char* name) {
+    // Before begin() registers the shadows (_count == 0) callers like the
+    // ADE7953 channel-config load fire this during setup; ignore quietly - the
+    // shadow reports its full state on MQTT connect anyway, so a dropped early
+    // flag costs nothing. After init an unknown name is a real bug, so warn.
+    if (_count == 0) return;
     int idx = _findShadow(name, strlen(name));
     if (idx >= 0) _shadows[idx].reportPending = true; // benign volatile set
     else LOG_WARNING("requestReport for unknown shadow '%s'", name);

--- a/source/src/shadow.cpp
+++ b/source/src/shadow.cpp
@@ -668,7 +668,11 @@ static bool _applySystem(JsonObjectConst delta, JsonObject reported, JsonObject 
 // meter shadow (writable): ADE7953 calibration + sample time
 // ============================================================================
 
-// The 19 calibration keys (camelCase) as serialized by getConfigurationAsJson.
+// The 19 calibration keys (camelCase) as serialized by getConfigurationAsJson and
+// accepted by Ade7953::configurationFromJson - keep this list in sync with that
+// setter's key set. Kept as an explicit allow-list (rather than handing the raw
+// delta to setConfigurationFromJson) so the meter delta's sample_time - applied
+// separately below - is filtered out before it reaches _validateJsonConfiguration.
 static const char* const METER_CAL_KEYS[] = {
     "aVGain", "aIGain", "bIGain", "aIRmsOs", "bIRmsOs",
     "aWGain", "bWGain", "aWattOs", "bWattOs",

--- a/source/src/shadow.cpp
+++ b/source/src/shadow.cpp
@@ -340,6 +340,14 @@ static void _applyDelta(uint8_t idx, const char* payload) {
     _topicUpdate(_shadows[idx].desc.name, topic, sizeof(topic));
     if (Mqtt::publishReservedThings(outDoc, topic)) {
         LOG_INFO("Applied delta for shadow '%s' (version %lu)", _shadows[idx].desc.name, (unsigned long)version);
+        // Refresh the drift baseline so the 3 s drift check does not see this
+        // cloud-applied change as a fresh local edit and republish it. The ack
+        // above carries only the changed fields (partial), so rebuild the full
+        // report here rather than reusing outDoc.
+        SpiRamAllocator repAllocator;
+        JsonDocument repDoc(&repAllocator);
+        _shadows[idx].desc.report(repDoc);
+        _storeBaseline(idx, repDoc["state"]["reported"].as<JsonObjectConst>());
     } else {
         LOG_WARNING("Failed to publish delta ack for shadow '%s'", _shadows[idx].desc.name);
     }

--- a/source/src/shadow.cpp
+++ b/source/src/shadow.cpp
@@ -9,6 +9,7 @@
 
 #include "ade7953.h"
 #include "awsconfig.h"
+#include "customwifi.h"
 #include "factory_keys.h"
 #include "globals.h"
 #include "hardware_profile.h"
@@ -20,8 +21,9 @@
 
 namespace Shadow {
 
-// Up to 5 named shadows: info, issues, system, meter, channels.
-#define SHADOW_MAX_COUNT 5
+// Up to 6 named shadows: info, issues, wifi (reported-only), system, meter,
+// channels (writable).
+#define SHADOW_MAX_COUNT 6
 #define SHADOW_NAME_PREFIX "shadow/name/"
 #define SHADOW_INFO_REFRESH_INTERVAL_US (24ULL * 60ULL * 60ULL * 1000000ULL) // 24 h
 // Drift-detect cadence: each writable shadow's reported state is rebuilt and
@@ -56,6 +58,7 @@ static esp_timer_handle_t _infoRefreshTimer = nullptr;
 // Report/apply callbacks (defined further down, registered in begin()).
 static void _reportInfo(JsonDocument& doc);
 static void _reportIssues(JsonDocument& doc);
+static void _reportWifi(JsonDocument& doc);
 static void _onIssuesChanged();
 static void _reportSystem(JsonDocument& doc);
 static bool _applySystem(JsonObjectConst delta, JsonObject reported, JsonObject desired);
@@ -118,6 +121,7 @@ void begin() {
     _count = 0;
     _registerShadow({"info", false, _reportInfo, nullptr});
     _registerShadow({"issues", false, _reportIssues, nullptr});
+    _registerShadow({"wifi", false, _reportWifi, nullptr});
     _registerShadow({"system", true, _reportSystem, _applySystem});
     _registerShadow({"meter", true, _reportMeter, _applyMeter});
     _registerShadow({"channels", true, _reportChannels, _applyChannels});
@@ -453,6 +457,43 @@ static void _reportInfo(JsonDocument& doc) {
     rep["serial_number"] = serial;
     rep["pcb_revision"] = pcbRev;
     rep["manufacturing_unix"] = mfgTs;
+}
+
+// ============================================================================
+// wifi shadow (reported-only): non-secret network state + mode
+// ============================================================================
+
+static void _reportWifi(JsonDocument& doc) {
+    JsonObject rep = doc["state"]["reported"].to<JsonObject>();
+    char buf[64]; // SSID <=32, IP <=15, MAC 17 - all fit; reused (ArduinoJson copies char[])
+
+    rep["connected"] = WiFi.isConnected();
+
+    // SSID only - the WiFi password is never placed in a shadow (AWS forbids
+    // secrets in shadow docs, and we keep credentials local-only).
+    snprintf(buf, sizeof(buf), "%s", WiFi.SSID().c_str());
+    rep["ssid"] = buf;
+    snprintf(buf, sizeof(buf), "%s", WiFi.localIP().toString().c_str());
+    rep["ip"] = buf;
+    snprintf(buf, sizeof(buf), "%s", WiFi.gatewayIP().toString().c_str());
+    rep["gateway"] = buf;
+    snprintf(buf, sizeof(buf), "%s", WiFi.subnetMask().toString().c_str());
+    rep["subnet"] = buf;
+    snprintf(buf, sizeof(buf), "%s", WiFi.dnsIP().toString().c_str());
+    rep["dns"] = buf;
+    snprintf(buf, sizeof(buf), "%s", WiFi.macAddress().c_str());
+    rep["mac"] = buf;
+
+    // Network mode (DHCP vs static) for visibility. Reported-only: static IP is
+    // configured locally via REST, never written from the cloud - a bad remote
+    // static IP would risk locking the device off the LAN (see customwifi.h).
+    WifiConfiguration cfg;
+    if (CustomWifi::getConfiguration(cfg)) {
+        rep["static_ip"] = cfg.useStaticIp;
+        rep["fallback_to_dhcp"] = cfg.fallbackToDhcp;
+    }
+    // RSSI is intentionally omitted: it's volatile (would churn the shadow
+    // version) and is already on the system/dynamic telemetry topic.
 }
 
 // ============================================================================

--- a/source/src/shadow.cpp
+++ b/source/src/shadow.cpp
@@ -254,28 +254,39 @@ bool routeMessage(const char* topic, const char* payload) {
 // Publishing primitives (MQTT task context only)
 // ============================================================================
 
+// Snapshot the reported object as the drift baseline (MQTT-task-only field, no
+// mutex). The periodic drift check diffs against this, so refreshing it after a
+// publish - or after a cloud-delta apply - stops that change from being treated
+// as a fresh local edit and re-published. OOM leaves the baseline stale, which
+// just costs one redundant republish on the next tick.
+static void _storeBaseline(uint8_t idx, JsonObjectConst reported) {
+    size_t len = measureJson(reported) + 1;
+    char* snap = (char*)ps_malloc(len);
+    if (snap == nullptr) return;
+    serializeJson(reported, snap, len);
+    if (_shadows[idx].lastReported != nullptr) free(_shadows[idx].lastReported);
+    _shadows[idx].lastReported = snap;
+}
+
+// Publish an already-built reported doc and refresh the drift baseline from it.
+// Split out of _publishReported so the drift check can hand over the doc it just
+// built to detect the change, instead of rebuilding the full report a second time.
+static void _publishReportedDoc(uint8_t idx, JsonDocument& doc) {
+    char topic[MQTT_TOPIC_BUFFER_SIZE];
+    _topicUpdate(_shadows[idx].desc.name, topic, sizeof(topic));
+    if (!Mqtt::publishReservedThings(doc, topic)) {
+        LOG_WARNING("Failed to publish reported state for shadow '%s'", _shadows[idx].desc.name);
+        return;
+    }
+    LOG_DEBUG("Published reported state for shadow '%s'", _shadows[idx].desc.name);
+    _storeBaseline(idx, doc["state"]["reported"].as<JsonObjectConst>());
+}
+
 static void _publishReported(uint8_t idx) {
     SpiRamAllocator allocator;
     JsonDocument doc(&allocator);
     _shadows[idx].desc.report(doc); // fills doc["state"]["reported"]
-
-    char topic[MQTT_TOPIC_BUFFER_SIZE];
-    _topicUpdate(_shadows[idx].desc.name, topic, sizeof(topic));
-    if (Mqtt::publishReservedThings(doc, topic)) {
-        LOG_DEBUG("Published reported state for shadow '%s'", _shadows[idx].desc.name);
-        // Refresh the drift baseline so the periodic check only republishes on a
-        // real change from here on (MQTT-task-only field, no mutex).
-        JsonObjectConst reported = doc["state"]["reported"].as<JsonObjectConst>();
-        size_t len = measureJson(reported) + 1;
-        char* snap = (char*)ps_malloc(len);
-        if (snap != nullptr) {
-            serializeJson(reported, snap, len);
-            if (_shadows[idx].lastReported != nullptr) free(_shadows[idx].lastReported);
-            _shadows[idx].lastReported = snap;
-        }
-    } else {
-        LOG_WARNING("Failed to publish reported state for shadow '%s'", _shadows[idx].desc.name);
-    }
+    _publishReportedDoc(idx, doc);
 }
 
 static void _addClientToken(JsonDocument& doc) {
@@ -356,7 +367,7 @@ static void _reportIfDrifted(uint8_t idx) {
     bool changed = _shadows[idx].lastReported == nullptr ||
                    strcmp(cur, _shadows[idx].lastReported) != 0;
     free(cur);
-    if (changed) _publishReported(idx); // rebuilds, publishes, refreshes baseline
+    if (changed) _publishReportedDoc(idx, doc); // reuse the doc we just built
 }
 
 void checkPublish() {

--- a/source/src/shadow.cpp
+++ b/source/src/shadow.cpp
@@ -74,6 +74,7 @@ static volatile bool _logLevelRevertPending = false;
 static int _logLevelBaseline = 2; // INFO
 static void _logLevelRevertCallback(void* arg);
 static void _checkSystemLogLevelRevert();
+static void _applyMqttLogLevel(int level); // defined below; called from begin() for reboot-restore
 
 // ============================================================================
 // Registration
@@ -151,6 +152,18 @@ void begin() {
         if (esp_timer_create(&revertArgs, &_logLevelRevertTimer) != ESP_OK) {
             LOG_WARNING("Failed to create mqtt_log_level revert timer");
         }
+    }
+
+    // Restore a transient (VERBOSE/DEBUG) mqtt_log_level across a reboot so a debug
+    // session keeps boot-time logs. Mqtt::begin() loaded the persisted baseline
+    // before this, so _applyMqttLogLevel captures the correct baseline and restarts
+    // the 5-min timer. Persistent levels never write the marker, so this only fires
+    // for a genuine transient window.
+    int transientLevel = Mqtt::getTransientLogLevel();
+    if (transientLevel >= 0 && ShadowLogic::isTransientLogLevel(transientLevel)) {
+        LOG_INFO("Restoring transient mqtt_log_level %s after reboot",
+                 ShadowLogic::logLevelToString(transientLevel));
+        _applyMqttLogLevel(transientLevel);
     }
 
     LOG_DEBUG("Shadow module initialized with %u shadow(s)", _count);
@@ -478,6 +491,7 @@ static void _checkSystemLogLevelRevert() {
     if (!_logLevelRevertPending) return;
     _logLevelRevertPending = false;
     Mqtt::setRuntimeLogLevel(_logLevelBaseline);
+    Mqtt::clearTransientLogLevel(); // window closed; nothing to restore on next boot
     LOG_INFO("mqtt_log_level auto-reverted to baseline %s", ShadowLogic::logLevelToString(_logLevelBaseline));
     requestReport("system");
 }
@@ -495,12 +509,17 @@ static void _applyMqttLogLevel(int level) {
             esp_timer_stop(_logLevelRevertTimer); // harmless if not running
             esp_timer_start_once(_logLevelRevertTimer, SHADOW_LOG_LEVEL_REVERT_INTERVAL_US);
         }
+        // Persist a marker so a reboot mid-window restores the transient level and
+        // restarts the timer - a debug session keeps boot-time logs (the baseline
+        // key is left untouched).
+        Mqtt::saveTransientLogLevel(level);
         LOG_INFO("mqtt_log_level transient %s (auto-revert in 5 min to %s)",
                  ShadowLogic::logLevelToString(level), ShadowLogic::logLevelToString(_logLevelBaseline));
     } else {
         if (_logLevelRevertTimer != nullptr) esp_timer_stop(_logLevelRevertTimer);
         _logLevelBaseline = level;    // track the new baseline so a late timer flag is a no-op
         _logLevelRevertPending = false;
+        Mqtt::clearTransientLogLevel(); // leaving the transient window
         Mqtt::setMqttLogLevel(ShadowLogic::logLevelToString(level)); // persisted baseline
     }
 }

--- a/source/test/test_shadow_logic/test_shadow_logic.cpp
+++ b/source/test/test_shadow_logic/test_shadow_logic.cpp
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+//
+// Host unit tests for the pure shadow logic. Run with:
+//   pio test -e native          (from WSL - Windows native toolchain is unreliable)
+//
+// These need no hardware and no JSON library: they exercise the log-level name
+// mapping, the transient/persistent classification, the channel-key bounds
+// check, the client-token formatter and the version gate entirely in memory.
+
+#include <unity.h>
+#include <cstring>
+#include "shadow_logic.h"
+
+using namespace ShadowLogic;
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ============================================================================
+// logLevelFromString
+// ============================================================================
+
+void test_loglevel_from_string_all_valid(void) {
+    TEST_ASSERT_EQUAL_INT(0, logLevelFromString("VERBOSE"));
+    TEST_ASSERT_EQUAL_INT(1, logLevelFromString("DEBUG"));
+    TEST_ASSERT_EQUAL_INT(2, logLevelFromString("INFO"));
+    TEST_ASSERT_EQUAL_INT(3, logLevelFromString("WARNING"));
+    TEST_ASSERT_EQUAL_INT(4, logLevelFromString("ERROR"));
+    TEST_ASSERT_EQUAL_INT(5, logLevelFromString("FATAL"));
+}
+
+void test_loglevel_from_string_rejects_unknown(void) {
+    TEST_ASSERT_EQUAL_INT(LOG_LEVEL_INVALID, logLevelFromString("TRACE"));
+    TEST_ASSERT_EQUAL_INT(LOG_LEVEL_INVALID, logLevelFromString("WARN"));
+    TEST_ASSERT_EQUAL_INT(LOG_LEVEL_INVALID, logLevelFromString(""));
+}
+
+void test_loglevel_from_string_is_case_sensitive(void) {
+    // The cloud contract and existing firmware parser both use strict uppercase.
+    TEST_ASSERT_EQUAL_INT(LOG_LEVEL_INVALID, logLevelFromString("info"));
+    TEST_ASSERT_EQUAL_INT(LOG_LEVEL_INVALID, logLevelFromString("Debug"));
+}
+
+void test_loglevel_from_string_null_is_invalid(void) {
+    TEST_ASSERT_EQUAL_INT(LOG_LEVEL_INVALID, logLevelFromString(nullptr));
+}
+
+// ============================================================================
+// logLevelToString
+// ============================================================================
+
+void test_loglevel_to_string_all_valid(void) {
+    TEST_ASSERT_EQUAL_STRING("VERBOSE", logLevelToString(0));
+    TEST_ASSERT_EQUAL_STRING("DEBUG", logLevelToString(1));
+    TEST_ASSERT_EQUAL_STRING("INFO", logLevelToString(2));
+    TEST_ASSERT_EQUAL_STRING("WARNING", logLevelToString(3));
+    TEST_ASSERT_EQUAL_STRING("ERROR", logLevelToString(4));
+    TEST_ASSERT_EQUAL_STRING("FATAL", logLevelToString(5));
+}
+
+void test_loglevel_to_string_out_of_range_is_null(void) {
+    TEST_ASSERT_NULL(logLevelToString(-1));
+    TEST_ASSERT_NULL(logLevelToString(6));
+    TEST_ASSERT_NULL(logLevelToString(100));
+}
+
+void test_loglevel_round_trip(void) {
+    for (int i = 0; i <= 5; i++) {
+        TEST_ASSERT_EQUAL_INT(i, logLevelFromString(logLevelToString(i)));
+    }
+}
+
+// ============================================================================
+// isTransientLogLevel
+// ============================================================================
+
+void test_transient_levels(void) {
+    TEST_ASSERT_TRUE(isTransientLogLevel(0));  // VERBOSE
+    TEST_ASSERT_TRUE(isTransientLogLevel(1));  // DEBUG
+}
+
+void test_persistent_levels(void) {
+    TEST_ASSERT_FALSE(isTransientLogLevel(2)); // INFO
+    TEST_ASSERT_FALSE(isTransientLogLevel(3)); // WARNING
+    TEST_ASSERT_FALSE(isTransientLogLevel(4)); // ERROR
+    TEST_ASSERT_FALSE(isTransientLogLevel(5)); // FATAL
+}
+
+void test_transient_out_of_range_is_false(void) {
+    TEST_ASSERT_FALSE(isTransientLogLevel(-1));
+    TEST_ASSERT_FALSE(isTransientLogLevel(6));
+}
+
+// ============================================================================
+// parseChannelIndex
+// ============================================================================
+
+void test_channel_index_valid_bounds(void) {
+    uint8_t idx = 255;
+    TEST_ASSERT_TRUE(parseChannelIndex("0", 17, &idx));
+    TEST_ASSERT_EQUAL_UINT8(0, idx);
+    TEST_ASSERT_TRUE(parseChannelIndex("16", 17, &idx));
+    TEST_ASSERT_EQUAL_UINT8(16, idx);
+    TEST_ASSERT_TRUE(parseChannelIndex("5", 17, &idx));
+    TEST_ASSERT_EQUAL_UINT8(5, idx);
+}
+
+void test_channel_index_out_of_range(void) {
+    uint8_t idx = 255;
+    TEST_ASSERT_FALSE(parseChannelIndex("17", 17, &idx));   // == count
+    TEST_ASSERT_FALSE(parseChannelIndex("99", 17, &idx));
+    TEST_ASSERT_FALSE(parseChannelIndex("100000", 17, &idx)); // would overflow if unguarded
+    TEST_ASSERT_EQUAL_UINT8(255, idx);                       // untouched on failure
+}
+
+void test_channel_index_non_numeric(void) {
+    uint8_t idx = 255;
+    TEST_ASSERT_FALSE(parseChannelIndex("abc", 17, &idx));
+    TEST_ASSERT_FALSE(parseChannelIndex("3x", 17, &idx));
+    TEST_ASSERT_FALSE(parseChannelIndex("-1", 17, &idx));
+    TEST_ASSERT_FALSE(parseChannelIndex(" 5", 17, &idx));
+    TEST_ASSERT_FALSE(parseChannelIndex("", 17, &idx));
+}
+
+void test_channel_index_null_args(void) {
+    uint8_t idx = 255;
+    TEST_ASSERT_FALSE(parseChannelIndex(nullptr, 17, &idx));
+    TEST_ASSERT_FALSE(parseChannelIndex("5", 17, nullptr));
+}
+
+// ============================================================================
+// formatClientToken
+// ============================================================================
+
+void test_client_token_format(void) {
+    char buf[24];
+    size_t n = formatClientToken(buf, sizeof(buf), 0x12345678u, 0x9abcdef0u);
+    TEST_ASSERT_EQUAL_size_t(16, n);
+    TEST_ASSERT_EQUAL_STRING("123456789abcdef0", buf);
+}
+
+void test_client_token_zero_padding(void) {
+    char buf[24];
+    formatClientToken(buf, sizeof(buf), 0x1u, 0x0u);
+    TEST_ASSERT_EQUAL_STRING("0000000100000000", buf);
+    TEST_ASSERT_EQUAL_size_t(16, strlen(buf));
+}
+
+void test_client_token_buffer_too_small(void) {
+    char buf[16];  // one short of the 17 needed
+    TEST_ASSERT_EQUAL_size_t(0, formatClientToken(buf, sizeof(buf), 1u, 2u));
+    TEST_ASSERT_EQUAL_size_t(0, formatClientToken(nullptr, 24, 1u, 2u));
+}
+
+// ============================================================================
+// shouldSendVersion
+// ============================================================================
+
+void test_should_send_version(void) {
+    TEST_ASSERT_FALSE(shouldSendVersion(0));
+    TEST_ASSERT_TRUE(shouldSendVersion(1));
+    TEST_ASSERT_TRUE(shouldSendVersion(4294967295u));
+}
+
+// ============================================================================
+// Runner
+// ============================================================================
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_loglevel_from_string_all_valid);
+    RUN_TEST(test_loglevel_from_string_rejects_unknown);
+    RUN_TEST(test_loglevel_from_string_is_case_sensitive);
+    RUN_TEST(test_loglevel_from_string_null_is_invalid);
+
+    RUN_TEST(test_loglevel_to_string_all_valid);
+    RUN_TEST(test_loglevel_to_string_out_of_range_is_null);
+    RUN_TEST(test_loglevel_round_trip);
+
+    RUN_TEST(test_transient_levels);
+    RUN_TEST(test_persistent_levels);
+    RUN_TEST(test_transient_out_of_range_is_false);
+
+    RUN_TEST(test_channel_index_valid_bounds);
+    RUN_TEST(test_channel_index_out_of_range);
+    RUN_TEST(test_channel_index_non_numeric);
+    RUN_TEST(test_channel_index_null_args);
+
+    RUN_TEST(test_client_token_format);
+    RUN_TEST(test_client_token_zero_padding);
+    RUN_TEST(test_client_token_buffer_too_small);
+
+    RUN_TEST(test_should_send_version);
+
+    return UNITY_END();
+}

--- a/source/test/test_shadow_logic/test_shadow_logic.cpp
+++ b/source/test/test_shadow_logic/test_shadow_logic.cpp
@@ -164,6 +164,57 @@ void test_should_send_version(void) {
 }
 
 // ============================================================================
+// extractExecutionId
+// ============================================================================
+
+void test_exec_id_basic(void) {
+    char id[64];
+    TEST_ASSERT_TRUE(extractExecutionId(
+        "$aws/commands/things/907069875394/executions/abc123/request/json", id, sizeof(id)));
+    TEST_ASSERT_EQUAL_STRING("abc123", id);
+}
+
+void test_exec_id_uuid(void) {
+    char id[64];
+    TEST_ASSERT_TRUE(extractExecutionId(
+        "$aws/commands/things/dev/executions/7f3e-1a2b-99cd/request/cbor", id, sizeof(id)));
+    TEST_ASSERT_EQUAL_STRING("7f3e-1a2b-99cd", id);
+}
+
+void test_exec_id_malformed(void) {
+    char id[64];
+    TEST_ASSERT_FALSE(extractExecutionId("$aws/commands/things/dev/no-exec-segment", id, sizeof(id)));
+    TEST_ASSERT_FALSE(extractExecutionId("$aws/commands/things/dev/executions/", id, sizeof(id))); // empty id, no trailing /
+    TEST_ASSERT_FALSE(extractExecutionId("$aws/commands/things/dev/executions//request/json", id, sizeof(id))); // empty id
+    TEST_ASSERT_FALSE(extractExecutionId(nullptr, id, sizeof(id)));
+}
+
+void test_exec_id_truncation_rejected(void) {
+    char id[5]; // too small for "abc123" (6 chars + null)
+    TEST_ASSERT_FALSE(extractExecutionId(
+        "$aws/commands/things/dev/executions/abc123/request/json", id, sizeof(id)));
+}
+
+// ============================================================================
+// isCommandStale
+// ============================================================================
+
+void test_command_stale(void) {
+    TEST_ASSERT_TRUE(isCommandStale(1000, 1000 + 301, 300));  // 301s old, 5-min limit
+    TEST_ASSERT_FALSE(isCommandStale(1000, 1000 + 299, 300)); // 299s old
+    TEST_ASSERT_FALSE(isCommandStale(1000, 1000 + 300, 300)); // exactly at limit (not over)
+}
+
+void test_command_stale_no_timestamp(void) {
+    TEST_ASSERT_FALSE(isCommandStale(0, 1781650000, 300)); // no timestamp -> cannot judge
+}
+
+void test_command_stale_clock_skew(void) {
+    TEST_ASSERT_FALSE(isCommandStale(2000, 1000, 300)); // created "in the future" -> not stale
+    TEST_ASSERT_FALSE(isCommandStale(1000, 1000, 300)); // same instant
+}
+
+// ============================================================================
 // Runner
 // ============================================================================
 
@@ -193,6 +244,15 @@ int main(int argc, char **argv) {
     RUN_TEST(test_client_token_buffer_too_small);
 
     RUN_TEST(test_should_send_version);
+
+    RUN_TEST(test_exec_id_basic);
+    RUN_TEST(test_exec_id_uuid);
+    RUN_TEST(test_exec_id_malformed);
+    RUN_TEST(test_exec_id_truncation_rejected);
+
+    RUN_TEST(test_command_stale);
+    RUN_TEST(test_command_stale_no_timestamp);
+    RUN_TEST(test_command_stale_clock_skew);
 
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

AWS IoT Device Shadow config (v2.1.0 firmware surface) + IoT Commands. Moves device-side configurable state from bespoke MQTT config topics onto AWS IoT Named Device Shadows, adds IoT Commands, and retires the legacy config topics. Full contract + per-shadow design docs live in `source/docs/feature/2026-06-16-shadow-v2-config/`.

Closes #159.

## Shadows (publish-reported-first; no GET, no `/update/accepted`)

- **info, issues, wifi** - reported-only (identity / issue-registry mirror / non-secret network state)
- **system, meter, channels** - writable (behavioural config / ADE7953 calibration / per-channel config)
- Source-agnostic 3 s drift-detect republishes any local change (REST/UI/internal), reported-only
- `system.mqtt_log_level` transient (VERBOSE/DEBUG) auto-reverts after 5 min and survives a reboot (restored + timer restarted; baseline untouched)
- `wifi`: connected/ssid/ip/gateway/subnet/dns/mac + static_ip/fallback_to_dhcp. No writable network config, no credentials (local-only)

## IoT Commands (restart, factory_reset, energy_reset)

- Processed in the MQTT task body, not the PubSubClient callback - per-channel NVS work + status publishes run off the callback (#138) and avoid corrupting the QoS1 PUBACK
- Only `.../request/json` routes to the handler; AWS rejection echoes are ignored (fixes an infinite status-publish loop)
- `reasonCode`s uppercased to the AWS `[A-Z0-9_-]+` pattern
- `factory_reset` requires `confirm == DEVICE_ID`

## Design decision - the cloud owns clearing `desired`

Recorded in `00-overview-and-contract.md`. The device uses asymmetric desired-null (the delta-ack nulls `desired`; local edits publish reported-only). E2E testing surfaced a seam: a `desired` written **equal to** `reported` (a no-op or re-assert) yields no delta, so the no-GET device never clears it, and it then reverts the next local edit. Resolution (agreed with the cloud/infra side): the **cloud clears `desired` reactively after convergence** (load-bearing); avoiding `desired == reported` writes is an optional optimization only. No firmware change - the seam is not reachable until the cloud desired-writer exists.

## Other

- `issues` boot-race fixed: registry initialises before the web server, and `issuesToJson` degrades to an empty 200 on a null mutex (was HTTP 500 on early-boot polls)
- Legacy config topics retired (`system/static`, `command`, `channel`); surviving telemetry topics unchanged -> zero ingest gap; `MQTT_TOPIC_VERSION` stays `v1`
- `MQTT_BUFFER_SIZE` 5 KB -> 9 KB (worst-case inbound shadow delta)
- `fix(ade7953)`: sample-time reject log used `%lu` for a `uint64_t` so the minimum printed as `0`; now `%llu`
- Docs 01/05/06 realigned to the as-built drift-detect (removed stale `publishLocalEdit` references)

## Testing

Native unit tests: **162/162 pass** (incl. 25 `shadow_logic` cases).

Hardware-verified on dev .174, including the **real broker-delivered delta path** driven via `aws iot-data update-thing-shadow` (admin-dev) - the path the dev inject shim could not reach:

- Full writable matrix (every system/meter/channels field, both directions): apply -> persist -> report -> null `desired`, ~1 s round trip
- All 5 reject paths run real validation + ack-null (no stuck delta, no loop)
- Bulk 16-channel 63-char label+groupLabel delta = single **3848 B** inbound message, applied (< 9 KB buffer)
- Local+cloud interplay (drift + delta), idle no-thrash, read-only-shadow write inert (writable-gated subscribe)
- NVS persistence across reboot; `mqtt_log_level` transient full lifecycle (DEBUG -> reboot-restore + timer restart -> 5-min auto-revert)
- Offline->reconnect-apply (cloud-wins-on-reconnect); 409 optimistic-concurrency forced + recovers (re-publish without version -> fresh delta applies), bounded, no loop
- All commands + reject paths incl. a real `factory_reset` wipe + recovery

Device restored to baseline afterward, all `desired` cleared. Session details in `PROGRESS.md` (session-3).

## Not in this PR

- Firmware version bump to 2.1.0 (separate release step on `development`)
- Cloud-side: shadow ingestion + desired-state writer (must clear `desired` after convergence, per the decision above) + `StartCommandExecution` dispatcher (`energyme-infra`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
