### PR TITLE
fix(mqtt): accept comma-separated channels string in energy_reset

### DIFF
--- a/openspec/changes/energy-reset-channels-string/.openspec.yaml
+++ b/openspec/changes/energy-reset-channels-string/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/energy-reset-channels-string/design.md
+++ b/openspec/changes/energy-reset-channels-string/design.md
@@ -1,0 +1,31 @@
+## Context
+
+`_handleCommandExecution`'s `energy_reset` branch (`source/src/mqtt.cpp:1019-1035`) currently accepts `channels` as either the literal string `"all"` or a JSON array of integer indices. AWS IoT Commands parameters are string-typed end-to-end - `dispatch_command.py` already sends `channels` as a string (e.g. `"0,2,5"`) - so the JSON-array path can never actually be reached from the cloud. Today only `"all"` works from the cloud path; any selective cloud reset is rejected with `BAD_CHANNELS`. The JSON-array path remains reachable only from the on-device inject test harness, which must keep working unmodified.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Accept comma-separated channel specs (`"5"`, `"0,2,5"`) delivered as a string, in addition to the existing `"all"` string.
+- Preserve current behavior for the array-based on-device inject test harness, byte-for-byte.
+- No cloud/CDK change - the cloud already sends the right shape.
+
+**Non-Goals:**
+- Changing the AWS IoT Command parameter schema (already string-typed).
+- De-duplicating or sorting the parsed channel list.
+- Validating channel count limits beyond what fits the parse buffer.
+
+## Decisions
+
+- **Pure, read-only scan - no copy buffer, no `strtok`.** `doc["channels"].as<const char*>()` points into the already-deserialized, already-bounded (9 KB `MQTT_BUFFER_SIZE`) JSON document. A new `ShadowLogic::parseChannelList(spec, channelCount, validIndices, maxOut, &invalidTokenSeen)` host-testable helper (`lib/shadow_logic`, alongside the existing `extractExecutionId`/`isCommandStale` IoT-Commands helpers) scans `spec` directly without mutating or copying it, so there is no fixed-size buffer to size or overflow. Per token it copies only the (small, bounded) digit run into an internal stack scratch buffer to reuse the existing `parseChannelIndex` digit/range check.
+- **No up-front length check needed.** Since nothing is copied into a fixed buffer, there is no truncation/overflow risk to guard against; the scan is O(length of `channels`), already bounded by the MQTT buffer size. (Supersedes the earlier `strlcpy`-into-`buf[64]` + length-reject plan.)
+- **Per-token parsing is best-effort, not all-or-nothing.** A non-numeric or out-of-range token is skipped (and reported back via `invalidTokenSeen` so the caller logs `WARNING`), mirroring the existing array branch's per-index validation (`isChannelValid` failure -> `WARNING`, not abort). Alternative considered: validate the whole string in a first pass and only apply on a clean parse (true all-or-nothing). Rejected - it would diverge from the array branch's existing semantics for no real benefit.
+- **Leading/trailing-space trim + empty-token skip.** Tolerates `"0, 2, 5"` and a stray trailing comma (`"5,"`) without treating them as parse failures, since cloud-formatted lists may include either.
+- **Zero valid channels -> reject, not silent success.** If the spec yields no valid indices at all (empty string, or every token invalid/out-of-range), the command is `REJECTED` with `BAD_CHANNELS` rather than reporting `SUCCEEDED` for a no-op. A partial list (>=1 valid index, some invalid) still succeeds per the best-effort rule above - only the fully-empty result is treated as a rejection.
+
+## Risks / Trade-offs
+
+- Best-effort per-token parsing means a request like `"5,x,8"` resets channels 5 and 8 while only warning on `x`, rather than rejecting the whole command -> Mitigation: this matches the array branch's existing precedent (out-of-range index -> warn and continue), so it's consistent behavior, not a new failure mode.
+
+## Migration Plan
+
+None required - additive parsing branch, single firmware commit, no version bump (separate release step on `development` per repo convention).

--- a/openspec/changes/energy-reset-channels-string/proposal.md
+++ b/openspec/changes/energy-reset-channels-string/proposal.md
@@ -1,0 +1,20 @@
+## Why
+
+The `energy_reset` IoT Command's `channels` param currently accepts only the literal string `"all"` or a JSON array of channel indices. AWS IoT Commands parameters are string-typed end-to-end, so the cloud (`dispatch_command.py`) can only ever deliver a string - it can never actually send a JSON array. That means today, cloud-issued selective resets (e.g. "reset channel 5 only") are rejected with `BAD_CHANNELS`; only the full-reset path (`"all"`) works from the cloud. The JSON-array path is only reachable from the on-device inject test harness.
+
+## What Changes
+
+- `_handleCommandExecution`'s `energy_reset` branch (`source/src/mqtt.cpp:1019-1035`) gains a comma-separated string form for `channels`: `"all"` (unchanged), a single index (`"5"`), or a list (`"0,2,5"`).
+- Per-token parsing is best-effort, matching the existing array branch: an invalid/out-of-range channel index logs `WARNING` and continues; only an oversized input string (won't fit the bounded parse buffer) is rejected up front with `BAD_CHANNELS`, before any reset has happened.
+- The existing `JsonArrayConst` branch is unchanged, preserving the on-device inject test harness.
+- `openspec/specs/iot-commands/spec.md` updated to document the channel selector formats.
+
+## Capabilities
+
+### Modified Capabilities
+- `iot-commands`: `energy_reset`'s channel selector now also accepts a comma-separated string spec (in addition to `"all"` and the array form), since that is the only form AWS IoT Commands can actually deliver.
+
+## Impact
+
+- Firmware only: `source/src/mqtt.cpp`. No CDK/infra change - the cloud command schema already declares `channels` as a string and `dispatch_command.py` already sends `"0,2,5"`-style values; the device has just been silently unable to parse anything but `"all"`.
+- No version bump as part of this change (release-step policy: version bumps happen separately on `development`, never inside a feature branch).

--- a/openspec/changes/energy-reset-channels-string/specs/iot-commands/spec.md
+++ b/openspec/changes/energy-reset-channels-string/specs/iot-commands/spec.md
@@ -1,8 +1,5 @@
-# iot-commands Specification
+## MODIFIED Requirements
 
-## Purpose
-Transient device actions over AWS IoT Commands (restart, factory_reset, energy_reset): json-request routing only, off-callback processing, anti-fat-finger confirmation, and AWS-pattern reason codes. Jobs remain OTA-only.
-## Requirements
 ### Requirement: Three transient IoT Commands
 The device SHALL support exactly three AWS IoT Commands: `restart` (no payload), `factory_reset` (`{"confirm": "<device_id>"}`), and `energy_reset` (selective or full counter reset). Jobs remain OTA-only.
 
@@ -29,25 +26,3 @@ Parsing of the comma-separated form SHALL be best-effort per channel: an out-of-
 #### Scenario: energy_reset rejects a channel list with no valid indices
 - **WHEN** an `energy_reset` command is delivered with a `channels` string that is empty or contains no valid channel index (e.g. all tokens out-of-range or non-numeric)
 - **THEN** the device rejects the command with `BAD_CHANNELS` and resets no channels
-
-### Requirement: factory_reset requires device-id confirmation
-The device SHALL reject a `factory_reset` whose `confirm` field does not equal the device id. Only a matching `confirm` SHALL trigger the wipe of user NVS (factory NVS preserved).
-
-#### Scenario: Mismatched confirm is rejected
-- **WHEN** a `factory_reset` arrives with `confirm` not equal to the device id
-- **THEN** the device rejects it and performs no wipe
-
-### Requirement: Only the json request topic routes to the handler
-The device SHALL route only `.../request/json` to the command handler. AWS rejection echoes and any other payload-format segment SHALL be ignored, preventing an infinite status-publish loop.
-
-#### Scenario: Rejection echo is ignored
-- **WHEN** an AWS rejection echo is received on the command topic
-- **THEN** the device does not route it to the handler and does not publish a status in response
-
-### Requirement: Commands processed off the RX callback
-Command handling (per-channel NVS work and status publishes) SHALL run in the MQTT task body, not in the PubSubClient callback, to avoid corrupting the QoS1 PUBACK. Emitted `reasonCode`s SHALL be uppercased to the AWS `[A-Z0-9_-]+` pattern.
-
-#### Scenario: Status published from the task body
-- **WHEN** a command requires NVS work and a status publish
-- **THEN** that work runs in the MQTT task body and the reasonCode matches `[A-Z0-9_-]+`
-

--- a/openspec/changes/energy-reset-channels-string/tasks.md
+++ b/openspec/changes/energy-reset-channels-string/tasks.md
@@ -1,0 +1,18 @@
+## 1. Firmware
+
+- [x] 1.1 Add `ShadowLogic::parseChannelList(spec, channelCount, validIndices, maxOut, &invalidTokenSeen)` to `lib/shadow_logic` (`.h`/`.cpp`): read-only scan of a comma-separated index string (no copy/mutation of `spec`), trimming leading/trailing spaces and skipping empty tokens, reusing `parseChannelIndex` per token
+- [x] 1.2 In `_handleCommandExecution`'s `energy_reset` branch (`source/src/mqtt.cpp:~1019-1035`), add a comma-separated-string path: when `channels` is a string and not `"all"`, call `parseChannelList` and `Ade7953::resetChannelEnergyValues` each returned index; log `WARNING` if `invalidTokenSeen`; if zero valid indices are returned, reject with `BAD_CHANNELS` instead of reporting success
+- [x] 1.3 Leave the existing `JsonArrayConst` branch unchanged (on-device inject test harness)
+
+## 2. Spec
+
+- [x] 2.1 Sync the `iot-commands` delta spec into `openspec/specs/iot-commands/spec.md` (via `/opsx:sync` or archive)
+
+## 3. Tests
+
+- [x] 3.1 Native unit tests (`pio test -e native`, from WSL) for `ShadowLogic::parseChannelList`: `"all"` handled by the unchanged literal branch, single index (`"5"`), multi-index (`"0,2,5"`), list with one out-of-range index (others still returned, `invalidTokenSeen` set), list with one non-numeric token (others still returned, `invalidTokenSeen` set), leading/trailing-space + trailing-comma tolerance (`"0, 2, 5"`, `"5,"`), empty string and all-invalid string both yield zero valid indices (mqtt.cpp rejects these with `BAD_CHANNELS`), `maxOut` cap, array-branch regression unchanged - all 174 native tests pass
+- [x] 3.2 Hardware E2E on dev device (.174): via `/api/v1/shadow/inject-command` with `channels` as a JSON string (not the array inject-harness shape) - confirmed via UDP debug log: `"0,2,5"` and `"3"` -> SUCCEEDED; `"0,x,5"` -> WARNING + still SUCCEEDED (best-effort); `"x,y"` and `""` -> REJECTED/BAD_CHANNELS (zero-valid-channels guard); `[1,4]` (array) -> SUCCEEDED (regression-free). Additionally validated the real cloud path with `energyme-infra/.../dispatch_command.py` (AWS IoT `StartCommandExecution` via `iot-jobs-data`, `admin-dev` account 071378139398, real `.../request/json` broker round trip, not the local inject bypass): `"0,2,5"` -> SUCCEEDED, `"0,x,5"` -> WARNING + SUCCEEDED, `"x,y"` -> REJECTED/BAD_CHANNELS with the exact reasonDescription - device-side UDP log matched the cloud-reported status in all three
+
+## 4. Verification
+
+- [x] 4.1 Confirm `dispatch_command.py` / the cloud command schema already sends `channels` as this string format - no `energyme-infra` change needed (confirmed directly by Jibril, cloud side is source of truth)

--- a/source/lib/shadow_logic/shadow_logic.cpp
+++ b/source/lib/shadow_logic/shadow_logic.cpp
@@ -76,4 +76,41 @@ bool isCommandStale(uint64_t createdAtUnix, uint64_t nowUnix, uint64_t maxAgeSec
     return (nowUnix - createdAtUnix) > maxAgeSeconds;
 }
 
+size_t parseChannelList(const char* spec, uint8_t channelCount,
+                         uint8_t* validIndices, size_t maxOut,
+                         bool* invalidTokenSeen) {
+    if (invalidTokenSeen != nullptr) *invalidTokenSeen = false;
+    if (spec == nullptr || validIndices == nullptr || maxOut == 0) return 0;
+
+    size_t written = 0;
+    const char* p = spec;
+    while (*p != '\0') {
+        while (*p == ' ') p++; // trim leading spaces
+        const char* tokenStart = p;
+        while (*p != '\0' && *p != ',') p++;
+        const char* tokenEnd = p; // exclusive
+        while (tokenEnd > tokenStart && *(tokenEnd - 1) == ' ') tokenEnd--; // trim trailing spaces
+
+        size_t tokenLen = (size_t)(tokenEnd - tokenStart);
+        if (tokenLen > 0) {
+            char tok[8]; // room for any uint8_t index ("255") with margin
+            if (tokenLen >= sizeof(tok)) {
+                if (invalidTokenSeen != nullptr) *invalidTokenSeen = true; // can't possibly be a valid index
+            } else {
+                memcpy(tok, tokenStart, tokenLen);
+                tok[tokenLen] = '\0';
+                uint8_t idx;
+                if (parseChannelIndex(tok, channelCount, &idx)) {
+                    if (written < maxOut) validIndices[written++] = idx; // beyond maxOut: silently dropped, not invalid
+                } else {
+                    if (invalidTokenSeen != nullptr) *invalidTokenSeen = true;
+                }
+            }
+        } // empty token (stray "," or trailing comma): skipped silently
+
+        if (*p == ',') p++;
+    }
+    return written;
+}
+
 } // namespace ShadowLogic

--- a/source/lib/shadow_logic/shadow_logic.h
+++ b/source/lib/shadow_logic/shadow_logic.h
@@ -69,4 +69,20 @@ bool extractExecutionId(const char* topic, char* out, size_t outSize);
 // is also not stale.
 bool isCommandStale(uint64_t createdAtUnix, uint64_t nowUnix, uint64_t maxAgeSeconds);
 
+// Parses a comma-separated channel-index list (e.g. "5" or "0,2,5") for the
+// energy_reset command's string-typed `channels` param - the only shape AWS
+// IoT Commands can actually deliver. Read-only scan: spec is never mutated or
+// copied into a fixed buffer, so there is no length limit to enforce. Leading
+// and trailing spaces around each token are trimmed; empty tokens (from a
+// stray "5," or ",,") are skipped silently. Each non-empty token is validated
+// with parseChannelIndex; an out-of-range or non-numeric token is skipped and
+// causes *invalidTokenSeen to be set to true (so the caller can log a single
+// WARNING), while parsing continues best-effort for the remaining tokens.
+// Valid indices are written to validIndices in order, up to maxOut entries
+// (extra valid tokens beyond maxOut are silently dropped - callers should size
+// maxOut to >= channelCount). Returns the number of valid indices written.
+size_t parseChannelList(const char* spec, uint8_t channelCount,
+                         uint8_t* validIndices, size_t maxOut,
+                         bool* invalidTokenSeen);
+
 } // namespace ShadowLogic

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -1021,6 +1021,21 @@ namespace Mqtt
             if (channels.is<const char*>() && strcmp(channels.as<const char*>(), "all") == 0) {
                 Ade7953::resetEnergyValues();
                 LOG_INFO("Command %s: reset energy for all channels", executionId);
+            } else if (channels.is<const char*>()) {
+                // AWS IoT Commands params are string-typed end-to-end, so this is the
+                // only shape the cloud can actually deliver for a selective reset
+                // (e.g. "5" or "0,2,5"). See ShadowLogic::parseChannelList.
+                uint8_t indices[MAX_CHANNEL_COUNT];
+                bool invalidTokenSeen = false;
+                size_t count = ShadowLogic::parseChannelList(channels.as<const char*>(), globalHwProfile->totalChannelCount,
+                                                               indices, MAX_CHANNEL_COUNT, &invalidTokenSeen);
+                if (count == 0) {
+                    _publishCommandStatus(executionId, "REJECTED", "BAD_CHANNELS", "channels string contained no valid channel index");
+                    return;
+                }
+                if (invalidTokenSeen) LOG_WARNING("Command %s: invalid token(s) in energy_reset channels list", executionId);
+                for (size_t i = 0; i < count; i++) Ade7953::resetChannelEnergyValues(indices[i]);
+                LOG_INFO("Command %s: reset energy for listed channels", executionId);
             } else if (channels.is<JsonArrayConst>()) {
                 for (JsonVariantConst ch : channels.as<JsonArrayConst>()) {
                     if (!ch.is<int>()) continue;
@@ -1030,7 +1045,7 @@ namespace Mqtt
                 }
                 LOG_INFO("Command %s: reset energy for listed channels", executionId);
             } else {
-                _publishCommandStatus(executionId, "REJECTED", "BAD_CHANNELS", "channels must be an array of indices or \"all\"");
+                _publishCommandStatus(executionId, "REJECTED", "BAD_CHANNELS", "channels must be \"all\", a comma-separated index string, or an array of indices");
                 return;
             }
             _publishCommandStatus(executionId, "SUCCEEDED", nullptr, nullptr);

--- a/source/test/test_shadow_logic/test_shadow_logic.cpp
+++ b/source/test/test_shadow_logic/test_shadow_logic.cpp
@@ -215,6 +215,111 @@ void test_command_stale_clock_skew(void) {
 }
 
 // ============================================================================
+// parseChannelList
+// ============================================================================
+
+void test_parse_channel_list_single(void) {
+    uint8_t out[8];
+    bool invalid = true;
+    TEST_ASSERT_EQUAL_size_t(1, parseChannelList("5", 17, out, 8, &invalid));
+    TEST_ASSERT_EQUAL_UINT8(5, out[0]);
+    TEST_ASSERT_FALSE(invalid);
+}
+
+void test_parse_channel_list_multi(void) {
+    uint8_t out[8];
+    bool invalid = true;
+    TEST_ASSERT_EQUAL_size_t(3, parseChannelList("0,2,5", 17, out, 8, &invalid));
+    TEST_ASSERT_EQUAL_UINT8(0, out[0]);
+    TEST_ASSERT_EQUAL_UINT8(2, out[1]);
+    TEST_ASSERT_EQUAL_UINT8(5, out[2]);
+    TEST_ASSERT_FALSE(invalid);
+}
+
+void test_parse_channel_list_skips_non_numeric_token(void) {
+    uint8_t out[8];
+    bool invalid = false;
+    TEST_ASSERT_EQUAL_size_t(2, parseChannelList("0,x,5", 17, out, 8, &invalid));
+    TEST_ASSERT_EQUAL_UINT8(0, out[0]);
+    TEST_ASSERT_EQUAL_UINT8(5, out[1]);
+    TEST_ASSERT_TRUE(invalid);
+}
+
+void test_parse_channel_list_skips_out_of_range_token(void) {
+    uint8_t out[8];
+    bool invalid = false;
+    // channelCount=6 -> valid indices are 0..5; "9" is out of range
+    TEST_ASSERT_EQUAL_size_t(2, parseChannelList("0,9,2", 6, out, 8, &invalid));
+    TEST_ASSERT_EQUAL_UINT8(0, out[0]);
+    TEST_ASSERT_EQUAL_UINT8(2, out[1]);
+    TEST_ASSERT_TRUE(invalid);
+}
+
+void test_parse_channel_list_trims_spaces(void) {
+    uint8_t out[8];
+    bool invalid = true;
+    TEST_ASSERT_EQUAL_size_t(3, parseChannelList(" 0, 2 , 5 ", 17, out, 8, &invalid));
+    TEST_ASSERT_EQUAL_UINT8(0, out[0]);
+    TEST_ASSERT_EQUAL_UINT8(2, out[1]);
+    TEST_ASSERT_EQUAL_UINT8(5, out[2]);
+    TEST_ASSERT_FALSE(invalid);
+}
+
+void test_parse_channel_list_trailing_comma_tolerated(void) {
+    uint8_t out[8];
+    bool invalid = true;
+    // The empty token after the trailing comma is skipped silently (not invalid).
+    TEST_ASSERT_EQUAL_size_t(1, parseChannelList("5,", 17, out, 8, &invalid));
+    TEST_ASSERT_EQUAL_UINT8(5, out[0]);
+    TEST_ASSERT_FALSE(invalid);
+}
+
+void test_parse_channel_list_empty_string_yields_nothing(void) {
+    uint8_t out[8];
+    bool invalid = true;
+    TEST_ASSERT_EQUAL_size_t(0, parseChannelList("", 17, out, 8, &invalid));
+    TEST_ASSERT_FALSE(invalid); // genuinely empty, not "every token was invalid"
+}
+
+void test_parse_channel_list_all_invalid_yields_nothing(void) {
+    uint8_t out[8];
+    bool invalid = false;
+    TEST_ASSERT_EQUAL_size_t(0, parseChannelList("x,y", 17, out, 8, &invalid));
+    TEST_ASSERT_TRUE(invalid);
+}
+
+void test_parse_channel_list_overlong_token_is_invalid(void) {
+    uint8_t out[8];
+    bool invalid = false;
+    TEST_ASSERT_EQUAL_size_t(1, parseChannelList("99999999999,5", 17, out, 8, &invalid));
+    TEST_ASSERT_EQUAL_UINT8(5, out[0]);
+    TEST_ASSERT_TRUE(invalid);
+}
+
+void test_parse_channel_list_respects_max_out(void) {
+    uint8_t out[3] = {0, 0, 0};
+    bool invalid = true;
+    // 5 valid tokens, but only room for 3 - extras silently dropped, not "invalid".
+    TEST_ASSERT_EQUAL_size_t(3, parseChannelList("0,1,2,3,4", 17, out, 3, &invalid));
+    TEST_ASSERT_EQUAL_UINT8(0, out[0]);
+    TEST_ASSERT_EQUAL_UINT8(1, out[1]);
+    TEST_ASSERT_EQUAL_UINT8(2, out[2]);
+    TEST_ASSERT_FALSE(invalid);
+}
+
+void test_parse_channel_list_null_spec_is_safe(void) {
+    uint8_t out[8];
+    bool invalid = true;
+    TEST_ASSERT_EQUAL_size_t(0, parseChannelList(nullptr, 17, out, 8, &invalid));
+    TEST_ASSERT_FALSE(invalid);
+}
+
+void test_parse_channel_list_null_invalid_flag_is_safe(void) {
+    uint8_t out[8];
+    TEST_ASSERT_EQUAL_size_t(1, parseChannelList("5", 17, out, 8, nullptr));
+}
+
+// ============================================================================
 // Runner
 // ============================================================================
 
@@ -253,6 +358,19 @@ int main(int argc, char **argv) {
     RUN_TEST(test_command_stale);
     RUN_TEST(test_command_stale_no_timestamp);
     RUN_TEST(test_command_stale_clock_skew);
+
+    RUN_TEST(test_parse_channel_list_single);
+    RUN_TEST(test_parse_channel_list_multi);
+    RUN_TEST(test_parse_channel_list_skips_non_numeric_token);
+    RUN_TEST(test_parse_channel_list_skips_out_of_range_token);
+    RUN_TEST(test_parse_channel_list_trims_spaces);
+    RUN_TEST(test_parse_channel_list_trailing_comma_tolerated);
+    RUN_TEST(test_parse_channel_list_empty_string_yields_nothing);
+    RUN_TEST(test_parse_channel_list_all_invalid_yields_nothing);
+    RUN_TEST(test_parse_channel_list_overlong_token_is_invalid);
+    RUN_TEST(test_parse_channel_list_respects_max_out);
+    RUN_TEST(test_parse_channel_list_null_spec_is_safe);
+    RUN_TEST(test_parse_channel_list_null_invalid_flag_is_safe);
 
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary
- `energy_reset`'s `channels` param only ever accepted `"all"` or a JSON array from the cloud - but AWS IoT Commands params are string-typed end-to-end, so a selective cloud reset (e.g. channel 5 only) always failed with `BAD_CHANNELS`. Only the JSON-array shape (reachable only from the on-device inject test harness) supported multi-channel resets.
- Adds `ShadowLogic::parseChannelList`, a read-only comma-separated channel-list parser (`"5"`, `"0,2,5"`), wired into `_handleCommandExecution`'s `energy_reset` branch. Best-effort per token (invalid/out-of-range index logs `WARNING` and is skipped); rejects `BAD_CHANNELS` if the string yields zero valid channels instead of reporting a silent no-op success. The array branch is unchanged.
- OpenSpec change `energy-reset-channels-string` documents the design/spec and is synced into `openspec/specs/iot-commands/spec.md`.

## Test plan
- [x] Native unit tests: 174/174 passing (`pio test -e native`, incl. 12 new `parseChannelList` cases - TDD, RED confirmed before implementation)
- [x] Hardware E2E on dev device .174 via `/api/v1/shadow/inject-command`: multi-index, single-index, invalid-token tolerance, all-invalid/empty rejection, array-branch regression - all confirmed via UDP debug log
- [x] Real cloud dispatch via `energyme-infra`'s `dispatch_command.py` (`StartCommandExecution` through `iot-jobs-data`, `admin-dev` account): `"0,2,5"` -> SUCCEEDED, `"0,x,5"` -> WARNING + SUCCEEDED, `"x,y"` -> REJECTED/BAD_CHANNELS - device UDP log matched cloud-reported status in all cases

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SLnimJ2KQzVPEpzcyUejfv