### PR TITLE
feat(ade7953): grid frequency + voltage telemetry edge pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ v6.1 (current): Y1 absent on PCB - 15 mux channels + 1 direct ADE7953 input = **
 
 - Mandatory mutex on any non-atomic shared state. Keep critical sections short - copy needed data under the mutex, release, then act on the copy.
 - Graceful shutdown via task notifications (`ulTaskNotifyTake`); task self-deletes with `vTaskDelete(NULL)`.
-- Stack in **PSRAM** for non-flash tasks (WiFi, LED, ADE7953, etc.); **internal RAM** for tasks that touch flash (NVS, LittleFS, OTA) - flash cache disable crashes PSRAM-stack tasks.
+- All task stacks are **internal RAM** (plain `xTaskCreate()`), regardless of whether the task touches flash. PSRAM-backed task stacks were tried in the past and dropped due to problems; PSRAM is still used extensively for buffers/queues (`ps_malloc`, `SpiRamAllocator`), just not task stacks.
 
 ## Secrets / provisioning
 

--- a/openspec/changes/grid-telemetry-edge/.openspec.yaml
+++ b/openspec/changes/grid-telemetry-edge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/grid-telemetry-edge/design.md
+++ b/openspec/changes/grid-telemetry-edge/design.md
@@ -86,7 +86,7 @@ On pass: emit `{uint64_t timestamp_ms; float frequency; float voltage}` - freque
 
 New `MQTT_TOPIC_GRID "grid"` via `_constructMqttTopicWithRule(AWS_IOT_CORE_RULE_GRID, ...)` - same Basic Ingest pattern as meter/log (halves messaging cost at this cadence). The publish path drains the grid queue on the existing publish cadence (~30 s) and ships one JSON array of points per publish. Queue: 128 x 16 B = 2 KB, ~64 s buffer (2x publish period); on overflow drop oldest (grid telemetry is redundant fleet data, not billing data - recency beats completeness). Meter payload untouched.
 
-Payload schema (cross-repo contract, v1): `{"points": [{"t": <unix_ms>, "f": <hz float>, "v": <volt float>}, ...]}` - `t` is the true read at the tick (never the nominal boundary), array sorted, gaps explicit (missing boundaries).
+Payload schema (cross-repo contract, v1): bare top-level array of positional triplets `[[<t unix_ms>, <f hz>, <v volt>], ...]` - same compact style as the meter power points. `t` is the true read at the tick (never the nominal boundary); array sorted ascending; gaps explicit (missing boundaries). Serialization precision: `f` 4 decimals (0.1 mHz - preserves the 0.8 mHz EMA floor; the existing `GRID_FREQUENCY_DECIMALS`=3 would quantize it), `v` 1 decimal.
 
 *Rejected:* piggybacking on the meter payload (mixes the anonymous-at-rest stream into the attributed user path - breaks the ADR's load-bearing privacy boundary); per-point publish (60 msgs/min, cost).
 

--- a/openspec/changes/grid-telemetry-edge/design.md
+++ b/openspec/changes/grid-telemetry-edge/design.md
@@ -1,0 +1,114 @@
+## Context
+
+The ADE7953 exposes grid frequency via the 16-bit PERIOD register (0x10E), updated every line cycle. Today it is read once per linecyc inside the channel-0 meter path (`_readGridFrequency()`), unfiltered (quantization step ~11 mHz at 50 Hz) and converted without the datasheet's `+1` term (Eq.36, Rev. C p.36: `f = 223750 / (PERIOD + 1)`), giving a ~11 mHz systematic high bias.
+
+Issue #157 (supersedes #93) defines a per-cycle EMA that turns this into a ~0.8 mHz-resolution signal. The grid-telemetry ADR (energyme-infra) consumes it: anonymized 500 ms frequency+voltage points per device, per-zone consensus via cloud-side median over a rotating quorum. This change is the edge half only; the cloud contract items (topic, payload schema, report flag) are fixed here and handed to the infra repo (`infra-handoff.md`).
+
+Key existing machinery this builds on:
+
+- One shared active-low IRQ pin (GPIO from `globalHwProfile->ade7953InterruptPin`); ISR gives a binary semaphore; the ADE7953 task reads `RSTIRQSTATA_32` (read-with-reset: clears ALL bits) and dispatches.
+- `_interruptHandledChannelA/B`: double-read guard for read-with-reset energy registers, currently cleared in the ISR (assumes every IRQ = new linecyc).
+- Meter/log topics use Basic Ingest (`_constructMqttTopicWithRule`); payload batching over FreeRTOS queues.
+- `send_power_data`: NVS-persisted boolean, cloud-controlled via `system` shadow delta - the pattern the grid report flag mirrors.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Low-noise, absolutely-accurate grid frequency (EMA + Eq.36) exposed to all existing consumers.
+- 500 ms wall-clock-aligned `{t, f, v}` points on a dedicated batched grid topic, gated (NTP / report flag / freshness), with honest gaps (skipped ticks, never stale or fabricated points).
+- Zero regression to the metering path: energy reads, linecyc timing, and guard semantics preserved or strengthened.
+
+**Non-Goals:**
+
+- Cloud side: anonymization, zone resolution, consensus, quorum manager, dashboard, API (energyme-infra).
+- RoCoF / event-triggered raw capture, sag/swell, per-cycle min/max (deferred in #157).
+- Phase-angle / PMU claims (hardware cannot).
+- Stream B (user ~30 s house voltage on the meter path) - unchanged, out of scope.
+
+## Decisions
+
+### D1. Interrupt demux: one snapshot, service every set bit
+
+The ADE7953 IRQ pin is level-active-low; the ESP32 interrupt is edge-triggered (FALLING). A bit asserting while the pin is already low produces no new edge - so co-pending bits are routine once ZXV (~50 Hz) joins CYCEND. `RSTIRQSTATA` is read-with-reset, so the current single-type dispatch (`if/else if` returning one enum) silently discards co-pending bits.
+
+Rework: read `RSTIRQSTATA_32` once per wake, then independent `if`s over the snapshot - ZXV first (PERIOD is transient, overwritten every cycle), then CYCEND, RESET, CRC. Never re-read status to check another bit (second read returns zeros). No drain loop: anything asserting after the read-and-clear raises a fresh edge and a new wake; the existing timeout wake is the backstop.
+
+*Rejected:* per-type ISR dispatch (can't know cause without SPI); drain-until-clean loop (spins at 50 Hz ZXV; unbounded).
+
+### D2. ISR becomes pure; energy guard flags move into the task
+
+`_interruptHandledChannelA/B` protect read-with-reset energy registers from double reads within one frozen linecyc window. The ISR currently clears them on every interrupt - encoding the assumption "every IRQ is a new linecyc". ZXV at 50 Hz breaks that assumption and would re-arm the guard every 20 ms, making it decorative and reopening the double-read window (second read returns ~0, destroying that cycle's energy).
+
+Fix: ISR does semaphore give + statistics counter only. The task clears the flags iff the CYCEND bit is set in the snapshot, immediately before `_handleCycendInterrupt()`. Strictly stronger than today: the guard re-arms only on a true new linecyc.
+
+### D3. Frequency: per-cycle Q24.8 EMA in the period domain (issue #157)
+
+- ZXV handler: read PERIOD (16-bit), validate via existing `_validateGridFrequency` (45-65 Hz) - out-of-range cycles are dropped, never fed to the EMA; first in-range read seeds it (never 0).
+- `ema_q8 += (x_q8 - ema_q8) >> 3` (alpha = 1/8): ~15-cycle / ~300 ms window, ~1.06 Hz cutoff, ~0.8 mHz floor (Allan-optimal per #157). Q8 keeps sub-LSB resolution through the shift; int32 read/write is atomic on Xtensa.
+- Monotonic `_emaUpdateCount` incremented on each accepted update - the freshness signal (D5).
+- Conversion at readout only: `f = 223750 / (ema/256 + 1)`. The `+1` (datasheet Eq.36) is applied fleet-wide including the raw path `_readGridFrequency()` - fixes the ~11 mHz absolute bias. Filtering in the period domain is deliberate: reciprocal nonlinearity bias is sub-uHz at <1% period swing.
+- `getGridFrequency()` returns the EMA value. `_updateSampleTime()` (50/60 Hz bootstrap for linecyc) stays on the direct raw read - it runs before the EMA seeds.
+- ZXV misses under load are best-effort by design: bits are flags not counters, PERIOD holds only the latest cycle; a missed cycle just shrinks effective N (~15 -> ~13 worst case, sub-mHz effect). CYCEND is never best-effort - its bit rides every snapshot.
+
+*Rejected:* histogram telemetry (superseded in #157 - no useful sub-mHz structure beyond ~320 ms averaging); float/divide on hot path; timestamping ZXV events (sampler stamps snapshots instead).
+
+### D4. Register init: extend constants, no RMW
+
+Init is the only writer of `CONFIG_16` / `IRQENA_32`, so extend the existing constants: `DEFAULT_IRQENA_REGISTER` gains bit 15 (ZXV); `DEFAULT_CONFIG_REGISTER` gains ZX_EDGE = `10b` (bits 13:12, positive-going only -> 1 IRQ/cycle). Datasheet-confirmed safe: "changing the ZX_EDGE bits affects only the ZX status bits and interrupts" - linecyc half-line-cycle counting and energy accumulation are unaffected; the waveform capture routine counts zero crossings in software and is independent.
+
+### D5. Sampler: dedicated task, absolute wall-clock alignment, three gates
+
+Dedicated task (PSRAM stack; RAM-only work - no SPI, no flash, no JSON). Each iteration targets the next absolute .000/.500 boundary derived from the wall clock:
+
+```c
+uint64_t now = CustomTime::getUnixTimeMilliseconds();
+uint32_t delayMs = 500 - (now % 500);
+if (delayMs < 20) delayMs += 500;      // degenerate-sleep / backward-NTP-step guard
+vTaskDelay(pdMS_TO_TICKS(delayMs));
+```
+
+Boundary-derived delay (not `vTaskDelayUntil`): re-targets the absolute grid every tick, so crystal drift never accumulates and NTP steps self-heal with no re-phasing logic. `vTaskDelayUntil` gives perfect spacing but in the tick domain, which slides off the wall-clock grid.
+
+Why absolute alignment matters (and is required by the ADR): consensus quality during grid events. Apparent disagreement between healthy devices = RoCoF x time skew. Normal RoCoF (~13 mHz/s p99.9) x 250 ms = ~3 mHz (noise-level); event RoCoF (0.5-2 Hz/s) x 250 ms = 125-500 mHz - which would make cloud outlier-rejection reject healthy devices exactly when the data matters. Alignment collapses skew to NTP error (~±50 ms), a 5-10x improvement for four lines of code. Staggered ("sparse") sampling was considered and rejected: the EMA band-limits each device to ~1 Hz (nothing above Nyquist to recover), NTP jitter scrambles sub-50 ms interleave order, and it destroys same-instant cross-validation. Alignment is best-effort, not correctness-bearing: stamps are always the true `getUnixTimeMilliseconds()` read, so a misaligned device degrades bucket tightness, never data integrity.
+
+Gates, in order - all must pass or the tick is skipped (a real timestamp gap, visible to the cloud):
+
+1. Time is NTP-synced (existing `CustomTime` gate).
+2. Grid report flag enabled (D7).
+3. `_emaUpdateCount != lastSeen` - the EMA actually updated since the last emit. Line-dead => no ZXV => no points. Single-writer counter, no clearing, no race (elegant replacement for a dirty flag).
+
+On pass: emit `{uint64_t timestamp_ms; float frequency; float voltage}` - frequency from the EMA (D3), voltage = cached `_meterValues[0].voltage` (refreshed each CYCEND, <= `_sampleTime` stale; RMS moves slowly; keeps the sampler SPI-free). `xQueueSend` with zero block time.
+
+*Rejected:* esp_timer callback (gating logic in a timer cb, no fresh-read option ever); folding into an existing task (couples grid cadence to unrelated timing); fresh VRMS SPI read (forces SPI into the sampler for negligible gain).
+
+### D6. Transport: dedicated Basic Ingest topic, batched
+
+New `MQTT_TOPIC_GRID "grid"` via `_constructMqttTopicWithRule(AWS_IOT_CORE_RULE_GRID, ...)` - same Basic Ingest pattern as meter/log (halves messaging cost at this cadence). The publish path drains the grid queue on the existing publish cadence (~30 s) and ships one JSON array of points per publish. Queue: 128 x 16 B = 2 KB, ~64 s buffer (2x publish period); on overflow drop oldest (grid telemetry is redundant fleet data, not billing data - recency beats completeness). Meter payload untouched.
+
+Payload schema (cross-repo contract, v1): `{"points": [{"t": <unix_ms>, "f": <hz float>, "v": <volt float>}, ...]}` - `t` is the true read at the tick (never the nominal boundary), array sorted, gaps explicit (missing boundaries).
+
+*Rejected:* piggybacking on the meter payload (mixes the anonymous-at-rest stream into the attributed user path - breaks the ADR's load-bearing privacy boundary); per-point publish (60 msgs/min, cost).
+
+### D7. Report flag: `send_grid_data`, mirrors `send_power_data` exactly
+
+NVS-persisted boolean, default off; cloud flips it via the `system` shadow delta (the ADR's quorum rotation mechanism). Gates payload contribution only - the EMA always runs (it feeds `getGridFrequency()` for REST/Modbus/HA/issues regardless). Persistence means quorum membership survives reboot; no requirement change to the `iot-device-shadows` spec (new key rides the existing writable-shadow machinery).
+
+## Risks / Trade-offs
+
+- [Task wake rate 3-5/s -> ~50/s] -> ~100 us SPI per ZXV wake (~0.5% CPU); FreeRTOS handles this trivially. Verify with the task profiler + `getDebugCount()` rate after flashing; acceptance criterion: no measurable meter-heartbeat impact.
+- [ZXV floods during degraded line (brownout flicker)] -> validation drops out-of-range PERIODs; freshness gate stops emission; existing timeout/`_recordCriticalFailure` path unchanged.
+- [`statistics.ade7953TotalInterrupts` inflates ~10x] -> add a separate ZXV counter; keep total meaningful.
+- [`getGridFrequency()` shifts ~11 mHz lower + becomes filtered] -> correct per datasheet; imperceptible to users (3-decimal display); note in release notes.
+- [Backward NTP step could emit two points near one boundary] -> `delayMs < 20` guard absorbs small steps; stamps are honest so the cloud dedupes by bucket; harmless.
+- [Queue overflow during long MQTT outage] -> drop-oldest by design; grid data is fleet-redundant.
+- [Cross-repo drift: topic/rule/schema/flag names] -> single source of truth is this design + `infra-handoff.md`; both repos must reference it before shipping either side.
+
+## Migration Plan
+
+Pure firmware addition behind the `send_grid_data` flag (default off): deploy order-independent. Flash dev device (.174), verify metering unchanged (UDP logs + heartbeats), enable flag manually, verify points on the topic with MQTT test client before any infra work. Rollback = flag off or previous OTA image; no data-format or NVS migrations.
+
+## Open Questions
+
+- Final topic/rule literal (`AWS_IOT_CORE_RULE_GRID` name) - confirm against infra naming conventions at infra-PR time; placeholder fixed in `infra-handoff.md`.
+- QoS for grid publishes: QoS0 suggested (redundant data, cheapest); meter uses QoS1 today - decide at implementation.

--- a/openspec/changes/grid-telemetry-edge/design.md
+++ b/openspec/changes/grid-telemetry-edge/design.md
@@ -110,5 +110,8 @@ Pure firmware addition behind the `send_grid_data` flag (default off): deploy or
 
 ## Open Questions
 
-- Final topic/rule literal (`AWS_IOT_CORE_RULE_GRID` name) - confirm against infra naming conventions at infra-PR time; placeholder fixed in `infra-handoff.md`.
 - QoS for grid publishes: QoS0 suggested (redundant data, cheapest); meter uses QoS1 today - decide at implementation.
+
+## Resolved
+
+- Rule literal: `AWS_IOT_CORE_RULE_GRID` = `energyme_home_dev_rule_grid` / `energyme_home_prod_rule_grid`, `ENV_DEV`-guarded in `include/awsconfig.h` alongside the meter/log rules.

--- a/openspec/changes/grid-telemetry-edge/design.md
+++ b/openspec/changes/grid-telemetry-edge/design.md
@@ -110,8 +110,9 @@ Pure firmware addition behind the `send_grid_data` flag (default off): deploy or
 
 ## Open Questions
 
-- QoS for grid publishes: QoS0 suggested (redundant data, cheapest); meter uses QoS1 today - decide at implementation.
+(none)
 
 ## Resolved
 
 - Rule literal: `AWS_IOT_CORE_RULE_GRID` = `energyme_home_dev_rule_grid` / `energyme_home_prod_rule_grid`, `ENV_DEV`-guarded in `include/awsconfig.h` alongside the meter/log rules.
+- QoS: grid publishes at QoS0, consistent with all existing publishes (QoS1 is used only for subscriptions).

--- a/openspec/changes/grid-telemetry-edge/infra-handoff.md
+++ b/openspec/changes/grid-telemetry-edge/infra-handoff.md
@@ -1,0 +1,27 @@
+# Infra handoff: grid telemetry ingestion (copy-paste brief for energyme-infra)
+
+> Edge contract fixed by EnergyMe-Home change `grid-telemetry-edge` (issue #157 + grid-telemetry ADR).
+> Firmware ships Stream A only; everything below is the cloud side to build.
+
+## Contract (fixed by firmware)
+
+- **Topic:** Basic Ingest, new IoT rule (working name `AWS_IOT_CORE_RULE_GRID`), device publishes to `$aws/rules/<rule>/energyme/home/<device_id>/grid` (same pattern as the existing meter/log rules). Final rule name: infra's call - sync the literal back before firmware ships.
+- **Payload:** batched, ~1 per existing publish cadence (~30 s):
+  `{"points": [{"t": <unix_ms uint64>, "f": <Hz float>, "v": <V float>}, ...]}`
+  - `t` = true device wall-clock read at sample time, aligned near absolute .000/.500 boundaries (NTP-quality, ±10-50 ms typical); array sorted ascending; gaps are real (gated ticks), never interpolated.
+  - `f` = EMA-filtered grid frequency (~0.8 mHz resolution, ~1 Hz bandwidth); `v` = per-device RMS voltage (local signal - never aggregate across devices).
+- **Report flag:** `send_grid_data` boolean in the writable `system` named shadow (same mechanism as `send_power_data`), persisted on device, default **off**. This is the quorum on/off lever.
+
+## Work items (cloud)
+
+1. **IoT Core policy**: allow the new Basic Ingest rule publish for device certs (extend the provisioned policy template alongside meter/log).
+2. **IoT rule + anonymizing ingest Lambda**: resolve `device_id -> synchronous zone / geohash` from provisioned location, write zone-tagged records, **drop `device_id` before any write** (load-bearing privacy control - grid tables must never receive it; see ADR Decision 6).
+3. **Quorum manager**: per-zone selection of 5-15 reporting devices, rotate membership, flip `send_grid_data` via the shadow desired state (remember the write-to-change-then-null-desired contract).
+4. **Storage**: hot InfluxDB (1-3 d) + Iceberg/Parquet cold tables per ADR Decision 5 (`grid_frequency_raw` short retention, `grid_frequency_consensus` long, `grid_voltage` long), all keyed by zone, day-partitioned, reusing the Firehose plumbing.
+5. **Consensus compute**: per-zone median across the quorum per 500 ms bucket (bucket by nearest .000/.500; dedupe by bucket per device).
+
+## Notes for the ingest design
+
+- Devices only emit when NTP-synced, flag on, and the measurement actually updated - so absent points are meaningful (offline / line-dead / not in quorum), not errors.
+- QoS0 likely (redundant fleet data); tolerate duplicates and out-of-order batches idempotently (bucket + zone dedupe).
+- Chronically misaligned timestamps (far from .000/.500) indicate a bad device clock - down-weight, don't reject the zone.

--- a/openspec/changes/grid-telemetry-edge/infra-handoff.md
+++ b/openspec/changes/grid-telemetry-edge/infra-handoff.md
@@ -5,7 +5,7 @@
 
 ## Contract (fixed by firmware)
 
-- **Topic:** Basic Ingest, new IoT rule (working name `AWS_IOT_CORE_RULE_GRID`), device publishes to `$aws/rules/<rule>/energyme/home/<device_id>/grid` (same pattern as the existing meter/log rules). Final rule name: infra's call - sync the literal back before firmware ships.
+- **Topic:** Basic Ingest, new IoT rule `energyme_home_dev_rule_grid` / `energyme_home_prod_rule_grid` (same naming and env split as the existing meter/log rules); device publishes to `$aws/rules/<rule>/energyme/home/<device_id>/grid`.
 - **Payload:** batched, ~1 message per existing publish cadence (~30 s), bare JSON array of positional triplets:
   `[[<t unix_ms uint64>, <f Hz float 4-dec>, <v V float 1-dec>], ...]`
   e.g. `[[1751500000003, 50.0123, 230.1], [1751500000502, 50.0119, 230.2]]`

--- a/openspec/changes/grid-telemetry-edge/infra-handoff.md
+++ b/openspec/changes/grid-telemetry-edge/infra-handoff.md
@@ -6,10 +6,12 @@
 ## Contract (fixed by firmware)
 
 - **Topic:** Basic Ingest, new IoT rule (working name `AWS_IOT_CORE_RULE_GRID`), device publishes to `$aws/rules/<rule>/energyme/home/<device_id>/grid` (same pattern as the existing meter/log rules). Final rule name: infra's call - sync the literal back before firmware ships.
-- **Payload:** batched, ~1 per existing publish cadence (~30 s):
-  `{"points": [{"t": <unix_ms uint64>, "f": <Hz float>, "v": <V float>}, ...]}`
+- **Payload:** batched, ~1 message per existing publish cadence (~30 s), bare JSON array of positional triplets:
+  `[[<t unix_ms uint64>, <f Hz float 4-dec>, <v V float 1-dec>], ...]`
+  e.g. `[[1751500000003, 50.0123, 230.1], [1751500000502, 50.0119, 230.2]]`
   - `t` = true device wall-clock read at sample time, aligned near absolute .000/.500 boundaries (NTP-quality, ±10-50 ms typical); array sorted ascending; gaps are real (gated ticks), never interpolated.
-  - `f` = EMA-filtered grid frequency (~0.8 mHz resolution, ~1 Hz bandwidth); `v` = per-device RMS voltage (local signal - never aggregate across devices).
+  - `f` = EMA-filtered grid frequency (~0.8 mHz resolution, ~1 Hz bandwidth), 4 decimals; `v` = per-device RMS voltage (local signal - never aggregate across devices), 1 decimal.
+  - No envelope object: adding fields later means a new topic/rule version, not an in-place schema change.
 - **Report flag:** `send_grid_data` boolean in the writable `system` named shadow (same mechanism as `send_power_data`), persisted on device, default **off**. This is the quorum on/off lever.
 
 ## Work items (cloud)

--- a/openspec/changes/grid-telemetry-edge/proposal.md
+++ b/openspec/changes/grid-telemetry-edge/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Firmware has a high-quality grid frequency source (ADE7953 PERIOD register, ~0.8 mHz resolution after ~300 ms averaging) that is currently read once per linecyc, unfiltered (~11 mHz quantization dither) and with a known ~11 mHz absolute bias (missing the datasheet Eq.36 `+1`). Issue #157 defines the per-cycle EMA that fixes both; the grid-telemetry ADR (cloud side, energyme-infra) needs the edge to ship anonymizable 500 ms frequency + voltage points on a dedicated topic so the cloud can build a per-zone consensus dataset. This change is the firmware (edge) half of that contract.
+
+## What Changes
+
+- **ADE7953 interrupt demux rework**: ZXV (voltage zero-crossing, ~50 Hz) is enabled alongside CYCEND on the shared IRQ pin. `_handleInterrupt()` changes from "return one interrupt type" to "service every set bit of one `RSTIRQSTATA` snapshot" (independent `if`s, not `else if`). The ISR becomes pure (semaphore give + counter only); the `_interruptHandledChannelA/B` double-read guard flags move from the ISR into the task, cleared only when the CYCEND bit is actually set. This strengthens the existing energy read-with-reset guard.
+- **Per-cycle frequency EMA** (issue #157): each ZXV reads PERIOD, validates 45-65 Hz, updates a Q24.8 fixed-point EMA (alpha = 1/8, shift-only) plus a monotonic update counter. `getGridFrequency()` returns the filtered value.
+- **Absolute accuracy fix**: frequency conversion becomes `f = 223750 / (PERIOD + 1)` per datasheet Eq.36 everywhere (raw path included) - removes a ~11 mHz systematic high bias from all consumers (REST, Modbus, HA, shadow, issues).
+- **New 500 ms grid sampler task**: wall-clock-aligned to absolute .000/.500 boundaries (boundary-derived `vTaskDelay`, true `getUnixTimeMilliseconds()` stamps), gated on NTP sync, cloud-set report flag, and EMA freshness (update counter). Emits `{timestamp_ms, frequency, voltage}` (voltage = cached channel-0 RMS) into a FreeRTOS queue.
+- **New dedicated grid MQTT topic** (Stream A of the ADR): publish task drains the queue and ships batched point arrays on a new topic, separate from the meter payload, on the existing publish cadence. Meter payload unchanged.
+- **New cloud-settable report flag** (mirrors the existing meter power-flag pattern) gating payload contribution only - the EMA always runs locally.
+
+## Capabilities
+
+### New Capabilities
+- `grid-frequency-measurement`: per-cycle ZXV-driven EMA of the ADE7953 PERIOD register, datasheet-correct conversion, validation, freshness tracking, and the filtered `getGridFrequency()` surface.
+- `grid-telemetry-stream`: the 500 ms wall-clock-aligned frequency+voltage sampler, its gates (NTP / report flag / freshness), queue handoff, and the dedicated batched MQTT grid topic (edge side of the cloud contract).
+
+### Modified Capabilities
+<!-- none: iot-commands and iot-device-shadows requirements are unchanged; the report flag rides existing shadow/config machinery as an implementation detail -->
+
+## Impact
+
+- Firmware: `source/src/ade7953.cpp` / `include/ade7953.h` (ISR, demux, EMA, Eq.36 fix, IRQENA/CONFIG init constants), new grid sampler task, `source/src/mqtt.cpp` (new topic + batching), config surface for the report flag.
+- Existing behavior shift: `getGridFrequency()` moves ~11 mHz lower (bias fix) and becomes low-noise filtered - visible to REST/Modbus/HA/shadow consumers, imperceptible in practice.
+- Metering path: interrupt demux touched - guard semantics preserved-or-strengthened; energy reads, linecyc timing, and CYCEND handling functionally unchanged (datasheet-confirmed ZX_EDGE does not affect linecyc/energy accumulation).
+- Cross-repo contract (energyme-infra, out of scope here): topic name, payload schema, report-flag mechanism; ingestion + IoT Core policy changes handled in the infra repo (handoff brief in `infra-handoff.md`).
+- No new hardware, no NTP cadence change, no platform/partition changes.

--- a/openspec/changes/grid-telemetry-edge/specs/grid-frequency-measurement/spec.md
+++ b/openspec/changes/grid-telemetry-edge/specs/grid-frequency-measurement/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Interrupt demux services every set status bit
+The ADE7953 task SHALL read `RSTIRQSTATA` exactly once per wake and SHALL service every enabled interrupt bit set in that single snapshot (ZXV, CYCEND, RESET, CRC) with independent checks, never returning after the first match. The task SHALL NOT re-read the status register within the same wake to test further bits.
+
+#### Scenario: ZXV and CYCEND co-pending in one wake
+- **WHEN** the task wakes and the status snapshot has both ZXV and CYCEND set
+- **THEN** the PERIOD read/EMA update and the full CYCEND energy handling both execute in that wake, with no energy reading lost
+
+#### Scenario: No drain loop on continuous ZXV
+- **WHEN** a new ZXV asserts after the status read-and-clear
+- **THEN** it raises a new IRQ edge and is handled on the next wake, not by re-reading status in the current wake
+
+### Requirement: ISR is pure and energy guard re-arms only on CYCEND
+The ISR SHALL only give the wake semaphore and increment counters. The `_interruptHandledChannelA/B` double-read guard flags SHALL be cleared in the task, and only when the CYCEND bit is set in the status snapshot.
+
+#### Scenario: ZXV does not re-arm the energy guard
+- **WHEN** ZXV interrupts fire after a linecyc's energy registers have been read (guard flags set true)
+- **THEN** the guard flags remain true until the next genuine CYCEND, and any duplicate CYCEND processing within the same linecyc window is refused
+
+### Requirement: Per-cycle EMA of the PERIOD register
+On each ZXV the device SHALL read PERIOD, validate the equivalent frequency against the 45-65 Hz range, and update a Q24.8 fixed-point EMA with alpha = 1/8 (arithmetic shift, no float/divide on the hot path). Out-of-range readings SHALL be discarded without touching the EMA. The EMA SHALL be seeded by the first in-range reading, never zero. Each accepted update SHALL increment a monotonic update counter.
+
+#### Scenario: Out-of-range PERIOD is rejected
+- **WHEN** a PERIOD read converts to a frequency outside 45-65 Hz
+- **THEN** the EMA state and update counter are unchanged
+
+#### Scenario: First valid read seeds the EMA
+- **WHEN** the first in-range PERIOD arrives after boot
+- **THEN** the EMA state equals that reading (no ramp from zero) and the update counter increments
+
+### Requirement: Datasheet-correct frequency conversion everywhere
+All PERIOD-to-frequency conversions SHALL use `f = 223750 / (PERIOD + 1)` (ADE7953 datasheet Eq. 36), including the raw `_readGridFrequency()` path and the EMA readout.
+
+#### Scenario: Nominal 50 Hz register value
+- **WHEN** PERIOD reads 4474
+- **THEN** the converted frequency is 223750/4475 = 50.000 Hz (not 223750/4474 ≈ 50.011 Hz)
+
+### Requirement: getGridFrequency returns the filtered value
+`getGridFrequency()` SHALL return the EMA-filtered frequency for all consumers (REST, Modbus, Home Assistant, shadow, issue registry). The bootstrap 50/60 Hz detection (`_updateSampleTime`) SHALL keep using the direct raw register read so it works before the EMA seeds.
+
+#### Scenario: Consumers get the filtered value
+- **WHEN** any consumer calls `getGridFrequency()` after the EMA is seeded
+- **THEN** it receives the EMA value converted at readout, not a raw single-cycle read
+
+#### Scenario: Bootstrap before EMA seed
+- **WHEN** `_updateSampleTime()` runs before any ZXV has seeded the EMA
+- **THEN** it still obtains a usable frequency from the direct raw read
+
+### Requirement: Metering path is unaffected by ZXV
+Enabling ZXV (IRQENA bit 15) and positive-edge-only ZX events (CONFIG ZX_EDGE = 10b) SHALL NOT change linecyc accumulation, energy register handling, or CYCEND timing. CYCEND handling SHALL never be skipped or degraded by ZXV processing.
+
+#### Scenario: Meter heartbeat under ZXV load
+- **WHEN** ZXV runs continuously at line rate (~50 Hz)
+- **THEN** the meter task heartbeat and energy readings show no measurable degradation versus pre-change behavior

--- a/openspec/changes/grid-telemetry-edge/specs/grid-telemetry-stream/spec.md
+++ b/openspec/changes/grid-telemetry-edge/specs/grid-telemetry-stream/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: 500 ms sampler aligned to absolute wall-clock boundaries
+A dedicated sampler task SHALL emit at most one grid point per absolute half-second boundary (.000/.500), deriving each sleep from the current wall clock (`delay = 500 - (now % 500)`, with a minimum-sleep guard that skips to the next boundary). Each emitted point SHALL be timestamped with the true `getUnixTimeMilliseconds()` read at emission time, never the nominal boundary.
+
+#### Scenario: Alignment after NTP step
+- **WHEN** NTP steps the wall clock between ticks
+- **THEN** the next iteration computes its delay from the corrected clock and lands on the new absolute boundary without any re-phasing logic
+
+#### Scenario: Honest timestamps
+- **WHEN** a tick fires at 12:00:00.503
+- **THEN** the point carries 12:00:00.503, not 12:00:00.500
+
+### Requirement: Emission gates with honest gaps
+Each tick SHALL pass all gates before emitting, in order: (1) time is NTP-synced, (2) the grid report flag is enabled, (3) the EMA update counter has advanced since the last emission. A failed gate SHALL skip the tick entirely, producing a timestamp gap - the device SHALL never emit stale, repeated, or fabricated points.
+
+#### Scenario: Dead line stops emission
+- **WHEN** the voltage line is dead and no ZXV updates the EMA
+- **THEN** the update counter does not advance and no points are emitted until real zero crossings resume
+
+#### Scenario: Unsynced clock stops emission
+- **WHEN** the device has not (yet) synchronized time via NTP
+- **THEN** no grid points are emitted
+
+### Requirement: Grid point content
+Each point SHALL contain `{timestamp_ms (uint64), frequency (float), voltage (float)}` where frequency is the EMA readout and voltage is the cached channel-0 RMS value (refreshed each CYCEND). The sampler SHALL perform RAM-only work: no SPI, no flash access, no JSON serialization.
+
+#### Scenario: Sampler stays off the SPI bus
+- **WHEN** the sampler builds a point
+- **THEN** it reads only in-RAM state (EMA, cached voltage, wall clock) and enqueues the struct
+
+### Requirement: Dedicated batched grid topic
+Grid points SHALL be published on a dedicated Basic Ingest MQTT topic (`grid`, via its own IoT rule), separate from the meter payload, as batched sorted JSON arrays `{"points": [{"t", "f", "v"}, ...]}` on the existing publish cadence. The meter payload SHALL be unchanged by this capability.
+
+#### Scenario: Batch publish
+- **WHEN** the publish cadence fires with N queued points
+- **THEN** one message with a sorted array of N points is published on the grid topic and the queue is drained
+
+#### Scenario: Queue overflow drops oldest
+- **WHEN** the grid queue is full (e.g. prolonged MQTT outage)
+- **THEN** the oldest points are dropped in favor of new ones
+
+### Requirement: Cloud-controlled report flag
+A persisted boolean `send_grid_data` (default off) SHALL gate grid point emission. It SHALL be settable from the cloud via the existing writable `system` shadow mechanism and SHALL survive reboot. The flag SHALL NOT stop the EMA computation itself - local frequency consumers work regardless.
+
+#### Scenario: Cloud enables reporting
+- **WHEN** the cloud sets `send_grid_data: true` via the system shadow delta
+- **THEN** the device persists it, reports it in the shadow, and starts emitting grid points at the next boundary that passes all gates
+
+#### Scenario: Reporting off keeps local frequency alive
+- **WHEN** `send_grid_data` is false
+- **THEN** no grid points are emitted, while `getGridFrequency()` keeps returning the live filtered value

--- a/openspec/changes/grid-telemetry-edge/specs/grid-telemetry-stream/spec.md
+++ b/openspec/changes/grid-telemetry-edge/specs/grid-telemetry-stream/spec.md
@@ -30,7 +30,7 @@ Each point SHALL contain `{timestamp_ms (uint64), frequency (float), voltage (fl
 - **THEN** it reads only in-RAM state (EMA, cached voltage, wall clock) and enqueues the struct
 
 ### Requirement: Dedicated batched grid topic
-Grid points SHALL be published on a dedicated Basic Ingest MQTT topic (`grid`, via its own IoT rule), separate from the meter payload, as batched sorted JSON arrays `{"points": [{"t", "f", "v"}, ...]}` on the existing publish cadence. The meter payload SHALL be unchanged by this capability.
+Grid points SHALL be published on a dedicated Basic Ingest MQTT topic (`grid`, via its own IoT rule), separate from the meter payload, as a batched sorted bare JSON array of positional triplets `[[t_unix_ms, frequency, voltage], ...]` (frequency serialized at 4 decimals, voltage at 1 decimal) on the existing publish cadence. The meter payload SHALL be unchanged by this capability.
 
 #### Scenario: Batch publish
 - **WHEN** the publish cadence fires with N queued points

--- a/openspec/changes/grid-telemetry-edge/tasks.md
+++ b/openspec/changes/grid-telemetry-edge/tasks.md
@@ -5,9 +5,9 @@
 
 ## 2. Pure-logic EMA (host-testable first)
 
-- [ ] 2.1 Add `lib/` pure module: Q24.8 EMA update (alpha=1/8 shift form), seed-on-first-valid, 45-65 Hz range validation hook, monotonic update counter, Eq.36 readout conversion
-- [ ] 2.2 Unity tests in `test/` (WSL `pio test -e native`): seed behavior, out-of-range rejection, convergence to a dithering input's mean, sub-LSB resolution retention, counter monotonicity
-- [ ] 2.3 Commit `feat(lib): grid frequency EMA pure logic + unit tests`
+- [x] 2.1 Add `lib/` pure module: Q24.8 EMA update (alpha=1/8 shift form), seed-on-first-valid, 45-65 Hz range validation hook, monotonic update counter, Eq.36 readout conversion
+- [x] 2.2 Unity tests in `test/` (WSL `pio test -e native`): seed behavior, out-of-range rejection, convergence to a dithering input's mean, sub-LSB resolution retention, counter monotonicity
+- [x] 2.3 Commit `feat(lib): grid frequency EMA pure logic + unit tests`
 
 ## 3. Interrupt demux rework (metering-critical)
 

--- a/openspec/changes/grid-telemetry-edge/tasks.md
+++ b/openspec/changes/grid-telemetry-edge/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Accuracy fix (independent, lands first)
 
 - [x] 1.1 Apply Eq.36 `+1` to `_readGridFrequency()` and any other PERIOD-to-Hz conversion; adjust `GRID_FREQUENCY_CONVERSION_FACTOR` usage comments
-- [ ] 1.2 Verify on device (.174, UDP logs): reported frequency drops ~11 mHz, still validates; commit `fix(ade7953): apply datasheet eq.36 +1 to period-to-frequency conversion`
+- [x] 1.2 Verify on device (.174, UDP logs): reported frequency drops ~11 mHz, still validates; commit `fix(ade7953): apply datasheet eq.36 +1 to period-to-frequency conversion`
 
 ## 2. Pure-logic EMA (host-testable first)
 
@@ -11,11 +11,11 @@
 
 ## 3. Interrupt demux rework (metering-critical)
 
-- [ ] 3.1 Make ISR pure: remove `_interruptHandledChannelA/B` clearing from `_isrHandler()`; keep semaphore give + counters; add separate ZXV statistics counter
-- [ ] 3.2 Rework `_handleInterrupt()`: single `RSTIRQSTATA` snapshot, independent `if` per bit (ZXV -> CYCEND -> RESET -> CRC), guard flags cleared inside the CYCEND branch only; remove the single-type enum dispatch
-- [ ] 3.3 Add `_handleZxvInterrupt()`: PERIOD read -> lib EMA update (validated); wire `getGridFrequency()` to the EMA readout, keep `_updateSampleTime()` on the raw read
-- [ ] 3.4 Extend `DEFAULT_IRQENA_REGISTER` (bit 15 ZXV) and `DEFAULT_CONFIG_REGISTER` (ZX_EDGE=10b, bit 13)
-- [ ] 3.5 Bench test (.174 + UDP logs, listener started BEFORE flashing): meter heartbeat unchanged, energy values sane, ZXV counter ~50/s, no scheduler starvation, no double-read guard trips; commit demux + EMA wiring as separate commits
+- [x] 3.1 Make ISR pure: remove `_interruptHandledChannelA/B` clearing from `_isrHandler()`; keep semaphore give + counters; add separate ZXV statistics counter
+- [x] 3.2 Rework `_handleInterrupt()`: single `RSTIRQSTATA` snapshot, independent `if` per bit (ZXV -> CYCEND -> RESET -> CRC), guard flags cleared inside the CYCEND branch only; remove the single-type enum dispatch
+- [x] 3.3 Add `_handleZxvInterrupt()`: PERIOD read -> lib EMA update (validated); wire `getGridFrequency()` to the EMA readout, keep `_updateSampleTime()` on the raw read
+- [x] 3.4 Extend `DEFAULT_IRQENA_REGISTER` (bit 15 ZXV) and `DEFAULT_CONFIG_REGISTER` (ZX_EDGE=10b, bit 13)
+- [x] 3.5 Bench test (.174 + UDP logs, listener started BEFORE flashing): meter heartbeat unchanged, energy values sane, ZXV counter ~50/s, no scheduler starvation, no double-read guard trips; commit demux + EMA wiring as separate commits
 
 ## 4. Grid sampler task
 

--- a/openspec/changes/grid-telemetry-edge/tasks.md
+++ b/openspec/changes/grid-telemetry-edge/tasks.md
@@ -19,20 +19,20 @@
 
 ## 4. Grid sampler task
 
-- [ ] 4.1 New sampler task (PSRAM stack): boundary-derived delay loop (`500 - now%500`, <20 ms guard), gates (NTP sync -> `send_grid_data` -> update-counter freshness), builds `{t,f,v}` with cached `_meterValues[0].voltage`, `xQueueSend` no-block
-- [ ] 4.2 Graceful shutdown via task notification, consistent with existing task patterns
+- [x] 4.1 New sampler task (PSRAM stack): boundary-derived delay loop (`500 - now%500`, <20 ms guard), gates (NTP sync -> `send_grid_data` -> update-counter freshness), builds `{t,f,v}` with cached `_meterValues[0].voltage`, `xQueueSend` no-block
+- [x] 4.2 Graceful shutdown via task notification, consistent with existing task patterns
 - [ ] 4.3 Bench test: points land within a few ms of .000/.500, gaps appear when flag off / line events; commit `feat(grid): 500ms wall-clock-aligned grid sampler task`
 
 ## 5. Report flag
 
-- [ ] 5.1 Add `send_grid_data` (NVS-persisted, default off) mirroring `send_power_data`: getter/setter, preferences load/save
-- [ ] 5.2 Expose in `system` shadow (reported + writable delta handling)
+- [x] 5.1 Add `send_grid_data` (NVS-persisted, default off) mirroring `send_power_data`: getter/setter, preferences load/save
+- [x] 5.2 Expose in `system` shadow (reported + writable delta handling)
 - [ ] 5.3 Bench test flag flip via shadow (cloud -> device -> persisted across reboot); commit `feat(mqtt): cloud-settable send_grid_data flag`
 
 ## 6. Grid topic + publish path
 
-- [ ] 6.1 Add `MQTT_TOPIC_GRID "grid"` + `AWS_IOT_CORE_RULE_GRID` Basic Ingest topic construction (name synced with infra handoff)
-- [ ] 6.2 Grid queue (128 x 16 B, drop-oldest on overflow) + publish-cadence drain into sorted bare-array JSON `[[t,f,v],...]` (f 4-dec, v 1-dec; SpiRamAllocator, snprintf conventions)
+- [x] 6.1 Add `MQTT_TOPIC_GRID "grid"` + `AWS_IOT_CORE_RULE_GRID` Basic Ingest topic construction (name synced with infra handoff)
+- [x] 6.2 Grid queue (128 x 16 B, drop-oldest on overflow) + publish-cadence drain into sorted bare-array JSON `[[t,f,v],...]` (f 4-dec, v 1-dec; SpiRamAllocator, snprintf conventions)
 - [ ] 6.3 Bench e2e (.174): enable flag, verify batched arrays arrive on the grid topic via MQTT test client, meter payload byte-identical to before; commit `feat(mqtt): dedicated batched grid telemetry topic`
 
 ## 7. Verification + handoff

--- a/openspec/changes/grid-telemetry-edge/tasks.md
+++ b/openspec/changes/grid-telemetry-edge/tasks.md
@@ -1,0 +1,42 @@
+## 1. Accuracy fix (independent, lands first)
+
+- [ ] 1.1 Apply Eq.36 `+1` to `_readGridFrequency()` and any other PERIOD-to-Hz conversion; adjust `GRID_FREQUENCY_CONVERSION_FACTOR` usage comments
+- [ ] 1.2 Verify on device (.174, UDP logs): reported frequency drops ~11 mHz, still validates; commit `fix(ade7953): apply datasheet eq.36 +1 to period-to-frequency conversion`
+
+## 2. Pure-logic EMA (host-testable first)
+
+- [ ] 2.1 Add `lib/` pure module: Q24.8 EMA update (alpha=1/8 shift form), seed-on-first-valid, 45-65 Hz range validation hook, monotonic update counter, Eq.36 readout conversion
+- [ ] 2.2 Unity tests in `test/` (WSL `pio test -e native`): seed behavior, out-of-range rejection, convergence to a dithering input's mean, sub-LSB resolution retention, counter monotonicity
+- [ ] 2.3 Commit `feat(lib): grid frequency EMA pure logic + unit tests`
+
+## 3. Interrupt demux rework (metering-critical)
+
+- [ ] 3.1 Make ISR pure: remove `_interruptHandledChannelA/B` clearing from `_isrHandler()`; keep semaphore give + counters; add separate ZXV statistics counter
+- [ ] 3.2 Rework `_handleInterrupt()`: single `RSTIRQSTATA` snapshot, independent `if` per bit (ZXV -> CYCEND -> RESET -> CRC), guard flags cleared inside the CYCEND branch only; remove the single-type enum dispatch
+- [ ] 3.3 Add `_handleZxvInterrupt()`: PERIOD read -> lib EMA update (validated); wire `getGridFrequency()` to the EMA readout, keep `_updateSampleTime()` on the raw read
+- [ ] 3.4 Extend `DEFAULT_IRQENA_REGISTER` (bit 15 ZXV) and `DEFAULT_CONFIG_REGISTER` (ZX_EDGE=10b, bit 13)
+- [ ] 3.5 Bench test (.174 + UDP logs, listener started BEFORE flashing): meter heartbeat unchanged, energy values sane, ZXV counter ~50/s, no scheduler starvation, no double-read guard trips; commit demux + EMA wiring as separate commits
+
+## 4. Grid sampler task
+
+- [ ] 4.1 New sampler task (PSRAM stack): boundary-derived delay loop (`500 - now%500`, <20 ms guard), gates (NTP sync -> `send_grid_data` -> update-counter freshness), builds `{t,f,v}` with cached `_meterValues[0].voltage`, `xQueueSend` no-block
+- [ ] 4.2 Graceful shutdown via task notification, consistent with existing task patterns
+- [ ] 4.3 Bench test: points land within a few ms of .000/.500, gaps appear when flag off / line events; commit `feat(grid): 500ms wall-clock-aligned grid sampler task`
+
+## 5. Report flag
+
+- [ ] 5.1 Add `send_grid_data` (NVS-persisted, default off) mirroring `send_power_data`: getter/setter, preferences load/save
+- [ ] 5.2 Expose in `system` shadow (reported + writable delta handling)
+- [ ] 5.3 Bench test flag flip via shadow (cloud -> device -> persisted across reboot); commit `feat(mqtt): cloud-settable send_grid_data flag`
+
+## 6. Grid topic + publish path
+
+- [ ] 6.1 Add `MQTT_TOPIC_GRID "grid"` + `AWS_IOT_CORE_RULE_GRID` Basic Ingest topic construction (name synced with infra handoff)
+- [ ] 6.2 Grid queue (128 x 16 B, drop-oldest on overflow) + publish-cadence drain into sorted `{"points":[{"t","f","v"},...]}` JSON (SpiRamAllocator, snprintf conventions)
+- [ ] 6.3 Bench e2e (.174): enable flag, verify batched arrays arrive on the grid topic via MQTT test client, meter payload byte-identical to before; commit `feat(mqtt): dedicated batched grid telemetry topic`
+
+## 7. Verification + handoff
+
+- [ ] 7.1 Soak test on .174 (>=1 h): heartbeats, heap, `getDebugCount()` rate, energy continuity vs. pre-change baseline
+- [ ] 7.2 Confirm `infra-handoff.md` names/schema match the shipped firmware literals; hand to energyme-infra
+- [ ] 7.3 Open PR to `development` with `Closes #157`

--- a/openspec/changes/grid-telemetry-edge/tasks.md
+++ b/openspec/changes/grid-telemetry-edge/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Accuracy fix (independent, lands first)
 
-- [ ] 1.1 Apply Eq.36 `+1` to `_readGridFrequency()` and any other PERIOD-to-Hz conversion; adjust `GRID_FREQUENCY_CONVERSION_FACTOR` usage comments
+- [x] 1.1 Apply Eq.36 `+1` to `_readGridFrequency()` and any other PERIOD-to-Hz conversion; adjust `GRID_FREQUENCY_CONVERSION_FACTOR` usage comments
 - [ ] 1.2 Verify on device (.174, UDP logs): reported frequency drops ~11 mHz, still validates; commit `fix(ade7953): apply datasheet eq.36 +1 to period-to-frequency conversion`
 
 ## 2. Pure-logic EMA (host-testable first)
@@ -32,7 +32,7 @@
 ## 6. Grid topic + publish path
 
 - [ ] 6.1 Add `MQTT_TOPIC_GRID "grid"` + `AWS_IOT_CORE_RULE_GRID` Basic Ingest topic construction (name synced with infra handoff)
-- [ ] 6.2 Grid queue (128 x 16 B, drop-oldest on overflow) + publish-cadence drain into sorted `{"points":[{"t","f","v"},...]}` JSON (SpiRamAllocator, snprintf conventions)
+- [ ] 6.2 Grid queue (128 x 16 B, drop-oldest on overflow) + publish-cadence drain into sorted bare-array JSON `[[t,f,v],...]` (f 4-dec, v 1-dec; SpiRamAllocator, snprintf conventions)
 - [ ] 6.3 Bench e2e (.174): enable flag, verify batched arrays arrive on the grid topic via MQTT test client, meter payload byte-identical to before; commit `feat(mqtt): dedicated batched grid telemetry topic`
 
 ## 7. Verification + handoff

--- a/source/html/info.html
+++ b/source/html/info.html
@@ -588,11 +588,22 @@
                         <span class="info-tooltip">
                             <button class="info-tooltip-icon" onclick="toggleTooltip(this, event)" aria-label="More info about handled interrupts">ⓘ</button>
                             <div class="info-tooltip-popover" role="tooltip">
-                                Interrupts that were successfully read before the next one arrived. Should equal Total Interrupts. A gap means the ESP32S3 was too busy and missed readings.
+                                Line-cycle (CYCEND) interrupts serviced for meter readings. Lower than Total Interrupts, which also counts the per-cycle zero-crossing (ZX) interrupts used for grid frequency.
                             </div>
                         </span>
                     </span>
                     <span class="info-value" id="ade7953HandledInterrupts">Loading...</span>
+                </div>
+                <div class="info-item">
+                    <span class="info-label"><span class="emoji">🌊</span>ZX Interrupts
+                        <span class="info-tooltip">
+                            <button class="info-tooltip-icon" onclick="toggleTooltip(this, event)" aria-label="More info about zx interrupts">ⓘ</button>
+                            <div class="info-tooltip-popover" role="tooltip">
+                                Voltage zero-crossing interrupts, one per line cycle, driving the grid frequency measurement.
+                            </div>
+                        </span>
+                    </span>
+                    <span class="info-value" id="ade7953ZxInterrupts">Loading...</span>
                 </div>
                 <div class="info-item">
                     <span class="info-label"><span class="emoji">📈</span>Successful Readings
@@ -830,6 +841,7 @@
             // ADE7953 Statistics
             document.getElementById('ade7953TotalInterrupts').textContent = formatNumber(stats.ade7953.totalInterrupts);
             document.getElementById('ade7953HandledInterrupts').textContent = formatNumber(stats.ade7953.totalHandledInterrupts);
+            document.getElementById('ade7953ZxInterrupts').textContent = formatNumber(stats.ade7953.zxInterrupts);
             document.getElementById('ade7953Readings').textContent = formatNumber(stats.ade7953.readingCount);
             
             const ade7953Failures = stats.ade7953.readingCountFailure;

--- a/source/html/info.html
+++ b/source/html/info.html
@@ -606,6 +606,28 @@
                     <span class="info-value" id="ade7953ZxInterrupts">Loading...</span>
                 </div>
                 <div class="info-item">
+                    <span class="info-label"><span class="emoji">🔁</span>Service Passes
+                        <span class="info-tooltip">
+                            <button class="info-tooltip-icon" onclick="toggleTooltip(this, event)" aria-label="More info about service passes">ⓘ</button>
+                            <div class="info-tooltip-popover" role="tooltip">
+                                Interrupt status snapshots serviced. Total Interrupts minus this is how many ISR wakeups were coalesced into another pass (expected under load; the status snapshot covers every pending cause either way).
+                            </div>
+                        </span>
+                    </span>
+                    <span class="info-value" id="ade7953ServicePasses">Loading...</span>
+                </div>
+                <div class="info-item">
+                    <span class="info-label"><span class="emoji">❓</span>Unhandled Interrupts
+                        <span class="info-tooltip">
+                            <button class="info-tooltip-icon" onclick="toggleTooltip(this, event)" aria-label="More info about unhandled interrupts">ⓘ</button>
+                            <div class="info-tooltip-popover" role="tooltip">
+                                Interrupt status snapshots with none of the known bits (ZX, line-cycle end, reset, CRC change) set. Should stay at zero; a non-zero count means the chip raised a cause the firmware doesn't recognize.
+                            </div>
+                        </span>
+                    </span>
+                    <span class="info-value" id="ade7953UnhandledInterrupts">Loading...</span>
+                </div>
+                <div class="info-item">
                     <span class="info-label"><span class="emoji">📈</span>Successful Readings
                         <span class="info-tooltip">
                             <button class="info-tooltip-icon" onclick="toggleTooltip(this, event)" aria-label="More info about successful readings">ⓘ</button>
@@ -646,6 +668,28 @@
                         </span>
                     </span>
                     <span class="info-value" id="customMqttMessages">Loading...</span>
+                </div>
+                <div class="info-item">
+                    <span class="info-label"><span class="emoji">📉</span>Meter Points Dropped
+                        <span class="info-tooltip">
+                            <button class="info-tooltip-icon" onclick="toggleTooltip(this, event)" aria-label="More info about meter points dropped">ⓘ</button>
+                            <div class="info-tooltip-popover" role="tooltip">
+                                Meter readings evicted from the cloud publish queue because it was full. The oldest queued point is dropped to make room for the newest. A non-zero count means the device is producing readings faster than they can be published.
+                            </div>
+                        </span>
+                    </span>
+                    <span class="info-value" id="mqttMeterPointsDropped">Loading...</span>
+                </div>
+                <div class="info-item">
+                    <span class="info-label"><span class="emoji">📉</span>Grid Points Dropped
+                        <span class="info-tooltip">
+                            <button class="info-tooltip-icon" onclick="toggleTooltip(this, event)" aria-label="More info about grid points dropped">ⓘ</button>
+                            <div class="info-tooltip-popover" role="tooltip">
+                                Grid frequency/voltage points evicted from the cloud publish queue because it was full. The oldest queued point is dropped to make room for the newest.
+                            </div>
+                        </span>
+                    </span>
+                    <span class="info-value" id="mqttGridPointsDropped">Loading...</span>
                 </div>
                 <div class="info-item">
                     <span class="info-label"><span class="emoji">🌐</span>Web Requests
@@ -842,15 +886,32 @@
             document.getElementById('ade7953TotalInterrupts').textContent = formatNumber(stats.ade7953.totalInterrupts);
             document.getElementById('ade7953HandledInterrupts').textContent = formatNumber(stats.ade7953.totalHandledInterrupts);
             document.getElementById('ade7953ZxInterrupts').textContent = formatNumber(stats.ade7953.zxInterrupts);
+            document.getElementById('ade7953ServicePasses').textContent = formatNumber(stats.ade7953.servicePasses);
             document.getElementById('ade7953Readings').textContent = formatNumber(stats.ade7953.readingCount);
-            
+
             const ade7953Failures = stats.ade7953.readingCountFailure;
             const ade7953FailureElement = document.getElementById('ade7953ReadingFailures');
             ade7953FailureElement.textContent = formatNumber(ade7953Failures);
             ade7953FailureElement.style.color = ade7953Failures > 0 ? '#f44336' : '#4caf50';
 
+            const ade7953Unhandled = stats.ade7953.unhandledInterrupts;
+            const ade7953UnhandledElement = document.getElementById('ade7953UnhandledInterrupts');
+            ade7953UnhandledElement.textContent = formatNumber(ade7953Unhandled);
+            ade7953UnhandledElement.style.color = ade7953Unhandled > 0 ? '#f44336' : '#4caf50';
+
             // Communication Statistics
             document.getElementById('customMqttMessages').textContent = `${formatNumber(stats.customMqtt.messagesPublished)} (${stats.customMqtt.messagesPublishedError} errors)`;
+
+            const meterPointsDropped = stats.mqtt.meterPointsDropped;
+            const meterPointsDroppedElement = document.getElementById('mqttMeterPointsDropped');
+            meterPointsDroppedElement.textContent = formatNumber(meterPointsDropped);
+            meterPointsDroppedElement.style.color = meterPointsDropped > 0 ? '#f44336' : '#4caf50';
+
+            const gridPointsDropped = stats.mqtt.gridPointsDropped;
+            const gridPointsDroppedElement = document.getElementById('mqttGridPointsDropped');
+            gridPointsDroppedElement.textContent = formatNumber(gridPointsDropped);
+            gridPointsDroppedElement.style.color = gridPointsDropped > 0 ? '#f44336' : '#4caf50';
+
             document.getElementById('webServerRequests').textContent = `${formatNumber(stats.webServer.requests)} (${stats.webServer.requestsError} errors)`;
             document.getElementById('influxdbUploads').textContent = `${formatNumber(stats.influxdb.uploadCount)} (${stats.influxdb.uploadCountError} errors)`;
             document.getElementById('modbusRequests').textContent = `${formatNumber(stats.modbus.requests)} (${stats.modbus.requestsError} errors)`;

--- a/source/html/waveform.html
+++ b/source/html/waveform.html
@@ -211,13 +211,9 @@
             color: #c82333;
         }
 
-        /* Constrain main content width and center */
-        #tabContentContainer .section-box {
-            box-sizing: border-box;
-            width: 100%;
-            max-width: 1100px;    /* limit page width so stats and chart get real space */
-            margin: auto auto;
-            padding: 12px;
+        /* Sections inside the tab container lay out exactly like direct body sections */
+        #tabContentContainer {
+            display: contents;
         }
 
         /* Chart wrapper with fixed height to prevent runaway growth */
@@ -261,6 +257,43 @@
         </div>
     </section>
 
+    <section class="section-box">
+        <h2>Grid Frequency</h2>
+        <div class="control-panel">
+            <div class="control-row">
+                <span class="control-label">Live (500 ms):</span>
+                <button id="gridFreqToggle" class="buttonSecondary" onclick="toggleGridFreqPolling()">⏸ Pause</button>
+            </div>
+        </div>
+
+        <div style="height: 15px;"></div>
+
+        <div class="chart-wrapper">
+            <canvas id="gridFrequencyChart"></canvas>
+        </div>
+
+        <div style="height: 15px;"></div>
+
+        <div class="stats-panel">
+            <div class="stat-item">
+                <span class="stat-label">Current</span>
+                <span id="gridFreqCurrent" class="stat-value">-</span>
+            </div>
+            <div class="stat-item">
+                <span class="stat-label">Min (window)</span>
+                <span id="gridFreqMin" class="stat-value">-</span>
+            </div>
+            <div class="stat-item">
+                <span class="stat-label">Max (window)</span>
+                <span id="gridFreqMax" class="stat-value">-</span>
+            </div>
+            <div class="stat-item">
+                <span class="stat-label">Window</span>
+                <span id="gridFreqWindow" class="stat-value">-</span>
+            </div>
+        </div>
+    </section>
+
     <!-- Dynamic tab content will be inserted here -->
     <div id="tabContentContainer"></div>
 
@@ -274,14 +307,135 @@
 
         // Initialize on page load
         document.addEventListener('DOMContentLoaded', async () => {
+            initGridFrequencyChart();
+            startGridFreqPolling();
+
             await loadChannels();
             const status = await refreshStatus();
-            
+
             // If status is complete on page load, auto-fetch the data
             if (status === 'complete') {
                 await fetchWaveformData();
             }
         });
+
+        // === Grid frequency live chart ===
+        const GRID_FREQ_POLL_MS = 500;
+        const GRID_FREQ_MAX_POINTS = 240; // 2 minutes at 500 ms
+        let gridFrequencyChart = null;
+        let gridFreqTimer = null;
+        let gridFreqRunning = false;
+        let gridFreqGeneration = 0; // invalidates stale poll chains across pause/resume
+        const gridFreqLabels = [];
+        const gridFreqValues = [];
+
+        function initGridFrequencyChart() {
+            const ctx = document.getElementById('gridFrequencyChart').getContext('2d');
+            gridFrequencyChart = new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: gridFreqLabels,
+                    datasets: [{
+                        label: 'Grid Frequency (Hz)',
+                        data: gridFreqValues,
+                        borderColor: 'rgb(54, 162, 235)',
+                        backgroundColor: 'rgba(54, 162, 235, 0.1)',
+                        borderWidth: 2,
+                        pointRadius: 0,
+                        tension: 0.2,
+                        fill: true
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    animation: false,
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: {
+                            mode: 'index',
+                            intersect: false,
+                            callbacks: {
+                                label: (context) => `${context.parsed.y.toFixed(4)} Hz`
+                            }
+                        }
+                    },
+                    scales: {
+                        x: {
+                            title: { display: true, text: 'Time' },
+                            ticks: { maxTicksLimit: 8, maxRotation: 0, autoSkip: true }
+                        },
+                        y: {
+                            title: { display: true, text: 'Frequency (Hz)' },
+                            grace: '25%',
+                            ticks: { callback: (value) => Number(value).toFixed(3) }
+                        }
+                    },
+                    interaction: { mode: 'index', intersect: false }
+                }
+            });
+        }
+
+        // Self-rescheduling loop: the next request is only scheduled after the
+        // previous one completes, so at most one request is in flight.
+        async function pollGridFrequency() {
+            const generation = gridFreqGeneration;
+            const started = Date.now();
+            try {
+                const data = await api.get('ade7953/grid-frequency');
+                if (data && typeof data.gridFrequency === 'number' && data.gridFrequency > 0) {
+                    addGridFrequencyPoint(started, data.gridFrequency);
+                }
+            } catch (error) {
+                console.error('Grid frequency poll failed:', error);
+            }
+            if (!gridFreqRunning || generation !== gridFreqGeneration) return;
+            const elapsed = Date.now() - started;
+            gridFreqTimer = setTimeout(pollGridFrequency, Math.max(0, GRID_FREQ_POLL_MS - elapsed));
+        }
+
+        function addGridFrequencyPoint(timestampMs, frequency) {
+            const date = new Date(timestampMs);
+            const label = date.toLocaleTimeString('en-GB') + '.' + Math.floor(date.getMilliseconds() / 100);
+            gridFreqLabels.push(label);
+            gridFreqValues.push(frequency);
+            while (gridFreqValues.length > GRID_FREQ_MAX_POINTS) {
+                gridFreqLabels.shift();
+                gridFreqValues.shift();
+            }
+            gridFrequencyChart.update('none');
+
+            const windowSeconds = (gridFreqValues.length * GRID_FREQ_POLL_MS) / 1000;
+            document.getElementById('gridFreqCurrent').textContent = `${frequency.toFixed(4)} Hz`;
+            document.getElementById('gridFreqMin').textContent = `${Math.min(...gridFreqValues).toFixed(4)} Hz`;
+            document.getElementById('gridFreqMax').textContent = `${Math.max(...gridFreqValues).toFixed(4)} Hz`;
+            document.getElementById('gridFreqWindow').textContent = `${windowSeconds.toFixed(0)} s`;
+        }
+
+        function startGridFreqPolling() {
+            if (gridFreqRunning) return;
+            gridFreqRunning = true;
+            gridFreqGeneration++;
+            document.getElementById('gridFreqToggle').textContent = '⏸ Pause';
+            pollGridFrequency();
+        }
+
+        function stopGridFreqPolling() {
+            gridFreqRunning = false;
+            if (gridFreqTimer) {
+                clearTimeout(gridFreqTimer);
+                gridFreqTimer = null;
+            }
+            document.getElementById('gridFreqToggle').textContent = '▶ Resume';
+        }
+
+        function toggleGridFreqPolling() {
+            if (gridFreqRunning) {
+                stopGridFreqPolling();
+            } else {
+                startGridFreqPolling();
+            }
+        }
 
         /**
          * Load available channels from API and create tabs
@@ -553,8 +707,6 @@
                         <canvas id="waveformChart"></canvas>
                     </div>
                 </section>
-
-                <div style="height: 20px;"></div>
 
                 <section class="section-box">
                     <h2>Waveform Statistics</h2>
@@ -833,6 +985,7 @@
         // Cleanup on page unload
         window.addEventListener('beforeunload', () => {
             stopStatusPolling();
+            stopGridFreqPolling();
         });
     </script>
 </body>

--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -53,7 +53,7 @@
 #define CLEAR_ALL_CHANNELS_SENTINEL 0xFE
 
 #define ADE7953_GRID_SAMPLER_TASK_NAME "grid_sampler"
-#define ADE7953_GRID_SAMPLER_TASK_STACK_SIZE (3 * 1024) // RAM-only work
+#define ADE7953_GRID_SAMPLER_TASK_STACK_SIZE (6 * 1024) // Was 3 KB; too small caused a stack overflow that corrupted adjacent heap, surfacing as an unrelated heap-poisoning panic elsewhere
 #define ADE7953_GRID_SAMPLER_TASK_PRIORITY 2
 #define GRID_SAMPLE_INTERVAL_MS 500 // Samples aligned to absolute .000/.500 wall-clock boundaries
 #define GRID_SAMPLE_MIN_DELAY_MS 20 // Skip to the next boundary when too close

--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -94,8 +94,8 @@
 #define DEFAULT_DISNOLOAD_REGISTER 0 // 0x00 0b00000000 (enable all no-load detection)
 #define DEFAULT_LCYCMODE_REGISTER 0b01111111 // 0xFF 0b01111111 (enable accumulation mode for all channels, disable read with reset)
 #define DEFAULT_PGA_REGISTER 0 // PGA gain 1
-#define DEFAULT_CONFIG_REGISTER 0b1000000100001100 // Enable bit 2, bit 3 (line accumulation for PF), 8 (CRC is enabled), and 15 (keep HPF enabled, keep COMM_LOCK disabled)
-#define DEFAULT_IRQENA_REGISTER 0b001101000000000000000000 // Enable CYCEND interrupt (bit 18) and Reset (bit 20, mandatory) and CRC change (bit 21) for line cycle end detection
+#define DEFAULT_CONFIG_REGISTER 0b1010000100001100 // Enable bit 2, bit 3 (line accumulation for PF), 8 (CRC is enabled), 13:12=10b (ZX_EDGE: positive-going zero crossings only, 1 event/cycle; affects only ZX status/interrupt, not linecyc - datasheet p.43), and 15 (keep HPF enabled, keep COMM_LOCK disabled)
+#define DEFAULT_IRQENA_REGISTER 0b001101001000000000000000 // Enable ZXV (bit 15, voltage zero crossing for grid frequency), CYCEND (bit 18, line cycle end), Reset (bit 20, mandatory) and CRC change (bit 21)
 #define MINIMUM_SAMPLE_TIME 200ULL // The settling time of the ADE7953 is 200 ms, so reading faster than this makes little sense
 
 // Channel validation ranges
@@ -121,7 +121,7 @@
 // Computed once at begin(), stored as static floats in ade7953.cpp, with no per-measurement overhead.
 #define POWER_FACTOR_CONVERSION_FACTOR 0.00003052f // PF/LSB computed as 1.0f / 32768.0f (from ADE7953 datasheet). Unused but left for reference
 #define ANGLE_CONVERSION_FACTOR 0.0807f // 0.0807 °/LSB computed as 360.0f * 50.0f / 223000.0f. Unused but left for reference
-#define GRID_FREQUENCY_CONVERSION_FACTOR 223750.0f // Clock of the period measurement, in Hz. To be multiplied by the register value of 0x10E
+#define GRID_FREQUENCY_CONVERSION_FACTOR 223750.0f // Clock of the period measurement, in Hz. f = factor / (PERIOD_16 + 1) per datasheet Eq.36
 #define DEFAULT_FALLBACK_FREQUENCY 50 // Most of the world is 50 Hz
 
 // Waveform capture
@@ -301,16 +301,6 @@
 #define BIT_32 32
 
 #define INVALID_CHANNEL 255 // Invalid channel identifier, used to indicate no active channel
-
-// Enumeration for different types of ADE7953 interrupts
-enum class Ade7953InterruptType {
-  CYCEND,         // Line cycle end - normal meter reading
-  WSMP,           // Waveform sample ready - high-speed capture
-  RESET,          // Device reset detected
-  CRC_CHANGE,     // CRC register change detected
-  OTHER           // Other interrupts (SAG, etc.)
-};
-
 
 #include "phase_utils.h"  // Phase enum + PhaseUtils:: helpers (Arduino-free, host-testable)
 

--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -52,6 +52,12 @@
 #define ADE7953_HISTORY_CLEAR_TASK_PRIORITY 1
 #define CLEAR_ALL_CHANNELS_SENTINEL 0xFE
 
+#define ADE7953_GRID_SAMPLER_TASK_NAME "grid_sampler"
+#define ADE7953_GRID_SAMPLER_TASK_STACK_SIZE (3 * 1024) // RAM-only work
+#define ADE7953_GRID_SAMPLER_TASK_PRIORITY 2
+#define GRID_SAMPLE_INTERVAL_MS 500 // Samples aligned to absolute .000/.500 wall-clock boundaries
+#define GRID_SAMPLE_MIN_DELAY_MS 20 // Skip to the next boundary when too close
+
 // ENERGY_SAVING
 #define SAVE_ENERGY_INTERVAL (15 * 60 * 1000) // Time between each energy save to preferences. Do not increase the frequency to avoid wearing the flash memory. In any case, this is part of the requirement. The other part is ENERGY_SAVE_THRESHOLD 
 #define ENERGY_CSV_PREFIX "/energy"
@@ -94,8 +100,8 @@
 #define DEFAULT_DISNOLOAD_REGISTER 0 // 0x00 0b00000000 (enable all no-load detection)
 #define DEFAULT_LCYCMODE_REGISTER 0b01111111 // 0xFF 0b01111111 (enable accumulation mode for all channels, disable read with reset)
 #define DEFAULT_PGA_REGISTER 0 // PGA gain 1
-#define DEFAULT_CONFIG_REGISTER 0b1010000100001100 // Enable bit 2, bit 3 (line accumulation for PF), 8 (CRC is enabled), 13:12=10b (ZX_EDGE: positive-going zero crossings only, 1 event/cycle; affects only ZX status/interrupt, not linecyc - datasheet p.43), and 15 (keep HPF enabled, keep COMM_LOCK disabled)
-#define DEFAULT_IRQENA_REGISTER 0b001101001000000000000000 // Enable ZXV (bit 15, voltage zero crossing for grid frequency), CYCEND (bit 18, line cycle end), Reset (bit 20, mandatory) and CRC change (bit 21)
+#define DEFAULT_CONFIG_REGISTER 0b1010000100001100 // Bits 2, 3 (line accumulation for PF), 8 (CRC), 13:12=10b (ZX_EDGE: positive-going zero crossings only; does not affect linecyc), 15 (HPF enabled, COMM_LOCK disabled)
+#define DEFAULT_IRQENA_REGISTER 0b001101001000000000000000 // ZXV (bit 15, grid frequency), CYCEND (bit 18), Reset (bit 20, mandatory), CRC change (bit 21)
 #define MINIMUM_SAMPLE_TIME 200ULL // The settling time of the ADE7953 is 200 ms, so reading faster than this makes little sense
 
 // Channel validation ranges

--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -650,6 +650,7 @@ namespace Ade7953
     TaskInfo getMeterReadingTaskInfo();
     TaskInfo getEnergySaveTaskInfo();
     TaskInfo getHourlyCsvTaskInfo();
+    TaskInfo getGridSamplerTaskInfo();
 
     // Waveform capture API
     bool startWaveformCapture(uint8_t channelIndex);

--- a/source/include/awsconfig.h
+++ b/source/include/awsconfig.h
@@ -27,9 +27,11 @@ constexpr const char* AWS_IOT_CORE_ENDPOINT = "a26zjeqaj9a3xc-ats.iot.eu-west-1.
 #ifdef ENV_DEV
 constexpr const char* AWS_IOT_CORE_RULE_METER = "energyme_home_dev_rule_meter";
 constexpr const char* AWS_IOT_CORE_RULE_LOG   = "energyme_home_dev_rule_log";
+constexpr const char* AWS_IOT_CORE_RULE_GRID  = "energyme_home_dev_rule_grid";
 #else
 constexpr const char* AWS_IOT_CORE_RULE_METER = "energyme_home_prod_rule_meter";
 constexpr const char* AWS_IOT_CORE_RULE_LOG   = "energyme_home_prod_rule_log";
+constexpr const char* AWS_IOT_CORE_RULE_GRID  = "energyme_home_prod_rule_grid";
 #endif
 
 // AWS reserved topic prefixes

--- a/source/include/issueregistry.h
+++ b/source/include/issueregistry.h
@@ -19,7 +19,7 @@
 
 // Task
 #define ISSUE_REGISTRY_TASK_NAME "issue_reg_task"
-#define ISSUE_REGISTRY_TASK_STACK_SIZE (6 * 1024) // Internal RAM: the tick reads LittleFS usage (flash I/O)
+#define ISSUE_REGISTRY_TASK_STACK_SIZE (6 * 1024)
 #define ISSUE_REGISTRY_TASK_PRIORITY 1
 #define ISSUE_REGISTRY_TICK_INTERVAL (5 * 1000)
 

--- a/source/include/mqtt.h
+++ b/source/include/mqtt.h
@@ -30,6 +30,7 @@
 
 #define MQTT_LOG_QUEUE_SIZE (256 * 1024) // Generous log size (in bytes) thanks to PSRAM
 #define MQTT_METER_QUEUE_SIZE (64 * 1024) // Size in bytes to allocate to PSRAM
+#define MQTT_GRID_QUEUE_SIZE (64 * 1024) // Size in bytes to allocate to PSRAM (~34 min of 500 ms points); overflow drops oldest
 #define QUEUE_WAIT_TIMEOUT 100 // Amount of milliseconds to wait if the queue is full or busy
 
 // AWS IoT Jobs OTA constants
@@ -65,9 +66,11 @@
 
 #define DEFAULT_CLOUD_SERVICES_ENABLED false // Always off by default, and enabled only explicitly by the user
 #define DEFAULT_SEND_POWER_DATA_ENABLED true // Send all the data by default
+#define DEFAULT_SEND_GRID_DATA_ENABLED false // Off by default; the cloud enables it per device
 #define DEFAULT_MQTT_LOG_LEVEL_INT 2 // Default minimum log level for MQTT publishing (INFO = 2)
 
 #define MQTT_MAX_INTERVAL_METER_PUBLISH (60 * 1000) // The maximum interval between two meter payloads
+#define MQTT_MAX_INTERVAL_GRID_PUBLISH (60 * 1000) // Batch interval for grid points (no need for fast updates)
 #ifdef ENV_DEV
 // In dev: send system_dynamic and statistics every minute so post-mortem
 // telemetry has the resolution needed to investigate behavior.
@@ -82,6 +85,8 @@
 
 #define MQTT_LOOP_INTERVAL 100 // Interval between two MQTT loop checks
 #define MQTT_METER_ESTIMATED_PER_ENTRY 35 // Estimated size in bytes of each meter entry (unix ms, channel, active power, pf)
+#define MQTT_GRID_FREQUENCY_PAYLOAD_DECIMALS 4 // 0.1 mHz: preserves the ~0.8 mHz EMA resolution
+#define MQTT_GRID_VOLTAGE_PAYLOAD_DECIMALS 1
 #define MQTT_METER_ESTIMATED_ENERGY_VOLTAGE_OVERHEAD_BYTES 500 // Estimated overhead in bytes for energy and voltage data in the payload
 #define AWS_IOT_CORE_MQTT_PAYLOAD_MINIMUM_BILLABLE (5 * 1024) // This is the minimum billable size for AWS IoT Core, so it makes little sense to send smaller payloads
 #define AWS_IOT_CORE_MQTT_PAYLOAD_LIMIT (128 * 1024) // Limit of AWS
@@ -93,6 +98,7 @@
 #define MQTT_MAX_CONNECTION_ATTEMPTS 10 // Maximum number of connection attempts before restarting the device. High since we don't want a reboot cycle
 #define MQTT_PREFERENCES_IS_CLOUD_SERVICES_ENABLED_KEY "en_cloud"
 #define MQTT_PREFERENCES_SEND_POWER_DATA_KEY "send_power"
+#define MQTT_PREFERENCES_SEND_GRID_DATA_KEY "send_grid"
 #define MQTT_PREFERENCES_MQTT_LOG_LEVEL_KEY "log_level_int"
 #define MQTT_PREFERENCES_TRANSIENT_LOG_LEVEL_KEY "transient_log" // active transient (VERBOSE/DEBUG) level, persisted so a debug session survives a reboot; absent = none
 
@@ -100,6 +106,7 @@
 // Publish topics. system/static + channel retired (-> info + channels shadows);
 // configurable state lives in shadows, telemetry topics carry runtime data only.
 #define MQTT_TOPIC_METER "meter"
+#define MQTT_TOPIC_GRID "grid"
 #define MQTT_TOPIC_SYSTEM_DYNAMIC "system/dynamic"
 #define MQTT_TOPIC_STATISTICS "statistics"
 #define MQTT_TOPIC_CRASH "crash"
@@ -126,6 +133,7 @@
 struct PublishMqtt
 {
   bool meter;
+  bool grid;
   bool systemDynamic;
   bool statistics;
   bool crash;
@@ -133,6 +141,7 @@ struct PublishMqtt
 
   PublishMqtt() :
     meter(false), // Need to fill queue first
+    grid(false),  // Need to fill queue first
     systemDynamic(true),
     statistics(true),
     crash(false), // May not be present
@@ -156,6 +165,7 @@ namespace Mqtt
     // Public methods for pushing data to queues
     void pushLog(const LogEntry& entry);
     void pushMeter(const PayloadMeter& payload);
+    void pushGrid(const PayloadGridPoint& point);
 
     TaskInfo getMqttTaskInfo();
     TaskInfo getMqttOtaTaskInfo();
@@ -176,6 +186,8 @@ namespace Mqtt
     int  getTransientLogLevel();             // persisted transient level, or -1 if none
     bool getSendPowerData();
     void setSendPowerData(bool enabled);     // persisted
+    bool getSendGridData();
+    void setSendGridData(bool enabled);      // persisted; cloud-settable via the system shadow
 
 #ifdef ENV_DEV
     // Dev-only: inject a synthetic IoT Command execution through the real handler

--- a/source/include/structs.h
+++ b/source/include/structs.h
@@ -11,7 +11,7 @@
 struct Statistics { // This will be global and we accept the very small race condition as we only do ++ or read the value (almost atomic?)
   uint64_t ade7953TotalInterrupts;
   uint64_t ade7953TotalHandledInterrupts;
-  uint64_t ade7953ZxInterrupts; // ZXV (voltage zero-crossing) services, ~50/s - kept separate so total/handled keep their meaning
+  uint64_t ade7953ZxInterrupts; // ZXV (voltage zero-crossing) services, counted separately from CYCEND
   uint64_t ade7953ReadingCount;
   uint64_t ade7953ReadingCountFailure;
 
@@ -258,12 +258,29 @@ struct PayloadMeter
   PayloadMeter() : channel(0), unixTimeMs(0), activePower(0.0f), powerFactor(0.0f) {}
 
   PayloadMeter(
-    uint32_t channel, 
-    uint64_t unixTimeMs, 
-    float activePower, 
+    uint32_t channel,
+    uint64_t unixTimeMs,
+    float activePower,
     float powerFactor
-  ) : channel(channel), 
-      unixTimeMs(unixTimeMs), 
-      activePower(activePower), 
+  ) : channel(channel),
+      unixTimeMs(unixTimeMs),
+      activePower(activePower),
       powerFactor(powerFactor) {}
+};
+
+struct PayloadGridPoint
+{
+  uint64_t unixTimeMs; // True wall-clock read at sample time (never the nominal .000/.500 boundary)
+  float frequency;     // EMA-filtered grid frequency [Hz]
+  float voltage;       // Channel-0 RMS voltage [V]
+
+  PayloadGridPoint() : unixTimeMs(0), frequency(0.0f), voltage(0.0f) {}
+
+  PayloadGridPoint(
+    uint64_t unixTimeMs,
+    float frequency,
+    float voltage
+  ) : unixTimeMs(unixTimeMs),
+      frequency(frequency),
+      voltage(voltage) {}
 };

--- a/source/include/structs.h
+++ b/source/include/structs.h
@@ -12,6 +12,8 @@ struct Statistics { // This will be global and we accept the very small race con
   uint64_t ade7953TotalInterrupts;
   uint64_t ade7953TotalHandledInterrupts;
   uint64_t ade7953ZxInterrupts; // ZXV (voltage zero-crossing) services, counted separately from CYCEND
+  uint64_t ade7953ServicePasses; // Semaphore takes; ade7953TotalInterrupts - this = ISR wakeups coalesced into another pass
+  uint64_t ade7953UnhandledInterrupts; // Status snapshot had none of the known bits set
   uint64_t ade7953ReadingCount;
   uint64_t ade7953ReadingCountFailure;
 
@@ -19,10 +21,12 @@ struct Statistics { // This will be global and we accept the very small race con
   uint64_t mqttMessagesPublishedError;
   uint64_t mqttConnections;
   uint64_t mqttConnectionErrors;
-  
+  uint64_t mqttMeterPointsDropped; // Meter queue full; oldest point evicted to make room
+  uint64_t mqttGridPointsDropped;  // Grid queue full; oldest point evicted to make room
+
   uint64_t customMqttMessagesPublished;
   uint64_t customMqttMessagesPublishedError;
-  
+
   uint64_t modbusRequests;
   uint64_t modbusRequestsError;
   
@@ -43,10 +47,10 @@ struct Statistics { // This will be global and we accept the very small race con
   uint64_t logFatal;
   uint64_t logDropped;
 
-  Statistics() 
-    : ade7953TotalInterrupts(0), ade7953TotalHandledInterrupts(0), ade7953ZxInterrupts(0), ade7953ReadingCount(0), ade7953ReadingCountFailure(0),
-    mqttMessagesPublished(0), mqttMessagesPublishedError(0), mqttConnections(0), mqttConnectionErrors(0), 
-    customMqttMessagesPublished(0), customMqttMessagesPublishedError(0), modbusRequests(0), modbusRequestsError(0), 
+  Statistics()
+    : ade7953TotalInterrupts(0), ade7953TotalHandledInterrupts(0), ade7953ZxInterrupts(0), ade7953ServicePasses(0), ade7953UnhandledInterrupts(0), ade7953ReadingCount(0), ade7953ReadingCountFailure(0),
+    mqttMessagesPublished(0), mqttMessagesPublishedError(0), mqttConnections(0), mqttConnectionErrors(0), mqttMeterPointsDropped(0), mqttGridPointsDropped(0),
+    customMqttMessagesPublished(0), customMqttMessagesPublishedError(0), modbusRequests(0), modbusRequestsError(0),
     influxdbUploadCount(0), influxdbUploadCountError(0), wifiConnection(0), wifiConnectionError(0),
     webServerRequests(0), webServerRequestsError(0),
     logVerbose(0), logDebug(0), logInfo(0), logWarning(0), logError(0), logFatal(0), logDropped(0) {}

--- a/source/include/structs.h
+++ b/source/include/structs.h
@@ -237,6 +237,7 @@ struct SystemDynamicInfo {
     TaskInfo ade7953MeterReadingTaskInfo;
     TaskInfo ade7953EnergySaveTaskInfo;
     TaskInfo ade7953HourlyCsvTaskInfo;
+    TaskInfo ade7953GridSamplerTaskInfo;
     TaskInfo maintenanceTaskInfo;
     TaskInfo issueRegistryTaskInfo;
 

--- a/source/include/structs.h
+++ b/source/include/structs.h
@@ -11,6 +11,7 @@
 struct Statistics { // This will be global and we accept the very small race condition as we only do ++ or read the value (almost atomic?)
   uint64_t ade7953TotalInterrupts;
   uint64_t ade7953TotalHandledInterrupts;
+  uint64_t ade7953ZxInterrupts; // ZXV (voltage zero-crossing) services, ~50/s - kept separate so total/handled keep their meaning
   uint64_t ade7953ReadingCount;
   uint64_t ade7953ReadingCountFailure;
 
@@ -43,7 +44,7 @@ struct Statistics { // This will be global and we accept the very small race con
   uint64_t logDropped;
 
   Statistics() 
-    : ade7953TotalInterrupts(0), ade7953TotalHandledInterrupts(0), ade7953ReadingCount(0), ade7953ReadingCountFailure(0), 
+    : ade7953TotalInterrupts(0), ade7953TotalHandledInterrupts(0), ade7953ZxInterrupts(0), ade7953ReadingCount(0), ade7953ReadingCountFailure(0),
     mqttMessagesPublished(0), mqttMessagesPublishedError(0), mqttConnections(0), mqttConnectionErrors(0), 
     customMqttMessagesPublished(0), customMqttMessagesPublishedError(0), modbusRequests(0), modbusRequestsError(0), 
     influxdbUploadCount(0), influxdbUploadCountError(0), wifiConnection(0), wifiConnectionError(0),

--- a/source/lib/grid_frequency/grid_frequency.cpp
+++ b/source/lib/grid_frequency/grid_frequency.cpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Jibril Sharafi
+
+#include "grid_frequency.h"
+
+namespace GridFrequency {
+
+float rawFrequencyHz(const Config& cfg, int32_t periodRaw) {
+    if (periodRaw <= 0) return 0.0f;
+    return cfg.conversionFactorHz / (float(periodRaw) + 1.0f);
+}
+
+bool update(State& state, const Config& cfg, int32_t periodRaw) {
+    float frequency = rawFrequencyHz(cfg, periodRaw);
+    if (frequency < cfg.minFrequencyHz || frequency > cfg.maxFrequencyHz) return false;
+
+    int32_t xQ8 = periodRaw << 8;
+    if (!state.seeded) {
+        state.emaPeriodQ8 = xQ8;
+        state.seeded = true;
+    } else {
+        // ema += alpha * (x - ema), alpha = 1/8. The arithmetic shift keeps the
+        // low 8 fractional bits, so sub-LSB dither accumulates instead of vanishing.
+        state.emaPeriodQ8 += (xQ8 - state.emaPeriodQ8) >> 3;
+    }
+    state.updateCount++;
+    return true;
+}
+
+float frequencyHz(const State& state, const Config& cfg) {
+    if (!state.seeded) return 0.0f;
+    return cfg.conversionFactorHz / (float(state.emaPeriodQ8) / 256.0f + 1.0f);
+}
+
+} // namespace GridFrequency

--- a/source/lib/grid_frequency/grid_frequency.cpp
+++ b/source/lib/grid_frequency/grid_frequency.cpp
@@ -19,8 +19,7 @@ bool update(State& state, const Config& cfg, int32_t periodRaw) {
         state.emaPeriodQ8 = xQ8;
         state.seeded = true;
     } else {
-        // ema += alpha * (x - ema), alpha = 1/8. The arithmetic shift keeps the
-        // low 8 fractional bits, so sub-LSB dither accumulates instead of vanishing.
+        // ema += alpha * (x - ema), alpha = 1/8; the shift keeps the Q8 fraction
         state.emaPeriodQ8 += (xQ8 - state.emaPeriodQ8) >> 3;
     }
     state.updateCount++;

--- a/source/lib/grid_frequency/grid_frequency.h
+++ b/source/lib/grid_frequency/grid_frequency.h
@@ -5,25 +5,18 @@
 
 #include <cstdint>
 
-// Pure per-cycle grid frequency EMA (issue #157).
+// Pure per-cycle grid frequency EMA (issue #157). Free-standing like the other
+// lib/ modules (no Arduino/FreeRTOS/SPI/logging) so it is host-testable.
 //
-// Free-standing like the other lib/ modules: no Arduino, no FreeRTOS, no SPI,
-// no logging, no global state. The caller (src/ade7953.cpp) feeds raw PERIOD
-// register reads from the ZXV interrupt path and reads the filtered frequency
-// off the hot path; this module owns only the arithmetic, which is what lets
-// it be unit-tested on the host (see test/test_grid_frequency).
+// First-order EMA on the raw integer PERIOD register, Q24.8 fixed point,
+// alpha = 1/8 (one arithmetic shift per update, no float on the hot path).
+// A ~15-line-cycle window: the Allan-optimal averaging length for the chip's
+// single-cycle quantization dither. The Q8 fraction is what keeps sub-LSB
+// resolution alive - a plain-integer EMA would freeze on a dithering input.
 //
-// Filter: first-order EMA on the raw integer PERIOD, Q24.8 fixed point,
-// alpha = 1/8 so the update is one arithmetic shift (no multiply, divide or
-// float on the per-cycle path). At 50 Hz this is a ~15-cycle (~300 ms) window,
-// ~1.06 Hz cutoff, ~0.8 mHz noise floor - the Allan-optimal averaging length
-// for the ADE7953's ~11 mHz single-cycle quantization dither. Q8 keeps the
-// sub-LSB fraction alive through the shift; a plain-integer EMA would freeze
-// on a dithering input and lose exactly the resolution the dither provides.
-//
-// Conversion (datasheet Eq.36): f = factor / (PERIOD + 1). Applied at readout
-// only - filtering happens in the period domain, where the reciprocal's
-// nonlinearity bias is sub-uHz for the <1% period swings of a real grid.
+// Conversion (datasheet Eq.36): f = factor / (PERIOD + 1), applied at readout
+// only; filtering stays in the period domain where the reciprocal bias is
+// negligible.
 namespace GridFrequency {
 
 struct Config {

--- a/source/lib/grid_frequency/grid_frequency.h
+++ b/source/lib/grid_frequency/grid_frequency.h
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Jibril Sharafi
+
+#pragma once
+
+#include <cstdint>
+
+// Pure per-cycle grid frequency EMA (issue #157).
+//
+// Free-standing like the other lib/ modules: no Arduino, no FreeRTOS, no SPI,
+// no logging, no global state. The caller (src/ade7953.cpp) feeds raw PERIOD
+// register reads from the ZXV interrupt path and reads the filtered frequency
+// off the hot path; this module owns only the arithmetic, which is what lets
+// it be unit-tested on the host (see test/test_grid_frequency).
+//
+// Filter: first-order EMA on the raw integer PERIOD, Q24.8 fixed point,
+// alpha = 1/8 so the update is one arithmetic shift (no multiply, divide or
+// float on the per-cycle path). At 50 Hz this is a ~15-cycle (~300 ms) window,
+// ~1.06 Hz cutoff, ~0.8 mHz noise floor - the Allan-optimal averaging length
+// for the ADE7953's ~11 mHz single-cycle quantization dither. Q8 keeps the
+// sub-LSB fraction alive through the shift; a plain-integer EMA would freeze
+// on a dithering input and lose exactly the resolution the dither provides.
+//
+// Conversion (datasheet Eq.36): f = factor / (PERIOD + 1). Applied at readout
+// only - filtering happens in the period domain, where the reciprocal's
+// nonlinearity bias is sub-uHz for the <1% period swings of a real grid.
+namespace GridFrequency {
+
+struct Config {
+    float conversionFactorHz; // PERIOD measurement clock, 223.75 kHz on the ADE7953
+    float minFrequencyHz;     // validation range; reads outside it never touch the EMA
+    float maxFrequencyHz;
+};
+
+struct State {
+    int32_t emaPeriodQ8 = 0;  // filtered PERIOD * 256 (Q24.8)
+    bool seeded = false;      // first in-range read seeds the EMA (never ramps from 0)
+    uint32_t updateCount = 0; // monotonic; advances only on accepted updates (freshness signal)
+};
+
+// Single-read conversion, Eq.36. Shared by the raw path so both agree on the +1.
+// Returns 0.0f for a non-positive period.
+float rawFrequencyHz(const Config& cfg, int32_t periodRaw);
+
+// Feed one raw PERIOD read. Returns true if accepted (in range) and the EMA advanced.
+bool update(State& state, const Config& cfg, int32_t periodRaw);
+
+// Filtered frequency in Hz. Returns 0.0f until the first accepted update.
+float frequencyHz(const State& state, const Config& cfg);
+
+} // namespace GridFrequency

--- a/source/resources/swagger.yaml
+++ b/source/resources/swagger.yaml
@@ -324,6 +324,8 @@ paths:
                     type: integer
                   ade7953TotalHandledInterrupts:
                     type: integer
+                  ade7953ZxInterrupts:
+                    type: integer
                   ade7953ReadingCount:
                     type: integer
                   ade7953ReadingCountFailure:

--- a/source/resources/swagger.yaml
+++ b/source/resources/swagger.yaml
@@ -326,6 +326,12 @@ paths:
                     type: integer
                   ade7953ZxInterrupts:
                     type: integer
+                  ade7953ServicePasses:
+                    type: integer
+                    description: Semaphore takes serviced; ade7953TotalInterrupts minus this is ISR wakeups coalesced into another pass
+                  ade7953UnhandledInterrupts:
+                    type: integer
+                    description: Interrupt status snapshots with none of the known bits set
                   ade7953ReadingCount:
                     type: integer
                   ade7953ReadingCountFailure:
@@ -334,6 +340,12 @@ paths:
                     type: integer
                   mqttMessagesPublishedError:
                     type: integer
+                  mqttMeterPointsDropped:
+                    type: integer
+                    description: Meter queue was full; oldest point evicted to make room
+                  mqttGridPointsDropped:
+                    type: integer
+                    description: Grid queue was full; oldest point evicted to make room
                   customMqttMessagesPublished:
                     type: integer
                   customMqttMessagesPublishedError:

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -11,6 +11,7 @@ namespace Ade7953
     static TaskHeartbeat _meterReadingHeartbeat;
     static TaskHeartbeat _energySaveHeartbeat;
     static TaskHeartbeat _hourlyCsvHeartbeat;
+    static TaskHeartbeat _gridSamplerHeartbeat;
 
     // Static variables
     // =========================================================
@@ -36,11 +37,10 @@ namespace Ade7953
     static int8_t _polarityVoteCount[MAX_CHANNEL_COUNT] = {}; // Net consistent-sign vote accumulator for CT-reversal detection (runtime only; reset on arm/decision)
     static uint16_t _polarityConductingReads[MAX_CHANNEL_COUNT] = {}; // Conducting reads since arming - bounds a sign-oscillating channel (runtime only; reset on arm/decision)
     static bool _lastConducting[MAX_CHANNEL_COUNT] = {}; // Was the channel's most recent reading conducting (pre-clamp)? Drives the CT-detection boost so a clamped reversed load/PV still gets it (meter-task only)
-    static float _gridFrequency = 50.0f; // Pre-EMA fallback: raw linecyc read, kept updated in the channel-0 path
+    static float _gridFrequency = 50.0f; // Pre-EMA fallback, updated by the raw read in the channel-0 path
 
     // Per-cycle grid frequency EMA (issue #157), fed from the ZXV interrupt path.
-    // int32 state is written only by the meter task and read lock-free elsewhere
-    // (aligned 32-bit access is atomic on Xtensa).
+    // Written only by the meter task; read lock-free (aligned 32-bit is atomic).
     static GridFrequency::State _gridFreqEma;
     static const GridFrequency::Config _gridFreqCfg = {GRID_FREQUENCY_CONVERSION_FACTOR, VALIDATE_GRID_FREQUENCY_MIN, VALIDATE_GRID_FREQUENCY_MAX};
 
@@ -103,6 +103,9 @@ namespace Ade7953
     
     static TaskHandle_t _hourlyCsvSaveTaskHandle = NULL;
     static bool _hourlyCsvSaveTaskShouldRun = false;
+
+    static TaskHandle_t _gridSamplerTaskHandle = NULL;
+    static bool _gridSamplerTaskShouldRun = false;
 
     static SemaphoreHandle_t _historyClearMutex = NULL;
 
@@ -171,6 +174,10 @@ namespace Ade7953
     static void _startHourlyCsvSaveTask();
     static void _stopHourlyCsvSaveTask();
     static void _hourlyCsvSaveTask(void* parameter);
+
+    static void _startGridSamplerTask();
+    static void _stopGridSamplerTask();
+    static void _gridSamplerTask(void* parameter);
 
     static void _historyClearTask(void* parameter);
     static void _spawnHistoryClearTask(uint8_t channelIndex);
@@ -368,6 +375,9 @@ namespace Ade7953
 
         _startHourlyCsvSaveTask();
         LOG_DEBUG("Hourly CSV save task started");
+
+        _startGridSamplerTask();
+        LOG_DEBUG("Grid sampler task started");
 
         return true;
     }
@@ -1615,9 +1625,7 @@ namespace Ade7953
     // ==============
 
     float getGridFrequency() {
-        // Filtered EMA once seeded (~one line cycle after task start): ~0.8 mHz
-        // resolution vs the ~11 mHz single-read quantization dither. Falls back to
-        // the raw linecyc-path value until then (and if ZXV never fires).
+        // Filtered EMA once seeded; raw fallback until then (and if ZXV never fires)
         if (_gridFreqEma.seeded) return GridFrequency::frequencyHz(_gridFreqEma, _gridFreqCfg);
         return _gridFrequency;
     }
@@ -1763,6 +1771,7 @@ namespace Ade7953
         _stopMeterReadingTask();
         _stopEnergySaveTask();
         _stopHourlyCsvSaveTask();
+        _stopGridSamplerTask();
 
         // Reset failure counters during cleanup
         _failureCount = 0;
@@ -1843,26 +1852,23 @@ namespace Ade7953
 
     void _handleInterrupt(uint64_t linecycUnix)
     {
-        // The ADE7953 IRQ pin is level-active-low while the ESP32 interrupt is edge
-        // triggered, so a bit asserting while the pin is already low raises no new
-        // edge: with ZXV at line rate, co-pending bits in one wake are routine, not
-        // rare. RSTIRQSTATA is read-with-reset (one read clears ALL bits), therefore
-        // this must be a single snapshot serviced bit by bit - independent ifs, never
-        // else-if, never a second status read (it would return zeros and lose bits).
+        // The IRQ pin is level-active-low but the ESP32 interrupt is edge-triggered,
+        // so multiple bits routinely co-pend in one wake. RSTIRQSTATA clears ALL bits
+        // on read: take one snapshot and service every set bit (never else-if,
+        // never a second read).
         int32_t statusA = readRegister(RSTIRQSTATA_32, BIT_32, false);
         // No need to read for channel B (only channel A has the relevant information for use)
 
-        // ZXV first: PERIOD is transient (overwritten every cycle), the energy path is not
+        // ZXV first: PERIOD is overwritten every cycle, the energy registers are not
         if (statusA & (1 << IRQSTATA_ZXV_BIT)) {
             statistics.ade7953ZxInterrupts++;
             _handleZxvInterrupt();
         }
 
         if (statusA & (1 << IRQSTATA_CYCEND_BIT)) {
-            // Re-arm the energy double-read guard here and ONLY here: a genuine new
-            // linecyc means fresh frozen energy registers. Re-arming anywhere else
-            // (e.g. the old ISR clearing) would let a duplicate CYCEND processing
-            // read the reset-on-read energy registers twice and destroy the cycle.
+            // Re-arm the energy double-read guard ONLY on a genuine new linecyc,
+            // otherwise a duplicate CYCEND could read the reset-on-read energy
+            // registers twice and lose the cycle.
             _interruptHandledChannelA = false;
             _interruptHandledChannelB = false;
             _handleCycendInterrupt(linecycUnix);
@@ -1886,10 +1892,7 @@ namespace Ade7953
 
     void _handleZxvInterrupt()
     {
-        // One 16-bit read + integer EMA update: the entire per-cycle hot path.
-        // Validation (45-65 Hz) happens inside update(); glitch reads never touch
-        // the filter, and the update counter it advances is the freshness signal
-        // for the 500 ms grid sampler.
+        // One PERIOD read + integer EMA update; out-of-range reads are discarded inside update()
         GridFrequency::update(_gridFreqEma, _gridFreqCfg, _readPeriod());
     }
 
@@ -1907,10 +1910,8 @@ namespace Ade7953
     {
         BaseType_t xHigherPriorityTaskWoken = pdFALSE;
         statistics.ade7953TotalInterrupts++;
-        // Deliberately nothing else here: with ZXV enabled the IRQ fires every line
-        // cycle (~50/s), so any state touched here would be clobbered mid-linecyc.
-        // The energy double-read guard flags are re-armed in the task, and only on a
-        // genuine CYCEND (see _handleInterrupt).
+        // Nothing else here: with ZXV the IRQ fires every line cycle, so any state
+        // touched here would be clobbered mid-linecyc (see _handleInterrupt).
 
         // Signal the task to handle the interrupt - let the task determine the cause
         if (_ade7953InterruptSemaphore != NULL) {
@@ -2255,6 +2256,77 @@ namespace Ade7953
 
         LOG_DEBUG("ADE7953 energy save task stopping");
         _energySaveTaskHandle = NULL;
+        vTaskDelete(NULL);
+    }
+
+    void _startGridSamplerTask() {
+        if (_gridSamplerTaskHandle != NULL) {
+            LOG_DEBUG("ADE7953 grid sampler task is already running");
+            return;
+        }
+
+        LOG_DEBUG("Starting ADE7953 grid sampler task with %d bytes stack in internal RAM", ADE7953_GRID_SAMPLER_TASK_STACK_SIZE);
+
+        BaseType_t result = xTaskCreate(
+            _gridSamplerTask,
+            ADE7953_GRID_SAMPLER_TASK_NAME,
+            ADE7953_GRID_SAMPLER_TASK_STACK_SIZE,
+            nullptr,
+            ADE7953_GRID_SAMPLER_TASK_PRIORITY,
+            &_gridSamplerTaskHandle);
+
+        if (result != pdPASS) {
+            LOG_ERROR("Failed to create ADE7953 grid sampler task");
+            _gridSamplerTaskHandle = NULL;
+        }
+    }
+
+    void _stopGridSamplerTask() {
+        stopTaskGracefully(&_gridSamplerTaskHandle, "ADE7953 grid sampler task");
+    }
+
+    void _gridSamplerTask(void* parameter) {
+        LOG_DEBUG("ADE7953 grid sampler task started");
+
+        // Freshness gate: only emit if the EMA advanced since the last point
+        uint32_t lastSeenUpdateCount = 0;
+
+        _gridSamplerTaskShouldRun = true;
+        while (_gridSamplerTaskShouldRun) {
+            TASK_HEARTBEAT(_gridSamplerHeartbeat);
+
+            // Sleep to the next absolute .000/.500 wall-clock boundary, re-derived
+            // from the clock each iteration so drift never accumulates and NTP
+            // steps self-heal. Points always carry the true read time.
+            uint64_t now = CustomTime::getUnixTimeMilliseconds();
+            uint32_t delayMs = GRID_SAMPLE_INTERVAL_MS - (uint32_t)(now % GRID_SAMPLE_INTERVAL_MS);
+            if (delayMs < GRID_SAMPLE_MIN_DELAY_MS) delayMs += GRID_SAMPLE_INTERVAL_MS;
+
+            // The aligned sleep doubles as the stop-notification wait
+            if (ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(delayMs)) > 0) {
+                _gridSamplerTaskShouldRun = false;
+                break;
+            }
+
+            // Gates: a failed gate skips the tick, leaving a real timestamp gap
+            if (!Mqtt::getSendGridData()) continue;
+            if (!CustomTime::isTimeSynched()) continue;
+            uint32_t updateCount = _gridFreqEma.updateCount;
+            if (updateCount == lastSeenUpdateCount) continue; // EMA frozen (no ZXV since last emit)
+            lastSeenUpdateCount = updateCount;
+
+            // Cached channel-0 RMS voltage (at most ~_sampleTime old); aligned float
+            // read is atomic, keeping the sampler off the SPI bus
+            PayloadGridPoint point(
+                CustomTime::getUnixTimeMilliseconds(),
+                getGridFrequency(),
+                _meterValues[0].voltage
+            );
+            Mqtt::pushGrid(point);
+        }
+
+        LOG_DEBUG("ADE7953 grid sampler task stopping");
+        _gridSamplerTaskHandle = NULL;
         vTaskDelete(NULL);
     }
 
@@ -4370,8 +4442,7 @@ namespace Ade7953
     }
 
     float _readGridFrequency() {
-        // Single unfiltered read; shares Eq.36 (the +1) with the EMA readout so the
-        // raw and filtered paths can never disagree on the conversion.
+        // Single unfiltered read; shares the Eq.36 conversion with the EMA readout
         float frequency = GridFrequency::rawFrequencyHz(_gridFreqCfg, _readPeriod());
         return frequency > 0.0f ? frequency : float(DEFAULT_FALLBACK_FREQUENCY);
     }

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -1886,6 +1886,7 @@ namespace Ade7953
             (1 << IRQSTATA_ZXV_BIT) | (1 << IRQSTATA_CYCEND_BIT) |
             (1 << IRQSTATA_RESET_BIT) | (1 << IRQSTATA_CRC_BIT);
         if ((statusA & handledIrqMask) == 0) {
+            statistics.ade7953UnhandledInterrupts++;
             LOG_WARNING("Unhandled ADE7953 interrupt status: 0x%08lX | %s", statusA, _irqstataBitName(statusA));
         }
     }
@@ -2168,6 +2169,10 @@ namespace Ade7953
                 _ade7953InterruptSemaphore != NULL &&
                 xSemaphoreTake(_ade7953InterruptSemaphore, pdMS_TO_TICKS(ADE7953_INTERRUPT_TIMEOUT_MS + _sampleTime)) == pdTRUE
             ) {
+                // One pass here can service several coalesced ISR wakeups (binary
+                // semaphore); ade7953TotalInterrupts - ade7953ServicePasses is how many were coalesced away.
+                statistics.ade7953ServicePasses++;
+
                 // Grab as quickly as possible the current unix time in milliseconds
                 // that refers to the "true" time at which the data is temporarily frozen in the ADE7953
                 uint64_t linecycUnix = CustomTime::getUnixTimeMilliseconds();

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -4,6 +4,7 @@
 #include "ade7953.h"
 #include "taskprofiler.h"
 #include "duration_format.h"
+#include "grid_frequency.h"
 
 namespace Ade7953
 {
@@ -35,7 +36,13 @@ namespace Ade7953
     static int8_t _polarityVoteCount[MAX_CHANNEL_COUNT] = {}; // Net consistent-sign vote accumulator for CT-reversal detection (runtime only; reset on arm/decision)
     static uint16_t _polarityConductingReads[MAX_CHANNEL_COUNT] = {}; // Conducting reads since arming - bounds a sign-oscillating channel (runtime only; reset on arm/decision)
     static bool _lastConducting[MAX_CHANNEL_COUNT] = {}; // Was the channel's most recent reading conducting (pre-clamp)? Drives the CT-detection boost so a clamped reversed load/PV still gets it (meter-task only)
-    static float _gridFrequency = 50.0f;
+    static float _gridFrequency = 50.0f; // Pre-EMA fallback: raw linecyc read, kept updated in the channel-0 path
+
+    // Per-cycle grid frequency EMA (issue #157), fed from the ZXV interrupt path.
+    // int32 state is written only by the meter task and read lock-free elsewhere
+    // (aligned 32-bit access is atomic on Xtensa).
+    static GridFrequency::State _gridFreqEma;
+    static const GridFrequency::Config _gridFreqCfg = {GRID_FREQUENCY_CONVERSION_FACTOR, VALIDATE_GRID_FREQUENCY_MIN, VALIDATE_GRID_FREQUENCY_MAX};
 
     // The library returns MeterLogic::NO_CHANNEL for "no channel"; the firmware
     // compares scheduler results against its own INVALID_CHANNEL macro. They must
@@ -142,15 +149,15 @@ namespace Ade7953
 
     // Interrupt handling
     static void _setupInterrupts();
-    static Ade7953InterruptType _handleInterrupt();
+    static void _handleInterrupt(uint64_t linecycUnix);
     static void _attachInterruptHandler();
     static void _detachInterruptHandler();
     static void IRAM_ATTR _isrHandler();
+    static void _handleZxvInterrupt();
     static void _handleCycendInterrupt(uint64_t linecycUnix);
     static void _pollWaveformSamples();
     static void _handleCrcChangeInterrupt();
     static void _handleResetInterrupt();
-    static void _handleOtherInterrupt();
     
     // Task management
     static void _startMeterReadingTask();
@@ -1608,6 +1615,10 @@ namespace Ade7953
     // ==============
 
     float getGridFrequency() {
+        // Filtered EMA once seeded (~one line cycle after task start): ~0.8 mHz
+        // resolution vs the ~11 mHz single-read quantization dither. Falls back to
+        // the raw linecyc-path value until then (and if ZXV never fires).
+        if (_gridFreqEma.seeded) return GridFrequency::frequencyHz(_gridFreqEma, _gridFreqCfg);
         return _gridFrequency;
     }
 
@@ -1821,35 +1832,65 @@ namespace Ade7953
     // ==================
 
     void _setupInterrupts() {
-        // Enable only CYCEND interrupt for line cycle end detection (bit 18)
         writeRegister(IRQENA_32, BIT_32, DEFAULT_IRQENA_REGISTER);
-        
+
         // Clear any existing interrupt status
         readRegister(RSTIRQSTATA_32, BIT_32, false);
         readRegister(RSTIRQSTATB_32, BIT_32, false);
 
-        LOG_DEBUG("ADE7953 interrupts enabled: CYCEND, RESET");
+        LOG_DEBUG("ADE7953 interrupts enabled: ZXV, CYCEND, RESET, CRC");
     }
 
-    Ade7953InterruptType _handleInterrupt() 
-    {    
+    void _handleInterrupt(uint64_t linecycUnix)
+    {
+        // The ADE7953 IRQ pin is level-active-low while the ESP32 interrupt is edge
+        // triggered, so a bit asserting while the pin is already low raises no new
+        // edge: with ZXV at line rate, co-pending bits in one wake are routine, not
+        // rare. RSTIRQSTATA is read-with-reset (one read clears ALL bits), therefore
+        // this must be a single snapshot serviced bit by bit - independent ifs, never
+        // else-if, never a second status read (it would return zeros and lose bits).
         int32_t statusA = readRegister(RSTIRQSTATA_32, BIT_32, false);
         // No need to read for channel B (only channel A has the relevant information for use)
 
-        // Check in order of priority, but ONLY check interrupts that are actually enabled
-        
-        // CYCEND is always enabled - check it first as it's the primary interrupt
-        if (statusA & (1 << IRQSTATA_CYCEND_BIT)) {
-            return Ade7953InterruptType::CYCEND;
-        } else if (statusA & (1 << IRQSTATA_RESET_BIT)) { 
-            return Ade7953InterruptType::RESET;
-        } else if (statusA & (1 << IRQSTATA_CRC_BIT)) {
-            return Ade7953InterruptType::CRC_CHANGE;
-        } else {
-            // Just log the unhandled status
-            LOG_WARNING("Unhandled ADE7953 interrupt status: 0x%08lX | %s", statusA, _irqstataBitName(statusA));
-            return Ade7953InterruptType::OTHER;
+        // ZXV first: PERIOD is transient (overwritten every cycle), the energy path is not
+        if (statusA & (1 << IRQSTATA_ZXV_BIT)) {
+            statistics.ade7953ZxInterrupts++;
+            _handleZxvInterrupt();
         }
+
+        if (statusA & (1 << IRQSTATA_CYCEND_BIT)) {
+            // Re-arm the energy double-read guard here and ONLY here: a genuine new
+            // linecyc means fresh frozen energy registers. Re-arming anywhere else
+            // (e.g. the old ISR clearing) would let a duplicate CYCEND processing
+            // read the reset-on-read energy registers twice and destroy the cycle.
+            _interruptHandledChannelA = false;
+            _interruptHandledChannelB = false;
+            _handleCycendInterrupt(linecycUnix);
+        }
+
+        if (statusA & (1 << IRQSTATA_RESET_BIT)) {
+            _handleResetInterrupt();
+        }
+
+        if (statusA & (1 << IRQSTATA_CRC_BIT)) {
+            _handleCrcChangeInterrupt();
+        }
+
+        constexpr int32_t handledIrqMask =
+            (1 << IRQSTATA_ZXV_BIT) | (1 << IRQSTATA_CYCEND_BIT) |
+            (1 << IRQSTATA_RESET_BIT) | (1 << IRQSTATA_CRC_BIT);
+        if ((statusA & handledIrqMask) == 0) {
+            LOG_WARNING("Unhandled ADE7953 interrupt status: 0x%08lX | %s", statusA, _irqstataBitName(statusA));
+        }
+    }
+
+    void _handleZxvInterrupt()
+    {
+        // One 16-bit read + integer EMA update: the entire per-cycle hot path.
+        // Validation (45-65 Hz) happens inside update(); glitch reads never touch
+        // the filter, and the update counter it advances is the freshness signal
+        // for the 500 ms grid sampler.
+        GridFrequency::update(_gridFreqEma, _gridFreqCfg, _readPeriod());
     }
 
     void _attachInterruptHandler() {
@@ -1866,8 +1907,10 @@ namespace Ade7953
     {
         BaseType_t xHigherPriorityTaskWoken = pdFALSE;
         statistics.ade7953TotalInterrupts++;
-        _interruptHandledChannelA = false;
-        _interruptHandledChannelB = false;
+        // Deliberately nothing else here: with ZXV enabled the IRQ fires every line
+        // cycle (~50/s), so any state touched here would be clobbered mid-linecyc.
+        // The energy double-read guard flags are re-armed in the task, and only on a
+        // genuine CYCEND (see _handleInterrupt).
 
         // Signal the task to handle the interrupt - let the task determine the cause
         if (_ade7953InterruptSemaphore != NULL) {
@@ -2058,10 +2101,6 @@ namespace Ade7953
         LOG_WARNING("TO BE IMPLEMENTED: ADE7953 reset interrupt detected - reinitializing device");
     }
 
-    void _handleOtherInterrupt() {
-        LOG_WARNING("TO BE IMPLEMENTED: unknown ADE7953 interrupt - this may indicate an unexpected condition");
-    }
-
     // Tasks
     // =====
 
@@ -2132,32 +2171,9 @@ namespace Ade7953
                 // that refers to the "true" time at which the data is temporarily frozen in the ADE7953
                 uint64_t linecycUnix = CustomTime::getUnixTimeMilliseconds();
 
-                // Handle the interrupt and determine its type (need to read it from ADE7953 since 
-                // we only got an interrupt, but we don't know the reason)
-                Ade7953InterruptType interruptType = _handleInterrupt();
-
-                // Process based on interrupt type
-                switch (interruptType)
-                {
-                    case Ade7953InterruptType::CYCEND:
-                        _handleCycendInterrupt(linecycUnix);
-                        break;
-
-                    case Ade7953InterruptType::RESET:
-                        _handleResetInterrupt();
-                        break;
-                        
-                    case Ade7953InterruptType::CRC_CHANGE:
-                        _handleCrcChangeInterrupt();
-                        break;
-
-                    case Ade7953InterruptType::OTHER:
-                        _handleOtherInterrupt();
-                        break;
-                    default:
-                        // Already logged in _handleInterrupt(), just continue
-                        break;
-                }
+                // Snapshot the status register once and service every pending cause
+                // (ZXV and CYCEND routinely co-pend at line rate - see _handleInterrupt)
+                _handleInterrupt(linecycUnix);
             } else {
                 LOG_DEBUG("No ADE7953 interrupt received within timeout, checking for stop notification");
                 _recordCriticalFailure();
@@ -4354,8 +4370,10 @@ namespace Ade7953
     }
 
     float _readGridFrequency() {
-        int32_t period = _readPeriod();
-        return period > 0 ? GRID_FREQUENCY_CONVERSION_FACTOR / float(period) : float(DEFAULT_FALLBACK_FREQUENCY);
+        // Single unfiltered read; shares Eq.36 (the +1) with the EMA readout so the
+        // raw and filtered paths can never disagree on the conversion.
+        float frequency = GridFrequency::rawFrequencyHz(_gridFreqCfg, _readPeriod());
+        return frequency > 0.0f ? frequency : float(DEFAULT_FALLBACK_FREQUENCY);
     }
 
     // Verification and validation functions

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -51,8 +51,8 @@ namespace Ade7953
     static_assert(INVALID_CHANNEL == MeterLogic::NO_CHANNEL, "INVALID_CHANNEL / MeterLogic::NO_CHANNEL value mismatch");
 
     // Set by the meter task when the CT-reversal detector flips the persisted reverse flag.
-    // Drained by the energy save task (internal-RAM stack, flash-capable) since the meter
-    // task runs on a PSRAM stack and cannot perform NVS writes.
+    // Drained by the energy save task instead of writing NVS directly from the meter task,
+    // keeping the hot meter-reading path free of flash I/O latency.
     static volatile bool _pendingPolaritySave[MAX_CHANNEL_COUNT] = {};
 
     // Issue-registry facts (issue #145), RAM-only and monotonic within this boot.
@@ -2124,7 +2124,7 @@ namespace Ade7953
         // Attach interrupt handler
         _attachInterruptHandler();
         
-        LOG_DEBUG("Starting ADE7953 meter reading task with %d bytes stack in internal RAM", ADE7953_METER_READING_TASK_STACK_SIZE);
+        LOG_DEBUG("Starting ADE7953 meter reading task with %d bytes stack", ADE7953_METER_READING_TASK_STACK_SIZE);
 
         BaseType_t result = xTaskCreate(
             _meterReadingTask, 
@@ -2206,7 +2206,7 @@ namespace Ade7953
             return;
         }
 
-        LOG_DEBUG("Starting ADE7953 energy save task with %d bytes stack in internal RAM (uses NVS)", ADE7953_ENERGY_SAVE_TASK_STACK_SIZE);
+        LOG_DEBUG("Starting ADE7953 energy save task with %d bytes stack", ADE7953_ENERGY_SAVE_TASK_STACK_SIZE);
 
         BaseType_t result = xTaskCreate(
             _energySaveTask,
@@ -2237,10 +2237,10 @@ namespace Ade7953
                 if (isChannelActive(i)) _saveEnergyToPreferences(i);
             }
 
-            // Drain pending polarity-flip persistence (queued by the meter task on PSRAM
-            // stack, which cannot itself touch NVS). Test-and-clear under _channelDataMutex
-            // so a concurrent re-set from the meter task lands on the *next* iteration
-            // instead of being lost between the read and the false-write.
+            // Drain pending polarity-flip persistence (queued by the meter task, which
+            // hands NVS writes off to this task instead of doing them inline). Test-and-clear
+            // under _channelDataMutex so a concurrent re-set from the meter task lands on the
+            // *next* iteration instead of being lost between the read and the false-write.
             for (uint8_t i = 0; i < globalHwProfile->totalChannelCount; i++) {
                 bool drain = false;
                 if (acquireMutex(&_channelDataMutex)) {
@@ -2270,7 +2270,7 @@ namespace Ade7953
             return;
         }
 
-        LOG_DEBUG("Starting ADE7953 grid sampler task with %d bytes stack in internal RAM", ADE7953_GRID_SAMPLER_TASK_STACK_SIZE);
+        LOG_DEBUG("Starting ADE7953 grid sampler task with %d bytes stack", ADE7953_GRID_SAMPLER_TASK_STACK_SIZE);
 
         BaseType_t result = xTaskCreate(
             _gridSamplerTask,
@@ -2341,7 +2341,7 @@ namespace Ade7953
             return;
         }
 
-        LOG_DEBUG("Starting ADE7953 hourly CSV save task with %d bytes stack in internal RAM (uses LittleFS)", ADE7953_HOURLY_CSV_SAVE_TASK_STACK_SIZE);
+        LOG_DEBUG("Starting ADE7953 hourly CSV save task with %d bytes stack", ADE7953_HOURLY_CSV_SAVE_TASK_STACK_SIZE);
 
         BaseType_t result = xTaskCreate(
             _hourlyCsvSaveTask,
@@ -4853,6 +4853,11 @@ namespace Ade7953
     TaskInfo getHourlyCsvTaskInfo()
     {
         return getTaskInfoSafely(_hourlyCsvSaveTaskHandle, ADE7953_HOURLY_CSV_SAVE_TASK_STACK_SIZE, &_hourlyCsvHeartbeat);
+    }
+
+    TaskInfo getGridSamplerTaskInfo()
+    {
+        return getTaskInfoSafely(_gridSamplerTaskHandle, ADE7953_GRID_SAMPLER_TASK_STACK_SIZE, &_gridSamplerHeartbeat);
     }
 
     // Waveform capture API

--- a/source/src/buttonhandler.cpp
+++ b/source/src/buttonhandler.cpp
@@ -49,8 +49,7 @@ namespace ButtonHandler
             return;
         }
 
-        // Create button handling task with internal RAM stack (performs Preferences operations)
-        LOG_DEBUG("Starting button task with %d bytes stack in internal RAM (performs Preferences operations)", BUTTON_TASK_STACK_SIZE);
+        LOG_DEBUG("Starting button task with %d bytes stack", BUTTON_TASK_STACK_SIZE);
 
         BaseType_t result = xTaskCreate(
             _buttonTask,

--- a/source/src/crashmonitor.cpp
+++ b/source/src/crashmonitor.cpp
@@ -197,7 +197,7 @@ namespace CrashMonitor
         _handleCounters();
 
         // Create task to handle the crash reset
-        LOG_DEBUG("Starting crash reset task with %d bytes stack in internal RAM", CRASH_RESET_TASK_STACK_SIZE);
+        LOG_DEBUG("Starting crash reset task with %d bytes stack", CRASH_RESET_TASK_STACK_SIZE);
 
         BaseType_t result = xTaskCreate(
             _crashResetTask, 

--- a/source/src/customlog.cpp
+++ b/source/src/customlog.cpp
@@ -200,7 +200,7 @@ namespace CustomLog
             return;
         }
 
-        LOG_DEBUG("Starting UDP log task with %d bytes stack in internal RAM (performs UDP network operations)", UDP_LOG_TASK_STACK_SIZE);
+        LOG_DEBUG("Starting UDP log task with %d bytes stack", UDP_LOG_TASK_STACK_SIZE);
 
         BaseType_t result = xTaskCreate(
             _udpTask,

--- a/source/src/custommqtt.cpp
+++ b/source/src/custommqtt.cpp
@@ -256,7 +256,7 @@ namespace CustomMqtt
             return;
         }
 
-        LOG_DEBUG("Starting Custom MQTT task with %d bytes stack in internal RAM (uses NVS)", CUSTOM_MQTT_TASK_STACK_SIZE);
+        LOG_DEBUG("Starting Custom MQTT task with %d bytes stack", CUSTOM_MQTT_TASK_STACK_SIZE);
 
         BaseType_t result = xTaskCreate(
             _customMqttTask,

--- a/source/src/customserver.cpp
+++ b/source/src/customserver.cpp
@@ -354,7 +354,7 @@ namespace CustomServer
             return;
         }
 
-        LOG_DEBUG("Starting health check task with %d bytes stack in internal RAM (performs TCP network operations)", HEALTH_CHECK_TASK_STACK_SIZE);
+        LOG_DEBUG("Starting health check task with %d bytes stack", HEALTH_CHECK_TASK_STACK_SIZE);
         _consecutiveFailures = 0;
 
         BaseType_t result = xTaskCreate(
@@ -382,7 +382,7 @@ namespace CustomServer
             return;
         }
 
-        LOG_DEBUG("Starting OTA timeout task with %d bytes stack in internal RAM (uses flash I/O)", OTA_TIMEOUT_TASK_STACK_SIZE);
+        LOG_DEBUG("Starting OTA timeout task with %d bytes stack", OTA_TIMEOUT_TASK_STACK_SIZE);
 
         BaseType_t result = xTaskCreate(
             _otaTimeoutTask,

--- a/source/src/customwifi.cpp
+++ b/source/src/customwifi.cpp
@@ -510,7 +510,7 @@ namespace CustomWifi
     _lastReconnectAttempt = 0;
 
     _setupMdns();
-    // Note: printDeviceStatusDynamic() removed to avoid flash I/O from PSRAM task
+    // Note: printDeviceStatusDynamic() removed to avoid flash I/O from this task
 
     Led::clearPattern(Led::PRIO_MEDIUM); // Ensure that if we are connected again, we don't keep the blue pattern
     Led::setGreen(Led::PRIO_NORMAL); // Hack: to ensure we get back to green light, we set it here even though a proper LED manager would handle priorities better
@@ -1087,7 +1087,7 @@ namespace CustomWifi
   static void _startWifiTask()
   {
     if (_wifiTaskHandle) { LOG_DEBUG("WiFi task is already running"); return; }
-    LOG_DEBUG("Starting WiFi task with %d bytes stack in internal RAM (performs TCP network operations)", WIFI_TASK_STACK_SIZE);
+    LOG_DEBUG("Starting WiFi task with %d bytes stack", WIFI_TASK_STACK_SIZE);
 
     BaseType_t result = xTaskCreate(
         _wifiConnectionTask,

--- a/source/src/influxdbclient.cpp
+++ b/source/src/influxdbclient.cpp
@@ -302,7 +302,7 @@ namespace InfluxDbClient
             return;
         }
 
-        LOG_DEBUG("Starting InfluxDB task with %d bytes stack in internal RAM (uses NVS)", INFLUXDB_TASK_STACK_SIZE);
+        LOG_DEBUG("Starting InfluxDB task with %d bytes stack", INFLUXDB_TASK_STACK_SIZE);
 
         BaseType_t result = xTaskCreate(
             _influxDbTask,

--- a/source/src/issueregistry.cpp
+++ b/source/src/issueregistry.cpp
@@ -102,7 +102,7 @@ namespace IssueRegistry
             return;
         }
 
-        LOG_DEBUG("Starting issue registry task with %d bytes stack in internal RAM (reads LittleFS usage)", ISSUE_REGISTRY_TASK_STACK_SIZE);
+        LOG_DEBUG("Starting issue registry task with %d bytes stack", ISSUE_REGISTRY_TASK_STACK_SIZE);
 
         BaseType_t result = xTaskCreate(
             _registryTask,

--- a/source/src/led.cpp
+++ b/source/src/led.cpp
@@ -75,7 +75,7 @@ namespace Led
         if (_ledQueue == nullptr) { return; } // Failed to create queue
 
         // Create LED task
-        LOG_DEBUG("Starting LED task with %d bytes stack in internal RAM", LED_TASK_STACK_SIZE);
+        LOG_DEBUG("Starting LED task with %d bytes stack", LED_TASK_STACK_SIZE);
         
         BaseType_t result = xTaskCreate(
             _ledTask,

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -23,12 +23,15 @@ namespace Mqtt
     // FreeRTOS queues
     static QueueHandle_t _logQueue = nullptr;
     static QueueHandle_t _meterQueue = nullptr;
+    static QueueHandle_t _gridQueue = nullptr;
 
     // Static queue structures and storage for PSRAM
     static StaticQueue_t _logQueueStruct;
     static StaticQueue_t _meterQueueStruct;
+    static StaticQueue_t _gridQueueStruct;
     static uint8_t* _logQueueStorage = nullptr;
     static uint8_t* _meterQueueStorage = nullptr;
+    static uint8_t* _gridQueueStorage = nullptr;
 
     // Connection attempt tracking
     static uint32_t _mqttConnectionAttempt = 0;
@@ -40,12 +43,14 @@ namespace Mqtt
 
     // Last publish timestamps
     static uint64_t _lastMillisMeterPublished = 0;
+    static uint64_t _lastMillisGridPublished = 0;
     static uint64_t _lastMillisSystemDynamicPublished = 0;
     static uint64_t _lastMillisStatisticsPublished = 0;
 
     // Configuration
     static bool _cloudServicesEnabled = DEFAULT_CLOUD_SERVICES_ENABLED;
     static bool _sendPowerDataEnabled = DEFAULT_SEND_POWER_DATA_ENABLED;
+    static bool _sendGridDataEnabled = DEFAULT_SEND_GRID_DATA_ENABLED;
     static uint8_t _mqttLogLevelInt = DEFAULT_MQTT_LOG_LEVEL_INT;
     static LogLevel _mqttMinLogLevel = LogLevel::INFO;
 
@@ -56,6 +61,7 @@ namespace Mqtt
     
     // Topic buffers
     static char _mqttTopicMeter[MQTT_TOPIC_BUFFER_SIZE];
+    static char _mqttTopicGrid[MQTT_TOPIC_BUFFER_SIZE];
     static char _mqttTopicSystemDynamic[MQTT_TOPIC_BUFFER_SIZE];
     static char _mqttTopicStatistics[MQTT_TOPIC_BUFFER_SIZE];
     static char _mqttTopicCrash[MQTT_TOPIC_BUFFER_SIZE];
@@ -83,17 +89,20 @@ namespace Mqtt
     // Queue initialization
     static bool _initializeLogQueue();
     static bool _initializeMeterQueue();
+    static bool _initializeGridQueue();
     
     // Configuration management
     static void _loadConfigFromPreferences();
     static void _saveConfigToPreferences();
     
     static void _setSendPowerDataEnabled(bool enabled);
+    static void _setSendGridDataEnabled(bool enabled);
     static void _setMqttLogLevel(const char* logLevel);
     static void _updateMqttMinLogLevel();
 
     static void _saveCloudServicesEnabledToPreferences(bool enabled);
     static void _saveSendPowerDataEnabledToPreferences(bool enabled);
+    static void _saveSendGridDataEnabledToPreferences(bool enabled);
     static void _saveMqttLogLevelToPreferences(uint8_t logLevel);
         
     // Task management
@@ -109,6 +118,7 @@ namespace Mqtt
 
     // Publish topics
     static void _setTopicMeter();
+    static void _setTopicGrid();
     static void _setTopicSystemDynamic();
     static void _setTopicStatistics();
     static void _setTopicCrash();
@@ -144,6 +154,7 @@ namespace Mqtt
 
     // Publishing functions
     static void _publishMeter();
+    static void _publishGrid();
     static void _publishSystemDynamic();
     static void _publishStatistics();
     static void _publishCrash();
@@ -152,6 +163,7 @@ namespace Mqtt
     
     static void _checkPublishMqtt();
     static void _checkIfPublishMeterNeeded();
+    static void _checkIfPublishGridNeeded();
     static void _checkIfPublishSystemDynamicNeeded();
     static void _checkIfPublishStatisticsNeeded();
 
@@ -208,6 +220,7 @@ namespace Mqtt
         Shadow::begin();
         _initializeLogQueue();
         _initializeMeterQueue();
+        _initializeGridQueue();
         
         // Initialize OTA buffers before checking pending validation
         if (_otaCurrentUrl == nullptr) {
@@ -263,6 +276,7 @@ namespace Mqtt
         
         _logQueue = nullptr;
         _meterQueue = nullptr;
+        _gridQueue = nullptr;
         
         if (_logQueueStorage != nullptr) {
             free(_logQueueStorage);
@@ -274,6 +288,12 @@ namespace Mqtt
             free(_meterQueueStorage);
             _meterQueueStorage = nullptr;
             LOG_DEBUG("MQTT meter queue PSRAM freed");
+        }
+
+        if (_gridQueueStorage != nullptr) {
+            free(_gridQueueStorage);
+            _gridQueueStorage = nullptr;
+            LOG_DEBUG("MQTT grid queue PSRAM freed");
         }
 
         deleteMutex(&_configMutex);
@@ -374,6 +394,19 @@ namespace Mqtt
         if (_sendPowerDataEnabled) xQueueSend(_meterQueue, &payload, pdMS_TO_TICKS(QUEUE_WAIT_TIMEOUT)); // Only add to queue if we chose to send power data
     }
 
+    void pushGrid(const PayloadGridPoint& point)
+    {
+        if (!_initializeGridQueue()) return;
+        if (!_sendGridDataEnabled) return; // Sampler already gates on this
+
+        // Drop-oldest on overflow: recent points are worth more than old ones
+        if (xQueueSend(_gridQueue, &point, 0) != pdTRUE) {
+            PayloadGridPoint discarded;
+            xQueueReceive(_gridQueue, &discarded, 0);
+            xQueueSend(_gridQueue, &point, 0);
+        }
+    }
+
     TaskInfo getMqttTaskInfo()
     {
         return getTaskInfoSafely(_taskHandle, MQTT_TASK_STACK_SIZE, &_mqttHeartbeat);
@@ -460,6 +493,10 @@ namespace Mqtt
     bool getSendPowerData() { return _sendPowerDataEnabled; }
 
     void setSendPowerData(bool enabled) { _setSendPowerDataEnabled(enabled); } // persists
+
+    bool getSendGridData() { return _sendGridDataEnabled; }
+
+    void setSendGridData(bool enabled) { _setSendGridDataEnabled(enabled); } // persists
 
     // Private functions
     // =================
@@ -549,6 +586,32 @@ namespace Mqtt
         return true;
     }
 
+    bool _initializeGridQueue()
+    {
+        if (_gridQueueStorage != nullptr) return true;
+
+        // Allocate queue storage in PSRAM
+        uint32_t queueLength = MQTT_GRID_QUEUE_SIZE / sizeof(PayloadGridPoint);
+        size_t realQueueSize = queueLength * sizeof(PayloadGridPoint);
+        _gridQueueStorage = (uint8_t*)ps_malloc(realQueueSize);
+
+        if (_gridQueueStorage == nullptr) {
+            LOG_ERROR("Failed to allocate PSRAM for MQTT grid queue (%zu bytes)", realQueueSize);
+            return false;
+        }
+
+        _gridQueue = xQueueCreateStatic(queueLength, sizeof(PayloadGridPoint), _gridQueueStorage, &_gridQueueStruct);
+        if (_gridQueue == nullptr) {
+            LOG_ERROR("Failed to create MQTT grid queue");
+            free(_gridQueueStorage);
+            _gridQueueStorage = nullptr;
+            return false;
+        }
+
+        LOG_DEBUG("MQTT grid queue initialized with PSRAM buffer (%zu bytes) | Free PSRAM: %zu bytes", realQueueSize, heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
+        return true;
+    }
+
     // Configuration management
     // ========================
     
@@ -564,12 +627,14 @@ namespace Mqtt
 
         _cloudServicesEnabled = prefs.getBool(MQTT_PREFERENCES_IS_CLOUD_SERVICES_ENABLED_KEY, DEFAULT_CLOUD_SERVICES_ENABLED);
         _sendPowerDataEnabled = prefs.getBool(MQTT_PREFERENCES_SEND_POWER_DATA_KEY, DEFAULT_SEND_POWER_DATA_ENABLED);
+        _sendGridDataEnabled = prefs.getBool(MQTT_PREFERENCES_SEND_GRID_DATA_KEY, DEFAULT_SEND_GRID_DATA_ENABLED);
         _mqttLogLevelInt = prefs.getUChar(MQTT_PREFERENCES_MQTT_LOG_LEVEL_KEY, DEFAULT_MQTT_LOG_LEVEL_INT);
         _updateMqttMinLogLevel(); // Convert integer to LogLevel enum
 
-        LOG_DEBUG("Cloud services enabled: %s, Send power data enabled: %s, MQTT log level: %u",
+        LOG_DEBUG("Cloud services enabled: %s, Send power data enabled: %s, Send grid data enabled: %s, MQTT log level: %u",
                    _cloudServicesEnabled ? "true" : "false",
                    _sendPowerDataEnabled ? "true" : "false",
+                   _sendGridDataEnabled ? "true" : "false",
                    _mqttLogLevelInt);
 
         prefs.end();
@@ -583,6 +648,7 @@ namespace Mqtt
     {
         _saveCloudServicesEnabledToPreferences(_cloudServicesEnabled);
         _saveSendPowerDataEnabledToPreferences(_sendPowerDataEnabled);
+        _saveSendGridDataEnabledToPreferences(_sendGridDataEnabled);
         _saveMqttLogLevelToPreferences(_mqttLogLevelInt);
         
         LOG_DEBUG("MQTT preferences saved");
@@ -593,6 +659,13 @@ namespace Mqtt
         _sendPowerDataEnabled = enabled;
         _saveSendPowerDataEnabledToPreferences(enabled);
         LOG_DEBUG("Set send power data enabled to %s", enabled ? "true" : "false");
+    }
+
+    static void _setSendGridDataEnabled(bool enabled)
+    {
+        _sendGridDataEnabled = enabled;
+        _saveSendGridDataEnabledToPreferences(enabled);
+        LOG_DEBUG("Set send grid data enabled to %s", enabled ? "true" : "false");
     }
 
     static void _updateMqttMinLogLevel()
@@ -662,6 +735,16 @@ namespace Mqtt
         size_t bytesWritten = prefs.putBool(MQTT_PREFERENCES_SEND_POWER_DATA_KEY, enabled);
         if (bytesWritten == 0) LOG_ERROR("Failed to save send power data enabled preference");
         
+        prefs.end();
+    }
+
+    static void _saveSendGridDataEnabledToPreferences(bool enabled) {
+        Preferences prefs;
+
+        prefs.begin(PREFERENCES_NAMESPACE_MQTT, false);
+        size_t bytesWritten = prefs.putBool(MQTT_PREFERENCES_SEND_GRID_DATA_KEY, enabled);
+        if (bytesWritten == 0) LOG_ERROR("Failed to save send grid data enabled preference");
+
         prefs.end();
     }
 
@@ -823,6 +906,7 @@ namespace Mqtt
 
     static void _setupTopics() {
         _setTopicMeter();
+        _setTopicGrid();
         _setTopicSystemDynamic();
         _setTopicStatistics();
         _setTopicCrash();
@@ -832,6 +916,7 @@ namespace Mqtt
     }
 
     static void _setTopicMeter() { _constructMqttTopicWithRule(AWS_IOT_CORE_RULE_METER, MQTT_TOPIC_METER, _mqttTopicMeter, sizeof(_mqttTopicMeter)); }
+    static void _setTopicGrid() { _constructMqttTopicWithRule(AWS_IOT_CORE_RULE_GRID, MQTT_TOPIC_GRID, _mqttTopicGrid, sizeof(_mqttTopicGrid)); }
     static void _setTopicSystemDynamic() { _constructMqttTopic(MQTT_TOPIC_SYSTEM_DYNAMIC, _mqttTopicSystemDynamic, sizeof(_mqttTopicSystemDynamic)); }
     static void _setTopicStatistics() { _constructMqttTopic(MQTT_TOPIC_STATISTICS, _mqttTopicStatistics, sizeof(_mqttTopicStatistics)); }
     static void _setTopicCrash() { _constructMqttTopic(MQTT_TOPIC_CRASH, _mqttTopicCrash, sizeof(_mqttTopicCrash)); }
@@ -1486,6 +1571,30 @@ namespace Mqtt
         if (_publishMeterJson()) _lastMillisMeterPublished = millis64();
     }
     
+    static void _publishGrid() {
+        if (_gridQueue == nullptr || uxQueueMessagesWaiting(_gridQueue) == 0) return;
+
+        // Bare top-level array of [t, f, v] triplets (cross-repo contract v1),
+        // FIFO-drained so the array is sorted; gaps stay explicit
+        SpiRamAllocator allocator;
+        JsonDocument doc(&allocator);
+        JsonArray points = doc.to<JsonArray>();
+
+        PayloadGridPoint point;
+        uint32_t loops = 0;
+        while (xQueueReceive(_gridQueue, &point, 0) == pdTRUE && loops < MAX_LOOP_ITERATIONS) {
+            loops++;
+            JsonArray triplet = points.add<JsonArray>();
+            triplet.add(point.unixTimeMs);
+            triplet.add(roundToDecimals(point.frequency, MQTT_GRID_FREQUENCY_PAYLOAD_DECIMALS));
+            triplet.add(roundToDecimals(point.voltage, MQTT_GRID_VOLTAGE_PAYLOAD_DECIMALS));
+
+            if (measureJson(doc) > AWS_IOT_CORE_MQTT_PAYLOAD_LIMIT * MQTT_METER_PAYLOAD_THRESHOLD_MULTIPLIER) break; // Remainder ships next cycle
+        }
+
+        if (_publishJsonStreaming(doc, _mqttTopicGrid)) _lastMillisGridPublished = millis64();
+    }
+
     static void _publishSystemDynamic() {
         SpiRamAllocator allocator;
         JsonDocument doc(&allocator);
@@ -1569,6 +1678,7 @@ namespace Mqtt
 
     static void _checkPublishMqtt() {
         if (_publishMqtt.meter) {_publishMeter();}
+        if (_publishMqtt.grid) {_publishGrid();}
         if (_publishMqtt.systemDynamic) {_publishSystemDynamic();}
         if (_publishMqtt.statistics) {_publishStatistics();}
         if (_publishMqtt.crash) {_publishCrash();}
@@ -1591,6 +1701,16 @@ namespace Mqtt
         ) {
             _publishMqtt.meter = true;
             LOG_DEBUG("Set flag to publish meter data (queue: %u entries, real size checked during publish)", queueSize);
+        }
+    }
+
+    static void _checkIfPublishGridNeeded() {
+        UBaseType_t queueSize = _gridQueue ? uxQueueMessagesWaiting(_gridQueue) : 0;
+
+        // Time-triggered only: a batch stays well under the billable minimum
+        if (queueSize > 0 && (millis64() - _lastMillisGridPublished) > MQTT_MAX_INTERVAL_GRID_PUBLISH) {
+            _publishMqtt.grid = true;
+            LOG_DEBUG("Set flag to publish grid data (queue: %u points)", queueSize);
         }
     }
 
@@ -2080,6 +2200,7 @@ namespace Mqtt
         // Process queues and publishing
         _processLogQueue();
         _checkIfPublishMeterNeeded();
+        _checkIfPublishGridNeeded();
         _checkIfPublishSystemDynamicNeeded();
         _checkIfPublishStatisticsNeeded();
         _checkPublishMqtt();

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -794,7 +794,7 @@ namespace Mqtt
         _nextMqttConnectionAttemptMillis = 0;
         _mqttConnectionAttempt = 0;
         
-        LOG_DEBUG("Starting MQTT task with %d bytes stack in internal RAM (uses NVS)", MQTT_TASK_STACK_SIZE);
+        LOG_DEBUG("Starting MQTT task with %d bytes stack", MQTT_TASK_STACK_SIZE);
 
         BaseType_t result = xTaskCreate(
             _mqttTask,
@@ -1523,7 +1523,7 @@ namespace Mqtt
         snprintf(_otaCurrentUrl, OTA_PRESIGNED_URL_BUFFER_SIZE, "%s", url);
         snprintf(_otaCurrentJobId, sizeof(_otaCurrentJobId), "%s", jobId);
 
-        LOG_DEBUG("Starting OTA task with %d bytes stack in internal RAM (writes firmware to flash)", OTA_TASK_STACK_SIZE);
+        LOG_DEBUG("Starting OTA task with %d bytes stack", OTA_TASK_STACK_SIZE);
 
         BaseType_t result = xTaskCreate(
             _otaTask, 
@@ -2340,7 +2340,7 @@ namespace Mqtt
         snprintf(_otaCurrentJobId, sizeof(_otaCurrentJobId), "%s", jobId);
 
         // Create validation task to monitor stability
-        LOG_DEBUG("Starting OTA validation task with %d bytes stack in internal RAM", OTA_VALIDATION_TASK_STACK_SIZE);
+        LOG_DEBUG("Starting OTA validation task with %d bytes stack", OTA_VALIDATION_TASK_STACK_SIZE);
         
         BaseType_t result = xTaskCreate(
             _otaValidationTask,

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -398,6 +398,7 @@ namespace Mqtt
             PayloadMeter discarded;
             xQueueReceive(_meterQueue, &discarded, 0);
             xQueueSend(_meterQueue, &payload, 0);
+            statistics.mqttMeterPointsDropped++;
         }
     }
 
@@ -411,6 +412,7 @@ namespace Mqtt
             PayloadGridPoint discarded;
             xQueueReceive(_gridQueue, &discarded, 0);
             xQueueSend(_gridQueue, &point, 0);
+            statistics.mqttGridPointsDropped++;
         }
     }
 

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -1601,7 +1601,10 @@ namespace Mqtt
             if (measureJson(doc) > AWS_IOT_CORE_MQTT_PAYLOAD_LIMIT * MQTT_METER_PAYLOAD_THRESHOLD_MULTIPLIER) break; // Remainder ships next cycle
         }
 
-        if (_publishJsonStreaming(doc, _mqttTopicGrid)) _lastMillisGridPublished = millis64();
+        if (_publishJsonStreaming(doc, _mqttTopicGrid)) {
+            _publishMqtt.grid = false;
+            _lastMillisGridPublished = millis64();
+        }
     }
 
     static void _publishSystemDynamic() {

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -391,7 +391,14 @@ namespace Mqtt
     void pushMeter(const PayloadMeter& payload)
     {
         if (!_initializeMeterQueue()) return;
-        if (_sendPowerDataEnabled) xQueueSend(_meterQueue, &payload, pdMS_TO_TICKS(QUEUE_WAIT_TIMEOUT)); // Only add to queue if we chose to send power data
+        if (!_sendPowerDataEnabled) return;
+
+        // Drop-oldest on overflow: recent points are worth more than old ones
+        if (xQueueSend(_meterQueue, &payload, 0) != pdTRUE) {
+            PayloadMeter discarded;
+            xQueueReceive(_meterQueue, &discarded, 0);
+            xQueueSend(_meterQueue, &payload, 0);
+        }
     }
 
     void pushGrid(const PayloadGridPoint& point)

--- a/source/src/shadow.cpp
+++ b/source/src/shadow.cpp
@@ -590,6 +590,7 @@ static void _reportSystem(JsonDocument& doc) {
     JsonObject rep = doc["state"]["reported"].to<JsonObject>();
     rep["led_brightness"] = Led::getBrightness();
     rep["send_power_data"] = Mqtt::getSendPowerData();
+    rep["send_grid_data"] = Mqtt::getSendGridData();
     rep["mqtt_log_level"] = ShadowLogic::logLevelToString(Mqtt::getMqttLogLevel());
     rep["log_level_print"] = AdvancedLogger::logLevelToString(AdvancedLogger::getPrintLevel());
     rep["log_level_save"] = AdvancedLogger::logLevelToString(AdvancedLogger::getSaveLevel());
@@ -634,6 +635,18 @@ static bool _applySystem(JsonObjectConst delta, JsonObject reported) {
             applied = true;
         } else {
             LOG_WARNING("Rejected send_power_data: not a boolean");
+        }
+    }
+
+    v = delta["send_grid_data"];
+    if (!v.isNull()) {
+        if (v.is<bool>()) {
+            bool e = v.as<bool>();
+            Mqtt::setSendGridData(e); // persists
+            reported["send_grid_data"] = e;
+            applied = true;
+        } else {
+            LOG_WARNING("Rejected send_grid_data: not a boolean");
         }
     }
 

--- a/source/src/utils.cpp
+++ b/source/src/utils.cpp
@@ -202,6 +202,7 @@ void populateSystemDynamicInfo(SystemDynamicInfo& info) {
     info.ade7953MeterReadingTaskInfo = Ade7953::getMeterReadingTaskInfo();
     info.ade7953EnergySaveTaskInfo = Ade7953::getEnergySaveTaskInfo();
     info.ade7953HourlyCsvTaskInfo = Ade7953::getHourlyCsvTaskInfo();
+    info.ade7953GridSamplerTaskInfo = Ade7953::getGridSamplerTaskInfo();
     info.maintenanceTaskInfo = getMaintenanceTaskInfo();
     info.issueRegistryTaskInfo = IssueRegistry::getTaskInfo();
 
@@ -366,6 +367,7 @@ void systemDynamicInfoToJson(SystemDynamicInfo& info, JsonDocument &doc) {
     addTask("ade7953MeterReading", info.ade7953MeterReadingTaskInfo);
     addTask("ade7953EnergySave", info.ade7953EnergySaveTaskInfo);
     addTask("ade7953HourlyCsv", info.ade7953HourlyCsvTaskInfo);
+    addTask("ade7953GridSampler", info.ade7953GridSamplerTaskInfo);
     addTask("maintenance", info.maintenanceTaskInfo);
     addTask("issueRegistry", info.issueRegistryTaskInfo);
 
@@ -470,7 +472,7 @@ void startMaintenanceTask() {
         return;
     }
     
-    LOG_DEBUG("Starting maintenance task with %d bytes stack in internal RAM (performs flash I/O operations)", TASK_MAINTENANCE_STACK_SIZE);
+    LOG_DEBUG("Starting maintenance task with %d bytes stack", TASK_MAINTENANCE_STACK_SIZE);
     
     BaseType_t result = xTaskCreate(
         _maintenanceTask,

--- a/source/src/utils.cpp
+++ b/source/src/utils.cpp
@@ -750,19 +750,23 @@ void printStatistics() {
     updateStatistics();
 
     LOG_DEBUG("--- Statistics ---");
-    LOG_DEBUG("Statistics - ADE7953: %llu total interrupts | %llu handled interrupts | %llu zx interrupts | %llu readings | %llu reading failures",  
-        statistics.ade7953TotalInterrupts, 
-        statistics.ade7953TotalHandledInterrupts, 
-        statistics.ade7953ZxInterrupts, 
-        statistics.ade7953ReadingCount, 
+    LOG_DEBUG("Statistics - ADE7953: %llu total interrupts | %llu handled interrupts | %llu zx interrupts | %llu service passes | %llu unhandled | %llu readings | %llu reading failures",
+        statistics.ade7953TotalInterrupts,
+        statistics.ade7953TotalHandledInterrupts,
+        statistics.ade7953ZxInterrupts,
+        statistics.ade7953ServicePasses,
+        statistics.ade7953UnhandledInterrupts,
+        statistics.ade7953ReadingCount,
         statistics.ade7953ReadingCountFailure
     );
 
-    LOG_DEBUG("Statistics - MQTT: %llu messages published | %llu errors | %llu connections | %llu connection errors",  
-        statistics.mqttMessagesPublished, 
+    LOG_DEBUG("Statistics - MQTT: %llu messages published | %llu errors | %llu connections | %llu connection errors | %llu meter points dropped | %llu grid points dropped",
+        statistics.mqttMessagesPublished,
         statistics.mqttMessagesPublishedError,
         statistics.mqttConnections,
-        statistics.mqttConnectionErrors
+        statistics.mqttConnectionErrors,
+        statistics.mqttMeterPointsDropped,
+        statistics.mqttGridPointsDropped
     );
 
     LOG_DEBUG("Statistics - Custom MQTT: %llu messages published | %llu errors",  
@@ -810,6 +814,8 @@ void statisticsToJson(Statistics& statistics, JsonDocument &jsonDocument) {
     jsonDocument["ade7953"]["totalInterrupts"] = statistics.ade7953TotalInterrupts;
     jsonDocument["ade7953"]["totalHandledInterrupts"] = statistics.ade7953TotalHandledInterrupts;
     jsonDocument["ade7953"]["zxInterrupts"] = statistics.ade7953ZxInterrupts;
+    jsonDocument["ade7953"]["servicePasses"] = statistics.ade7953ServicePasses;
+    jsonDocument["ade7953"]["unhandledInterrupts"] = statistics.ade7953UnhandledInterrupts;
     jsonDocument["ade7953"]["readingCount"] = statistics.ade7953ReadingCount;
     jsonDocument["ade7953"]["readingCountFailure"] = statistics.ade7953ReadingCountFailure;
 
@@ -818,6 +824,8 @@ void statisticsToJson(Statistics& statistics, JsonDocument &jsonDocument) {
     jsonDocument["mqtt"]["messagesPublishedError"] = statistics.mqttMessagesPublishedError;
     jsonDocument["mqtt"]["connections"] = statistics.mqttConnections;
     jsonDocument["mqtt"]["connectionErrors"] = statistics.mqttConnectionErrors;
+    jsonDocument["mqtt"]["meterPointsDropped"] = statistics.mqttMeterPointsDropped;
+    jsonDocument["mqtt"]["gridPointsDropped"] = statistics.mqttGridPointsDropped;
 
     // Custom MQTT statistics
     jsonDocument["customMqtt"]["messagesPublished"] = statistics.customMqttMessagesPublished;

--- a/source/src/utils.cpp
+++ b/source/src/utils.cpp
@@ -750,9 +750,10 @@ void printStatistics() {
     updateStatistics();
 
     LOG_DEBUG("--- Statistics ---");
-    LOG_DEBUG("Statistics - ADE7953: %llu total interrupts | %llu handled interrupts | %llu readings | %llu reading failures",  
+    LOG_DEBUG("Statistics - ADE7953: %llu total interrupts | %llu handled interrupts | %llu zx interrupts | %llu readings | %llu reading failures",  
         statistics.ade7953TotalInterrupts, 
         statistics.ade7953TotalHandledInterrupts, 
+        statistics.ade7953ZxInterrupts, 
         statistics.ade7953ReadingCount, 
         statistics.ade7953ReadingCountFailure
     );
@@ -808,6 +809,7 @@ void statisticsToJson(Statistics& statistics, JsonDocument &jsonDocument) {
     // ADE7953 statistics
     jsonDocument["ade7953"]["totalInterrupts"] = statistics.ade7953TotalInterrupts;
     jsonDocument["ade7953"]["totalHandledInterrupts"] = statistics.ade7953TotalHandledInterrupts;
+    jsonDocument["ade7953"]["zxInterrupts"] = statistics.ade7953ZxInterrupts;
     jsonDocument["ade7953"]["readingCount"] = statistics.ade7953ReadingCount;
     jsonDocument["ade7953"]["readingCountFailure"] = statistics.ade7953ReadingCountFailure;
 

--- a/source/test/test_grid_frequency/test_grid_frequency.cpp
+++ b/source/test/test_grid_frequency/test_grid_frequency.cpp
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Jibril Sharafi
+//
+// Host unit tests for the pure grid frequency EMA. Run with:  pio test -e native
+// (On Windows the native toolchain is unreliable - run it from WSL.)
+//
+// These need no hardware: they verify the datasheet Eq.36 conversion, seeding,
+// range rejection, convergence onto a dithering input's sub-LSB mean (the whole
+// point of the Q24.8 filter) and the monotonic update counter that the 500 ms
+// sampler uses as its freshness gate.
+
+#include <unity.h>
+#include <cmath>
+#include "grid_frequency.h"
+
+using namespace GridFrequency;
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// Firmware values: 223.75 kHz PERIOD clock, 45-65 Hz validation window.
+static const Config CFG = {223750.0f, 45.0f, 65.0f};
+
+// Eq.36 reference for a (possibly fractional) period value.
+static float eq36(float period) { return 223750.0f / (period + 1.0f); }
+
+// PERIOD is ~4474 raw at exactly 50.000 Hz: 223750 / (4474 + 1) = 50.000
+static const int32_t PERIOD_50HZ = 4474;
+
+// ---------------------------------------------------------------------------
+// Eq.36 conversion
+// ---------------------------------------------------------------------------
+
+void test_eq36_nominal_50hz(void) {
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, 50.0f, rawFrequencyHz(CFG, PERIOD_50HZ));
+}
+
+void test_eq36_plus_one_matters(void) {
+    // Without the +1 the same register value reads ~11 mHz high.
+    float withPlusOne = rawFrequencyHz(CFG, PERIOD_50HZ);
+    float withoutPlusOne = 223750.0f / float(PERIOD_50HZ);
+    TEST_ASSERT_FLOAT_WITHIN(0.002f, 0.0112f, withoutPlusOne - withPlusOne);
+}
+
+void test_eq36_non_positive_period(void) {
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, rawFrequencyHz(CFG, 0));
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, rawFrequencyHz(CFG, -1));
+}
+
+// ---------------------------------------------------------------------------
+// Seeding
+// ---------------------------------------------------------------------------
+
+void test_unseeded_readout_is_zero(void) {
+    State s;
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, frequencyHz(s, CFG));
+}
+
+void test_first_valid_read_seeds_exactly(void) {
+    State s;
+    TEST_ASSERT_TRUE(update(s, CFG, PERIOD_50HZ));
+    TEST_ASSERT_TRUE(s.seeded);
+    TEST_ASSERT_EQUAL_INT32(PERIOD_50HZ << 8, s.emaPeriodQ8);
+    TEST_ASSERT_EQUAL_UINT32(1, s.updateCount);
+    // Readout equals the single-read conversion: no ramp from zero.
+    TEST_ASSERT_FLOAT_WITHIN(0.0001f, eq36(float(PERIOD_50HZ)), frequencyHz(s, CFG));
+}
+
+void test_invalid_reads_do_not_seed(void) {
+    State s;
+    TEST_ASSERT_FALSE(update(s, CFG, 0));     // dead read
+    TEST_ASSERT_FALSE(update(s, CFG, 3000));  // ~74.5 Hz, above max
+    TEST_ASSERT_FALSE(update(s, CFG, 5000));  // ~44.7 Hz, below min
+    TEST_ASSERT_FALSE(s.seeded);
+    TEST_ASSERT_EQUAL_UINT32(0, s.updateCount);
+    TEST_ASSERT_EQUAL_FLOAT(0.0f, frequencyHz(s, CFG));
+}
+
+// ---------------------------------------------------------------------------
+// Range rejection after seeding
+// ---------------------------------------------------------------------------
+
+void test_out_of_range_leaves_state_untouched(void) {
+    State s;
+    update(s, CFG, PERIOD_50HZ);
+    int32_t emaBefore = s.emaPeriodQ8;
+    uint32_t countBefore = s.updateCount;
+
+    TEST_ASSERT_FALSE(update(s, CFG, 3000));   // glitch high
+    TEST_ASSERT_FALSE(update(s, CFG, 65535));  // ~3.4 Hz, absurd
+    TEST_ASSERT_FALSE(update(s, CFG, -5));
+
+    TEST_ASSERT_EQUAL_INT32(emaBefore, s.emaPeriodQ8);
+    TEST_ASSERT_EQUAL_UINT32(countBefore, s.updateCount);
+}
+
+// ---------------------------------------------------------------------------
+// Convergence and sub-LSB resolution (the reason the filter exists)
+// ---------------------------------------------------------------------------
+
+void test_converges_to_dithering_mean(void) {
+    // The raw register dithers between adjacent codes almost every cycle;
+    // 50/50 between 4474 and 4475 means a true period of 4474.5. The EMA must
+    // settle onto that half-code value, which no single read can express.
+    State s;
+    for (int i = 0; i < 400; i++) update(s, CFG, (i % 2 == 0) ? 4474 : 4475);
+
+    // EMA ripple for an alternating square wave is ~alpha/(2-alpha) of the step
+    // (~0.07 LSB, ~0.75 mHz here) - assert within 1.5 mHz of the true mean.
+    TEST_ASSERT_FLOAT_WITHIN(0.0015f, eq36(4474.5f), frequencyHz(s, CFG));
+}
+
+void test_sub_lsb_duty_cycle_resolved(void) {
+    // 25% duty (one 4475 in four reads) = true period 4474.25. A plain-integer
+    // EMA freezes on 4474 and cannot see this at all; the Q8 fraction must.
+    State s;
+    for (int i = 0; i < 800; i++) update(s, CFG, (i % 4 == 0) ? 4475 : 4474);
+
+    float f = frequencyHz(s, CFG);
+    float expected = eq36(4474.25f);
+    float frozen = eq36(4474.0f); // what an integer EMA would report
+    TEST_ASSERT_FLOAT_WITHIN(0.0015f, expected, f);
+    // Must be clearly distinguishable from the integer-frozen answer (~2.8 mHz off).
+    TEST_ASSERT_TRUE(fabsf(f - frozen) > fabsf(f - expected));
+}
+
+void test_step_response_converges_both_directions(void) {
+    State s;
+    for (int i = 0; i < 300; i++) update(s, CFG, 4474);
+    // Step up: >>3 on a positive gap truncates toward zero, parking within
+    // 7 Q8 units (~0.027 LSB, ~0.3 mHz) below the target - accept 0.5 mHz.
+    for (int i = 0; i < 300; i++) update(s, CFG, 4475);
+    TEST_ASSERT_FLOAT_WITHIN(0.0005f, eq36(4475.0f), frequencyHz(s, CFG));
+    // Step down: arithmetic shift of the negative gap rounds away from zero,
+    // so it converges exactly.
+    for (int i = 0; i < 300; i++) update(s, CFG, 4474);
+    TEST_ASSERT_FLOAT_WITHIN(0.0005f, eq36(4474.0f), frequencyHz(s, CFG));
+}
+
+// ---------------------------------------------------------------------------
+// Update counter (freshness gate for the 500 ms sampler)
+// ---------------------------------------------------------------------------
+
+void test_counter_advances_only_on_accept(void) {
+    State s;
+    update(s, CFG, PERIOD_50HZ);
+    update(s, CFG, PERIOD_50HZ + 1);
+    TEST_ASSERT_EQUAL_UINT32(2, s.updateCount);
+
+    update(s, CFG, 0);
+    update(s, CFG, 3000);
+    TEST_ASSERT_EQUAL_UINT32(2, s.updateCount);
+
+    update(s, CFG, PERIOD_50HZ);
+    TEST_ASSERT_EQUAL_UINT32(3, s.updateCount);
+}
+
+// ---------------------------------------------------------------------------
+
+int main(int argc, char** argv) {
+    (void)argc;
+    (void)argv;
+    UNITY_BEGIN();
+
+    RUN_TEST(test_eq36_nominal_50hz);
+    RUN_TEST(test_eq36_plus_one_matters);
+    RUN_TEST(test_eq36_non_positive_period);
+
+    RUN_TEST(test_unseeded_readout_is_zero);
+    RUN_TEST(test_first_valid_read_seeds_exactly);
+    RUN_TEST(test_invalid_reads_do_not_seed);
+
+    RUN_TEST(test_out_of_range_leaves_state_untouched);
+
+    RUN_TEST(test_converges_to_dithering_mean);
+    RUN_TEST(test_sub_lsb_duty_cycle_resolved);
+    RUN_TEST(test_step_response_converges_both_directions);
+
+    RUN_TEST(test_counter_advances_only_on_accept);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- Adds a full grid frequency/voltage telemetry pipeline: per-cycle ZXV interrupt EMA, a 500ms wall-clock-aligned grid sampler task, a dedicated batched MQTT grid topic (`send_grid_data` flag, cloud-settable via shadow), and a live grid frequency chart on the waveform page.
- Fixes a device crash bug found via commit-by-commit bisect: the new grid sampler task's stack was undersized (3 KB), overflowing into adjacent heap in the `-O0` dev build and surfacing later as an unrelated heap-poisoning panic. Bumped to 6 KB; validated with 6/6 clean device restarts (vs. 4-5/5 crashes before).
- Wires the grid sampler task into `/system/info` task monitoring (it existed but was never exposed, unlike the other ADE7953 tasks).
- Corrects stale comments/log lines that claimed certain tasks run on a PSRAM stack (a scheme tried in the past and dropped) - all task stacks are internal RAM.

## Test plan
- [x] `pio run -e esp32s3-dev` builds clean
- [x] Bisected the crash commit-by-commit against `development` on bench device 192.168.2.174, isolating the exact cause
- [x] 6/6 clean restarts on this branch's HEAD with the fix applied (crash-free, grid sampler stack usage ~54%)
- [ ] Jibril: hardware sanity check on grid frequency/voltage readings against a known-good reference

Closes #157

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>