### PR TITLE
feat(mqtt): shadow-configurable meter publish cadence

### DIFF
--- a/openspec/changes/configurable-meter-publish-rate/.openspec.yaml
+++ b/openspec/changes/configurable-meter-publish-rate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/configurable-meter-publish-rate/design.md
+++ b/openspec/changes/configurable-meter-publish-rate/design.md
@@ -1,0 +1,56 @@
+## Context
+
+`_checkIfPublishMeterNeeded()` (`source/src/mqtt.cpp:1703-1720`) triggers a meter publish on an OR of two hardcoded constants from `source/include/mqtt.h`:
+- `AWS_IOT_CORE_MQTT_PAYLOAD_MINIMUM_BILLABLE` (5 KB) - queue-size trigger, chosen to match AWS IoT Core's per-message billing floor so small payloads aren't sent at a billing loss.
+- `MQTT_MAX_INTERVAL_METER_PUBLISH` (60 s) - fallback ceiling so voltage/energy data still goes out even when the queue never fills.
+
+The `system` shadow (`source/src/shadow.cpp`, `_reportSystem`/`_applySystem`) already exposes `send_power_data` and `send_grid_data` as cloud-settable, NVS-persisted booleans, following a well-established delta-apply-persist-ack pattern. This change extends that same shadow and pattern with two numeric fields instead of introducing a new shadow or a new mechanism.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let the cloud change meter publish cadence at runtime, no reflash.
+- Reuse the exact existing `system` shadow config pattern (getter/setter, NVS key, delta-apply, ack-with-desired-null).
+- Keep the device fully stateless with respect to *why* a value is set - it only ever sees two numbers.
+- Preserve current fleet behavior by default (defaults identical to today's hardcoded constants).
+- Guard against a bad or forgotten write causing a publish storm or an oversized payload.
+
+**Non-Goals:**
+- No on-device "mode" concept (no `realtime`/`normal`/`night` enum) - scaling the two raw numbers together already spans the full range from batched to near-real-time.
+- No cloud-side scheduling, automation, or auto-revert logic (EventBridge cron, "fair mode" button, dead-man's switch) - that is cloud/infra work, entirely out of scope for this firmware change.
+- No change to grid publishing (`MQTT_GRID_PUBLISH_ALIGN_SECONDS`) - separate trigger, separate future change if ever needed.
+- No change to the OR trigger shape itself (size OR time) - only its two operands become configurable.
+
+## Decisions
+
+**Two independent numeric fields, not a single "mode" enum.**
+An enum (`normal`/`realtime`/`batch`) would need firmware-side preset tables and hides the actual numbers from whoever is tuning cadence from the cloud. Two raw fields keep the device as a pure function of (threshold, interval) and push all policy - including any future presets - to the cloud side, which already has the shadow desired/reported mechanism to express it.
+
+**Extend the existing `system` shadow, don't add a new shadow.**
+The `meter` shadow already exists but is scoped to ADE7953 calibration + sample_time (physical measurement config). Publish cadence is telemetry-transport config, the same category as `send_power_data`/`send_grid_data`, both of which already live in `system`. Adding a fourth named shadow would fragment related transport-behavior config across two shadows for no benefit.
+
+**Defaults equal today's hardcoded constants.**
+`meter_publish_threshold_bytes` defaults to `AWS_IOT_CORE_MQTT_PAYLOAD_MINIMUM_BILLABLE` (5120), `meter_publish_max_interval_ms` defaults to `MQTT_MAX_INTERVAL_METER_PUBLISH` (60000). A device that has never received a `desired` for these fields behaves identically to today.
+
+**Clamp, don't reject-and-ignore, out-of-range values.**
+Following the existing `_applySystem` pattern (e.g. rejecting a non-boolean `send_power_data` with a WARN and applying nothing), an out-of-range numeric value is clamped to the nearest valid bound and the clamped value is what gets persisted, reported, and logged - rather than silently ignoring the whole field. This keeps the ack (`reported`) always truthful about what the device is actually doing, which matters more for a manually-operated "dial down for the fair" field than a strict reject would.
+
+**Bounds:**
+- `meter_publish_threshold_bytes`: floor at some small non-zero value (e.g. 256 B, enough for a handful of entries so the trigger is meaningful but can go well below the 5 KB billing floor for real-time use); ceiling at `AWS_IOT_CORE_MQTT_PAYLOAD_LIMIT * MQTT_METER_PAYLOAD_THRESHOLD_MULTIPLIER` (matches the existing safety margin already used elsewhere for the 128 KB AWS limit).
+- `meter_publish_max_interval_ms`: floor at roughly `MQTT_LOOP_INTERVAL` (100 ms) - below the task's own poll cadence, a smaller value can't have any effect and only risks the device believing it's meeting an SLA it isn't; ceiling generous (e.g. 24 h) since a long interval is just "batch a lot," same risk class as today's default.
+
+## Risks / Trade-offs
+
+- **Real-time mode intentionally under-bills relative to actual usage** (payload &lt; 5 KB still costs a full AWS billing unit per message) → acceptable and expected trade-off for short, deliberate windows (a few hours at a fair); not a firmware concern, calling it out here only so it's not mistaken for a bug later.
+- **Left-on real-time mode after the fair could run indefinitely at elevated message rate/cost** → explicitly out of scope for this change (cloud-side revert job), but worth flagging loudly in the proposal/PR so it isn't lost.
+- **Clamping instead of rejecting could mask an operator typo** (e.g. asked for 5000 ms, typo'd 50000000 clamps silently to the 24 h ceiling instead of erroring) → mitigated by always logging the clamp at WARN and always reporting the clamped value back, so the cloud-side caller can see the actual applied value in `reported` and notice the mismatch.
+- **Two separate NVS writes on a single delta could interleave with a crash mid-write** → follow the existing `_configMutex`-guarded, copy-under-mutex-then-persist pattern already used elsewhere in the config modules; no new risk beyond what already exists for multi-field shadow deltas.
+
+## Migration Plan
+
+No migration needed - new NVS keys default to the current hardcoded constants when absent (first boot after the firmware update, or any device that has never received a `desired` for these fields). No breaking change to shadow shape; existing `send_power_data`/`send_grid_data` fields are untouched.
+
+## Open Questions
+
+- Exact floor for `meter_publish_threshold_bytes` (256 B suggested) - fine-tune once real payload sizes at low channel counts are checked against `MQTT_METER_ESTIMATED_PER_ENTRY`.
+- Should the two new field names be `meter_publish_threshold_bytes` / `meter_publish_max_interval_ms` (snake_case, matching `send_power_data`/`send_grid_data`) - assumed yes for shadow-field consistency, confirm during implementation.

--- a/openspec/changes/configurable-meter-publish-rate/proposal.md
+++ b/openspec/changes/configurable-meter-publish-rate/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Meter data to AWS IoT Core is gated by two compile-time constants: a 5 KB queue-size threshold (`AWS_IOT_CORE_MQTT_PAYLOAD_MINIMUM_BILLABLE`, chosen to match AWS IoT Core's per-message billing floor) and a 60 s fallback ceiling (`MQTT_MAX_INTERVAL_METER_PUBLISH`). Changing publish cadence today means editing a `#define` and reflashing. There's a real need to dial this per situation without a reflash - e.g. batch more aggressively overnight for cost efficiency, or batch far less during a live demo (upcoming trade fair) so remote viewers see near real-time data. The device should stay a dumb, stateless executor of whatever cadence the cloud currently wants; scheduling *when* to change cadence (day/night, demo mode, etc.) is a cloud-side concern, out of scope here.
+
+## What Changes
+
+- Add two new fields to the existing cloud-settable `system` shadow, alongside `send_power_data`/`send_grid_data`: a byte-size threshold and a max-interval-ms ceiling for meter publishing.
+- Both fields are persisted to NVS (survive reboot) and applied at runtime through the existing shadow delta-apply path (same pattern as `send_power_data`).
+- `_checkIfPublishMeterNeeded()` reads the two values from config instead of the hardcoded constants. The OR logic (size trigger OR time trigger) is unchanged - no new "mode" branching on-device.
+- Firmware defaults are unchanged (5 KB / 60 s) so fleet behavior is identical until the cloud explicitly writes a `desired`.
+- Add clamp/validation bounds in the `system` shadow's apply path so a bad or accidental write (e.g. `0`) can't cause a publish storm or exceed the AWS message size limit.
+
+## Capabilities
+
+### New Capabilities
+- `meter-publish-cadence`: the device-side mechanism that decides when to flush the queued meter payload to AWS IoT Core, driven by a configurable byte threshold and a configurable max-interval ceiling.
+
+### Modified Capabilities
+- `iot-device-shadows`: the `system` shadow gains two new writable fields (meter publish threshold bytes, meter publish max interval ms), following the same delta-apply, persist, and ack-with-desired-null pattern as existing `system` fields, with added validation/clamping.
+
+## Impact
+
+- `source/include/mqtt.h`: two constants become defaults instead of fixed values; new NVS preference keys.
+- `source/src/mqtt.cpp`: `_checkIfPublishMeterNeeded()` reads config values; add getter/setter pair (mirroring `getSendPowerData`/`setSendPowerData`).
+- `source/src/shadow.cpp`: `_reportSystem`/`_applySystem` gain the two new fields with validation.
+- No change to the byte-threshold-vs-interval OR logic, no change to grid publishing (`MQTT_GRID_PUBLISH_ALIGN_SECONDS` untouched - possible future follow-up, not in scope), no cloud/infra-side changes (scheduling automation lives in energyme-infra, out of scope for this repo).

--- a/openspec/changes/configurable-meter-publish-rate/specs/iot-device-shadows/spec.md
+++ b/openspec/changes/configurable-meter-publish-rate/specs/iot-device-shadows/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: System shadow exposes meter publish cadence fields
+The `system` shadow SHALL expose `meter_publish_threshold_bytes` and `meter_publish_max_interval_ms` as writable fields, following the same delta-apply-persist-ack pattern as `send_power_data`/`send_grid_data`: a delta sets the field, the device persists it to NVS, and the same publish carries both the new `reported` value and `desired:{<field>:null}`.
+
+#### Scenario: Field applied and intent cleared in one publish
+- **WHEN** a valid `system` delta sets `meter_publish_threshold_bytes` or `meter_publish_max_interval_ms`
+- **THEN** the device persists the (possibly clamped) value and publishes `reported=<applied>` and `desired:{<field>:null}` in the same message
+
+#### Scenario: Reconnect reports current cadence values
+- **WHEN** the MQTT client (re)connects
+- **THEN** the `system` shadow's full reported state includes the current `meter_publish_threshold_bytes` and `meter_publish_max_interval_ms`, alongside the existing fields

--- a/openspec/changes/configurable-meter-publish-rate/specs/meter-publish-cadence/spec.md
+++ b/openspec/changes/configurable-meter-publish-rate/specs/meter-publish-cadence/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Configurable meter publish trigger
+The device SHALL trigger an AWS IoT Core meter publish when EITHER the estimated queued meter payload size reaches a configurable byte threshold (`meter_publish_threshold_bytes`) AND power-data sending is enabled, OR the time since the last meter publish exceeds a configurable max interval (`meter_publish_max_interval_ms`). Both values SHALL default to the device's built-in constants (5120 bytes / 60000 ms) until the cloud sets a different `desired` value via the `system` shadow. Neither value SHALL introduce any on-device notion of a publish "mode" - the trigger logic SHALL remain the same OR of size-or-time regardless of what the two values are set to.
+
+#### Scenario: Default cadence unchanged from today
+- **WHEN** a device has never received a `desired` for `meter_publish_threshold_bytes` or `meter_publish_max_interval_ms`
+- **THEN** it publishes meter data exactly as it does today (5 KB queue threshold OR 60 s ceiling)
+
+#### Scenario: Cloud dials cadence down for near-real-time publishing
+- **WHEN** the cloud sets `meter_publish_threshold_bytes` to a small value and `meter_publish_max_interval_ms` to a few seconds
+- **THEN** the device publishes far more frequently, using the same OR trigger, with no separate "real-time mode" code path
+
+#### Scenario: Cloud dials cadence up for batching
+- **WHEN** the cloud sets both values higher than today's defaults
+- **THEN** the device accumulates a larger queue and/or waits longer before publishing, using the same OR trigger
+
+### Requirement: Meter publish cadence values are clamped, not rejected
+An out-of-range `meter_publish_threshold_bytes` or `meter_publish_max_interval_ms` delta value SHALL be clamped to the nearest valid bound rather than ignored. The clamped value SHALL be the one persisted to NVS, applied at runtime, reported back to the shadow, and logged at WARN.
+
+#### Scenario: Threshold below floor is clamped
+- **WHEN** a delta sets `meter_publish_threshold_bytes` below the minimum floor
+- **THEN** the device persists and reports the floor value instead, and logs a WARN
+
+#### Scenario: Interval above ceiling is clamped
+- **WHEN** a delta sets `meter_publish_max_interval_ms` above the maximum ceiling
+- **THEN** the device persists and reports the ceiling value instead, and logs a WARN

--- a/openspec/changes/configurable-meter-publish-rate/tasks.md
+++ b/openspec/changes/configurable-meter-publish-rate/tasks.md
@@ -1,0 +1,35 @@
+## 1. Constants and NVS keys
+
+- [x] 1.1 In `source/include/mqtt.h`, rename/repurpose `AWS_IOT_CORE_MQTT_PAYLOAD_MINIMUM_BILLABLE` usage and `MQTT_MAX_INTERVAL_METER_PUBLISH` as *default* values (keep the existing constants as the defaults; do not change their values).
+- [x] 1.2 Add `MQTT_METER_PUBLISH_THRESHOLD_BYTES_MIN` / `_MAX` and `MQTT_METER_PUBLISH_MAX_INTERVAL_MS_MIN` / `_MAX` clamp-bound constants per design.md.
+- [x] 1.3 Add NVS preference keys (e.g. `MQTT_PREFERENCES_METER_PUBLISH_THRESHOLD_KEY`, `MQTT_PREFERENCES_METER_PUBLISH_INTERVAL_KEY`), following the existing `MQTT_PREFERENCES_SEND_POWER_DATA_KEY` naming pattern.
+
+## 2. Config getters/setters in mqtt.cpp
+
+- [x] 2.1 Add persisted config state + getter/setter pair for `meter_publish_threshold_bytes`, mirroring `getSendPowerData`/`setSendPowerData` (load from NVS on boot, default to the existing constant if absent).
+- [x] 2.2 Add persisted config state + getter/setter pair for `meter_publish_max_interval_ms`, same pattern.
+- [x] 2.3 Clamp both setters to the Section 1.2 bounds using `std::clamp` (`<algorithm>`); log a WARN when the clamped value differs from the request, so callers can see it via `reported`.
+- [x] 2.4 Declare the new getters/setters in `source/include/mqtt.h`'s `Mqtt` namespace, alongside `getSendPowerData`/`setSendPowerData`.
+
+## 3. Wire into the publish trigger
+
+- [x] 3.1 Update `_checkIfPublishMeterNeeded()` (`source/src/mqtt.cpp`) to read the threshold and max-interval from the new getters instead of the hardcoded constants. Keep the OR logic (size-trigger AND power-enabled) OR (time-trigger) exactly as-is.
+- [x] 3.2 Confirm `MQTT_METER_ESTIMATED_ENERGY_VOLTAGE_OVERHEAD_BYTES` and the estimated-size math still make sense against a threshold that may now be far below 5 KB (i.e. no divide-by-zero or negative-size edge case when threshold is near the floor).
+
+## 4. System shadow integration
+
+- [x] 4.1 In `source/src/shadow.cpp::_reportSystem`, add `meter_publish_threshold_bytes` and `meter_publish_max_interval_ms` to the reported JSON, reading from the new getters.
+- [x] 4.2 In `_applySystem`, handle deltas for both fields: validate non-negative integer, persist via the new setters (which clamp and WARN internally, per 2.3), and include the applied (possibly clamped) value read back from the getter in the combined `reported`+`desired:null` ack publish - matching the existing `send_power_data` delta-apply block.
+- [x] 4.3 Reject (log WARN, apply nothing) non-integer values for either field, matching the existing "Rejected send_power_data: not a boolean" pattern.
+
+## 5. Tests
+
+- [x] 5.1 No new native unit tests needed: clamping uses `std::clamp` (already covered by the standard library, not worth re-testing) and the trigger logic stays inline in `_checkIfPublishMeterNeeded` rather than being extracted to `lib/` (avoids an extra module for two conditions that are trivial to read in place). Verification is hardware/e2e only (Section 6).
+- [x] 5.2 Confirm `pio test -e native` still passes unchanged (no test regressions from this change, since nothing new was added to `lib/`).
+
+## 6. Hardware verification (dev device)
+
+- [ ] 6.1 Flash dev build to a bench device; confirm default behavior (no shadow write yet) matches today's cadence (5 KB / 60 s) via UDP log capture.
+- [ ] 6.2 Push a `system` shadow `desired` lowering both values (e.g. small threshold, few-second interval); confirm via UDP logs and the reported shadow that the device applies, persists, and acks correctly, and that publish frequency visibly increases.
+- [ ] 6.3 Push an out-of-range `desired` (e.g. 0, or above ceiling) and confirm the device clamps, logs a WARN, and reports the clamped value rather than the requested one.
+- [ ] 6.4 Reboot the device with a non-default persisted value set; confirm it boots back into that same cadence (NVS persistence) rather than reverting to firmware defaults.

--- a/openspec/changes/configurable-meter-publish-rate/tasks.md
+++ b/openspec/changes/configurable-meter-publish-rate/tasks.md
@@ -29,7 +29,7 @@
 
 ## 6. Hardware verification (dev device)
 
-- [ ] 6.1 Flash dev build to a bench device; confirm default behavior (no shadow write yet) matches today's cadence (5 KB / 60 s) via UDP log capture.
-- [ ] 6.2 Push a `system` shadow `desired` lowering both values (e.g. small threshold, few-second interval); confirm via UDP logs and the reported shadow that the device applies, persists, and acks correctly, and that publish frequency visibly increases.
-- [ ] 6.3 Push an out-of-range `desired` (e.g. 0, or above ceiling) and confirm the device clamps, logs a WARN, and reports the clamped value rather than the requested one.
-- [ ] 6.4 Reboot the device with a non-default persisted value set; confirm it boots back into that same cadence (NVS persistence) rather than reverting to firmware defaults.
+- [x] 6.1 Flash dev build to a bench device; confirm default behavior (no shadow write yet) matches today's cadence (5 KB / 60 s) via UDP log capture.
+- [x] 6.2 Push a `system` shadow `desired` lowering both values (e.g. small threshold, few-second interval); confirm via UDP logs and the reported shadow that the device applies, persists, and acks correctly, and that publish frequency visibly increases.
+- [x] 6.3 Push an out-of-range `desired` (e.g. 0, or above ceiling) and confirm the device clamps, logs a WARN, and reports the clamped value rather than the requested one.
+- [x] 6.4 Reboot the device with a non-default persisted value set; confirm it boots back into that same cadence (NVS persistence) rather than reverting to firmware defaults.

--- a/source/include/mqtt.h
+++ b/source/include/mqtt.h
@@ -92,6 +92,19 @@
 #define AWS_IOT_CORE_MQTT_PAYLOAD_LIMIT (128 * 1024) // Limit of AWS
 #define MQTT_METER_PAYLOAD_THRESHOLD_MULTIPLIER 0.95 // Multiplier to avoid reaching exactly the limit
 
+// Meter publish cadence: shadow-configurable via the `system` shadow
+// (meter_publish_threshold_bytes / meter_publish_max_interval_ms), so cadence
+// can be dialed down for near-real-time viewing or up for cost-efficient
+// batching without a reflash. Defaults match today's fixed behavior; bounds
+// guard against a bad/forgotten write causing a publish storm or an
+// oversized payload (see openspec/changes/configurable-meter-publish-rate).
+#define MQTT_METER_PUBLISH_THRESHOLD_BYTES_DEFAULT AWS_IOT_CORE_MQTT_PAYLOAD_MINIMUM_BILLABLE
+#define MQTT_METER_PUBLISH_THRESHOLD_BYTES_MIN 256 // Small enough to allow near-real-time publishing, big enough to be a meaningful trigger
+#define MQTT_METER_PUBLISH_THRESHOLD_BYTES_MAX ((uint32_t)(AWS_IOT_CORE_MQTT_PAYLOAD_LIMIT * MQTT_METER_PAYLOAD_THRESHOLD_MULTIPLIER))
+#define MQTT_METER_PUBLISH_MAX_INTERVAL_MS_DEFAULT MQTT_MAX_INTERVAL_METER_PUBLISH
+#define MQTT_METER_PUBLISH_MAX_INTERVAL_MS_MIN MQTT_LOOP_INTERVAL // Below the task's own poll cadence, a smaller value has no effect
+#define MQTT_METER_PUBLISH_MAX_INTERVAL_MS_MAX (24UL * 60 * 60 * 1000) // 24 h ceiling - a long interval is just "batch a lot"
+
 #define MQTT_INITIAL_RETRY_INTERVAL (15 * 1000) // Base delay for exponential backoff in milliseconds
 #define MQTT_MAX_RETRY_INTERVAL (60 * 60 * 1000) // Maximum delay for exponential backoff in milliseconds
 #define MQTT_RETRY_MULTIPLIER 2 // Multiplier for exponential backoff
@@ -99,6 +112,8 @@
 #define MQTT_PREFERENCES_IS_CLOUD_SERVICES_ENABLED_KEY "en_cloud"
 #define MQTT_PREFERENCES_SEND_POWER_DATA_KEY "send_power"
 #define MQTT_PREFERENCES_SEND_GRID_DATA_KEY "send_grid"
+#define MQTT_PREFERENCES_METER_PUBLISH_THRESHOLD_KEY "meter_pub_thr"
+#define MQTT_PREFERENCES_METER_PUBLISH_INTERVAL_KEY "meter_pub_int"
 #define MQTT_PREFERENCES_MQTT_LOG_LEVEL_KEY "log_level_int"
 #define MQTT_PREFERENCES_TRANSIENT_LOG_LEVEL_KEY "transient_log" // active transient (VERBOSE/DEBUG) level, persisted so a debug session survives a reboot; absent = none
 
@@ -188,6 +203,10 @@ namespace Mqtt
     void setSendPowerData(bool enabled);     // persisted
     bool getSendGridData();
     void setSendGridData(bool enabled);      // persisted; cloud-settable via the system shadow
+    uint32_t getMeterPublishThresholdBytes();
+    void setMeterPublishThresholdBytes(uint32_t bytes);     // persisted; clamped to [MIN,MAX]; cloud-settable via the system shadow
+    uint32_t getMeterPublishMaxIntervalMs();
+    void setMeterPublishMaxIntervalMs(uint32_t intervalMs); // persisted; clamped to [MIN,MAX]; cloud-settable via the system shadow
 
 #ifdef ENV_DEV
     // Dev-only: inject a synthetic IoT Command execution through the real handler

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -7,6 +7,7 @@
 #include "taskprofiler.h"
 #include "duration_format.h"
 #include "mqtt_grid_schedule.h"
+#include <algorithm>
 
 namespace Mqtt
 {
@@ -54,6 +55,8 @@ namespace Mqtt
     static bool _cloudServicesEnabled = DEFAULT_CLOUD_SERVICES_ENABLED;
     static bool _sendPowerDataEnabled = DEFAULT_SEND_POWER_DATA_ENABLED;
     static bool _sendGridDataEnabled = DEFAULT_SEND_GRID_DATA_ENABLED;
+    static uint32_t _meterPublishThresholdBytes = MQTT_METER_PUBLISH_THRESHOLD_BYTES_DEFAULT;
+    static uint32_t _meterPublishMaxIntervalMs = MQTT_METER_PUBLISH_MAX_INTERVAL_MS_DEFAULT;
     static uint8_t _mqttLogLevelInt = DEFAULT_MQTT_LOG_LEVEL_INT;
     static LogLevel _mqttMinLogLevel = LogLevel::INFO;
 
@@ -100,12 +103,16 @@ namespace Mqtt
     
     static void _setSendPowerDataEnabled(bool enabled);
     static void _setSendGridDataEnabled(bool enabled);
+    static void _setMeterPublishThresholdBytes(uint32_t bytes);
+    static void _setMeterPublishMaxIntervalMs(uint32_t intervalMs);
     static void _setMqttLogLevel(const char* logLevel);
     static void _updateMqttMinLogLevel();
 
     static void _saveCloudServicesEnabledToPreferences(bool enabled);
     static void _saveSendPowerDataEnabledToPreferences(bool enabled);
     static void _saveSendGridDataEnabledToPreferences(bool enabled);
+    static void _saveMeterPublishThresholdBytesToPreferences(uint32_t bytes);
+    static void _saveMeterPublishMaxIntervalMsToPreferences(uint32_t intervalMs);
     static void _saveMqttLogLevelToPreferences(uint8_t logLevel);
         
     // Task management
@@ -510,6 +517,14 @@ namespace Mqtt
 
     void setSendGridData(bool enabled) { _setSendGridDataEnabled(enabled); } // persists
 
+    uint32_t getMeterPublishThresholdBytes() { return _meterPublishThresholdBytes; }
+
+    void setMeterPublishThresholdBytes(uint32_t bytes) { _setMeterPublishThresholdBytes(bytes); } // persists, clamped
+
+    uint32_t getMeterPublishMaxIntervalMs() { return _meterPublishMaxIntervalMs; }
+
+    void setMeterPublishMaxIntervalMs(uint32_t intervalMs) { _setMeterPublishMaxIntervalMs(intervalMs); } // persists, clamped
+
     // Private functions
     // =================
     // =================
@@ -640,13 +655,18 @@ namespace Mqtt
         _cloudServicesEnabled = prefs.getBool(MQTT_PREFERENCES_IS_CLOUD_SERVICES_ENABLED_KEY, DEFAULT_CLOUD_SERVICES_ENABLED);
         _sendPowerDataEnabled = prefs.getBool(MQTT_PREFERENCES_SEND_POWER_DATA_KEY, DEFAULT_SEND_POWER_DATA_ENABLED);
         _sendGridDataEnabled = prefs.getBool(MQTT_PREFERENCES_SEND_GRID_DATA_KEY, DEFAULT_SEND_GRID_DATA_ENABLED);
+        _meterPublishThresholdBytes = prefs.getUInt(MQTT_PREFERENCES_METER_PUBLISH_THRESHOLD_KEY, MQTT_METER_PUBLISH_THRESHOLD_BYTES_DEFAULT);
+        _meterPublishMaxIntervalMs = prefs.getUInt(MQTT_PREFERENCES_METER_PUBLISH_INTERVAL_KEY, MQTT_METER_PUBLISH_MAX_INTERVAL_MS_DEFAULT);
         _mqttLogLevelInt = prefs.getUChar(MQTT_PREFERENCES_MQTT_LOG_LEVEL_KEY, DEFAULT_MQTT_LOG_LEVEL_INT);
         _updateMqttMinLogLevel(); // Convert integer to LogLevel enum
 
-        LOG_DEBUG("Cloud services enabled: %s, Send power data enabled: %s, Send grid data enabled: %s, MQTT log level: %u",
+        LOG_DEBUG("Cloud services enabled: %s, Send power data enabled: %s, Send grid data enabled: %s, "
+                   "Meter publish threshold: %u bytes, Meter publish max interval: %u ms, MQTT log level: %u",
                    _cloudServicesEnabled ? "true" : "false",
                    _sendPowerDataEnabled ? "true" : "false",
                    _sendGridDataEnabled ? "true" : "false",
+                   _meterPublishThresholdBytes,
+                   _meterPublishMaxIntervalMs,
                    _mqttLogLevelInt);
 
         prefs.end();
@@ -661,6 +681,8 @@ namespace Mqtt
         _saveCloudServicesEnabledToPreferences(_cloudServicesEnabled);
         _saveSendPowerDataEnabledToPreferences(_sendPowerDataEnabled);
         _saveSendGridDataEnabledToPreferences(_sendGridDataEnabled);
+        _saveMeterPublishThresholdBytesToPreferences(_meterPublishThresholdBytes);
+        _saveMeterPublishMaxIntervalMsToPreferences(_meterPublishMaxIntervalMs);
         _saveMqttLogLevelToPreferences(_mqttLogLevelInt);
         
         LOG_DEBUG("MQTT preferences saved");
@@ -678,6 +700,30 @@ namespace Mqtt
         _sendGridDataEnabled = enabled;
         _saveSendGridDataEnabledToPreferences(enabled);
         LOG_DEBUG("Set send grid data enabled to %s", enabled ? "true" : "false");
+    }
+
+    static void _setMeterPublishThresholdBytes(uint32_t bytes)
+    {
+        uint32_t clamped = std::clamp<uint32_t>(bytes, MQTT_METER_PUBLISH_THRESHOLD_BYTES_MIN, MQTT_METER_PUBLISH_THRESHOLD_BYTES_MAX);
+        if (clamped != bytes) {
+            LOG_WARNING("Requested meter publish threshold %u bytes out of range [%u, %u], clamped to %u bytes",
+                        bytes, MQTT_METER_PUBLISH_THRESHOLD_BYTES_MIN, MQTT_METER_PUBLISH_THRESHOLD_BYTES_MAX, clamped);
+        }
+        _meterPublishThresholdBytes = clamped;
+        _saveMeterPublishThresholdBytesToPreferences(clamped);
+        LOG_DEBUG("Set meter publish threshold to %u bytes", clamped);
+    }
+
+    static void _setMeterPublishMaxIntervalMs(uint32_t intervalMs)
+    {
+        uint32_t clamped = std::clamp<uint32_t>(intervalMs, MQTT_METER_PUBLISH_MAX_INTERVAL_MS_MIN, MQTT_METER_PUBLISH_MAX_INTERVAL_MS_MAX);
+        if (clamped != intervalMs) {
+            LOG_WARNING("Requested meter publish max interval %u ms out of range [%u, %u], clamped to %u ms",
+                        intervalMs, MQTT_METER_PUBLISH_MAX_INTERVAL_MS_MIN, MQTT_METER_PUBLISH_MAX_INTERVAL_MS_MAX, clamped);
+        }
+        _meterPublishMaxIntervalMs = clamped;
+        _saveMeterPublishMaxIntervalMsToPreferences(clamped);
+        LOG_DEBUG("Set meter publish max interval to %u ms", clamped);
     }
 
     static void _updateMqttMinLogLevel()
@@ -756,6 +802,26 @@ namespace Mqtt
         prefs.begin(PREFERENCES_NAMESPACE_MQTT, false);
         size_t bytesWritten = prefs.putBool(MQTT_PREFERENCES_SEND_GRID_DATA_KEY, enabled);
         if (bytesWritten == 0) LOG_ERROR("Failed to save send grid data enabled preference");
+
+        prefs.end();
+    }
+
+    static void _saveMeterPublishThresholdBytesToPreferences(uint32_t bytes) {
+        Preferences prefs;
+
+        prefs.begin(PREFERENCES_NAMESPACE_MQTT, false);
+        size_t bytesWritten = prefs.putUInt(MQTT_PREFERENCES_METER_PUBLISH_THRESHOLD_KEY, bytes);
+        if (bytesWritten == 0) LOG_ERROR("Failed to save meter publish threshold preference");
+
+        prefs.end();
+    }
+
+    static void _saveMeterPublishMaxIntervalMsToPreferences(uint32_t intervalMs) {
+        Preferences prefs;
+
+        prefs.begin(PREFERENCES_NAMESPACE_MQTT, false);
+        size_t bytesWritten = prefs.putUInt(MQTT_PREFERENCES_METER_PUBLISH_INTERVAL_KEY, intervalMs);
+        if (bytesWritten == 0) LOG_ERROR("Failed to save meter publish max interval preference");
 
         prefs.end();
     }
@@ -1710,9 +1776,10 @@ namespace Mqtt
         // Real JSON size is checked during _publishMeterStreaming() with measureJson()
         // It is better to underestimate here (thus, the real payload will be more than 5kB) so we use all of the billable size
         // and only "risk" losing a few entries, which will just be published on the next cycle
+        // Threshold and max interval are shadow-configurable (system.meter_publish_threshold_bytes / max_interval_ms)
         if (
-            ((estimatedJsonSize >= AWS_IOT_CORE_MQTT_PAYLOAD_MINIMUM_BILLABLE) && _sendPowerDataEnabled) ||
-            ((millis64() - _lastMillisMeterPublished) > MQTT_MAX_INTERVAL_METER_PUBLISH)
+            ((estimatedJsonSize >= _meterPublishThresholdBytes) && _sendPowerDataEnabled) ||
+            ((millis64() - _lastMillisMeterPublished) > _meterPublishMaxIntervalMs)
         ) {
             _publishMqtt.meter = true;
             LOG_DEBUG("Set flag to publish meter data (queue: %u entries, real size checked during publish)", queueSize);

--- a/source/src/shadow.cpp
+++ b/source/src/shadow.cpp
@@ -591,6 +591,8 @@ static void _reportSystem(JsonDocument& doc) {
     rep["led_brightness"] = Led::getBrightness();
     rep["send_power_data"] = Mqtt::getSendPowerData();
     rep["send_grid_data"] = Mqtt::getSendGridData();
+    rep["meter_publish_threshold_bytes"] = Mqtt::getMeterPublishThresholdBytes();
+    rep["meter_publish_max_interval_ms"] = Mqtt::getMeterPublishMaxIntervalMs();
     rep["mqtt_log_level"] = ShadowLogic::logLevelToString(Mqtt::getMqttLogLevel());
     rep["log_level_print"] = AdvancedLogger::logLevelToString(AdvancedLogger::getPrintLevel());
     rep["log_level_save"] = AdvancedLogger::logLevelToString(AdvancedLogger::getSaveLevel());
@@ -647,6 +649,31 @@ static bool _applySystem(JsonObjectConst delta, JsonObject reported) {
             applied = true;
         } else {
             LOG_WARNING("Rejected send_grid_data: not a boolean");
+        }
+    }
+
+    // meter_publish_threshold_bytes / meter_publish_max_interval_ms: the setters
+    // clamp to their valid range (and WARN-log if a clamp occurred), so the
+    // reported value here is always the actual applied value, not the raw request.
+    v = delta["meter_publish_threshold_bytes"];
+    if (!v.isNull()) {
+        if (v.is<int>() && v.as<int>() >= 0) {
+            Mqtt::setMeterPublishThresholdBytes((uint32_t)v.as<int>()); // persists, clamped
+            reported["meter_publish_threshold_bytes"] = Mqtt::getMeterPublishThresholdBytes();
+            applied = true;
+        } else {
+            LOG_WARNING("Rejected meter_publish_threshold_bytes: not a non-negative integer");
+        }
+    }
+
+    v = delta["meter_publish_max_interval_ms"];
+    if (!v.isNull()) {
+        if (v.is<int>() && v.as<int>() >= 0) {
+            Mqtt::setMeterPublishMaxIntervalMs((uint32_t)v.as<int>()); // persists, clamped
+            reported["meter_publish_max_interval_ms"] = Mqtt::getMeterPublishMaxIntervalMs();
+            applied = true;
+        } else {
+            LOG_WARNING("Rejected meter_publish_max_interval_ms: not a non-negative integer");
         }
     }
 

--- a/source/utils/shadow_cli.py
+++ b/source/utils/shadow_cli.py
@@ -27,27 +27,27 @@ lists; info/issues/wifi are reported-only and not settable here).
 Examples
 --------
   # Generic set (any field on any writable shadow)
-  uv run utils/shadow_cli.py --host 192.168.1.111 set system led_brightness=20
+  uv run utils/shadow_cli.py set system led_brightness=20 --host 192.168.1.111
 
   # Convenience shorthands for things this repo tests often
-  uv run utils/shadow_cli.py --host 192.168.1.111 meter-cadence 1024 10000
-  uv run utils/shadow_cli.py --host 192.168.1.111 restore-cadence
-  uv run utils/shadow_cli.py --host 192.168.1.111 power-data off
-  uv run utils/shadow_cli.py --host 192.168.1.111 log-level print DEBUG
+  uv run utils/shadow_cli.py meter-cadence 1024 10000 --host 192.168.1.111
+  uv run utils/shadow_cli.py restore-cadence --host 192.168.1.111
+  uv run utils/shadow_cli.py power-data off --host 192.168.1.111
+  uv run utils/shadow_cli.py log-level print DEBUG --host 192.168.1.111
 
   # Per-channel config (channels shadow is keyed by channel index)
-  uv run utils/shadow_cli.py --host 192.168.1.111 channel 3 label="Kitchen" active=true
+  uv run utils/shadow_cli.py channel 3 label="Kitchen" active=true --host 192.168.1.111
 
   # Full escape hatch: raw state object for any shadow
-  uv run utils/shadow_cli.py --host 192.168.1.111 set-json meter '{"sample_time": 200}'
+  uv run utils/shadow_cli.py set-json meter '{"sample_time": 200}' --host 192.168.1.111
 
   # Best-effort local read (only fields with a local, non-shadow GET endpoint)
-  uv run utils/shadow_cli.py --host 192.168.1.111 get meter
-  uv run utils/shadow_cli.py --host 192.168.1.111 get channel 3
+  uv run utils/shadow_cli.py get meter --host 192.168.1.111
+  uv run utils/shadow_cli.py get channel 3 --host 192.168.1.111
 
   # IoT Commands (separate from shadow deltas, same dev-only injection path)
-  uv run utils/shadow_cli.py --host 192.168.1.111 command energy-reset --channels 0,2,5
-  uv run utils/shadow_cli.py --host 192.168.1.111 command restart --yes
+  uv run utils/shadow_cli.py command energy-reset --channels 0,2,5 --host 192.168.1.111
+  uv run utils/shadow_cli.py command restart --yes --host 192.168.1.111
 
 Every `set`/`channel`/shorthand command listens briefly on the UDP log port
 afterward (same port the device already sends AdvancedLogger syslog output
@@ -73,7 +73,7 @@ import requests
 from requests.auth import HTTPDigestAuth
 
 DEFAULT_USERNAME = "admin"
-DEFAULT_PASSWORD = "energyme"
+DEFAULT_PASSWORD = "energyme00"
 DEFAULT_WATCH_PORT = 514
 DEFAULT_WATCH_SECONDS = 3.0
 

--- a/source/utils/shadow_cli.py
+++ b/source/utils/shadow_cli.py
@@ -1,0 +1,413 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2025 Jibril Sharafi
+
+"""
+Shadow CLI for EnergyMe-Home
+=============================
+
+Drive a dev device's AWS IoT device-shadow apply logic locally, over plain
+HTTP, with no cloud round-trip. Wraps the dev-only endpoints registered in
+customserver.cpp (compiled only into esp32s3-dev, behind #ifdef ENV_DEV):
+
+    POST /api/v1/shadow/inject-delta    -> Shadow::injectDelta(name, doc)
+    POST /api/v1/shadow/inject-command  -> Mqtt::injectCommandExecution(id, payload)
+
+Both feed the device's real apply path (routeMessage -> task drain ->
+ApplyFn -> clamp/validate -> persist -> ack publish), so this exercises the
+exact same code as a real cloud shadow delta or a real IoT Command - the
+only difference is the delta/command originates from a local HTTP POST
+instead of AWS IoT Core. The device still tries to publish its resulting
+ack to AWS afterward; if it's offline or the payload's throwaway
+version/executionId doesn't match reality that publish may be rejected,
+but the local apply already happened by that point.
+
+Writable shadows: system, meter, channels (see shadow.cpp for the field
+lists; info/issues/wifi are reported-only and not settable here).
+
+Examples
+--------
+  # Generic set (any field on any writable shadow)
+  uv run utils/shadow_cli.py --host 192.168.1.111 set system led_brightness=20
+
+  # Convenience shorthands for things this repo tests often
+  uv run utils/shadow_cli.py --host 192.168.1.111 meter-cadence 1024 10000
+  uv run utils/shadow_cli.py --host 192.168.1.111 restore-cadence
+  uv run utils/shadow_cli.py --host 192.168.1.111 power-data off
+  uv run utils/shadow_cli.py --host 192.168.1.111 log-level print DEBUG
+
+  # Per-channel config (channels shadow is keyed by channel index)
+  uv run utils/shadow_cli.py --host 192.168.1.111 channel 3 label="Kitchen" active=true
+
+  # Full escape hatch: raw state object for any shadow
+  uv run utils/shadow_cli.py --host 192.168.1.111 set-json meter '{"sample_time": 200}'
+
+  # Best-effort local read (only fields with a local, non-shadow GET endpoint)
+  uv run utils/shadow_cli.py --host 192.168.1.111 get meter
+  uv run utils/shadow_cli.py --host 192.168.1.111 get channel 3
+
+  # IoT Commands (separate from shadow deltas, same dev-only injection path)
+  uv run utils/shadow_cli.py --host 192.168.1.111 command energy-reset --channels 0,2,5
+  uv run utils/shadow_cli.py --host 192.168.1.111 command restart --yes
+
+Every `set`/`channel`/shorthand command listens briefly on the UDP log port
+afterward (same port the device already sends AdvancedLogger syslog output
+to) and prints the lines confirming what was actually applied - so you get
+immediate feedback without needing a separate `get` or a second terminal
+running udp_log_listener.py. Pass --no-watch to skip this (e.g. if you
+already have udp_log_listener.py running and don't want two listeners
+racing for the same log lines - both can coexist via SO_REUSEADDR, but the
+device only sends once so only one process should print it if you want a
+single clean view).
+
+Requires the target device to be flashed with the esp32s3-dev build - the
+inject-* endpoints do not exist in esp32s3-prod.
+"""
+
+import argparse
+import socket
+import sys
+import time
+from typing import Any
+
+import requests
+from requests.auth import HTTPDigestAuth
+
+DEFAULT_USERNAME = "admin"
+DEFAULT_PASSWORD = "energyme"
+DEFAULT_WATCH_PORT = 514
+DEFAULT_WATCH_SECONDS = 3.0
+
+# Default watch filter: relevant shadow/command lines only, not the constant
+# _printMeterValues/_checkIfPublish*/streaming-publish chatter every task loop
+# produces. --watch-raw disables this and shows everything received.
+WATCH_KEYWORDS = ("shadow", "inject", "_set", "_apply", "rejected", "warning",
+                   "error", "command", "clamp")
+
+# Keep in sync with source/include/mqtt.h - only used by `restore-cadence` as
+# a convenience default, not read from firmware, so it can drift if those
+# constants change.
+FIRMWARE_DEFAULT_METER_THRESHOLD_BYTES = 5120
+FIRMWARE_DEFAULT_METER_MAX_INTERVAL_MS = 60000
+
+VALID_LOG_LEVELS = {"VERBOSE", "DEBUG", "INFO", "WARNING", "ERROR", "FATAL"}
+
+
+def _infer_value(raw: str) -> Any:
+    """Turn a CLI key=value's raw string into int/float/bool/string."""
+    low = raw.lower()
+    if low in ("true", "false"):
+        return low == "true"
+    try:
+        return int(raw)
+    except ValueError:
+        pass
+    try:
+        return float(raw)
+    except ValueError:
+        pass
+    return raw
+
+
+def _parse_kv_pairs(pairs: list[str]) -> dict:
+    """Parse ["a=1", "ctSpecification.ratedCurrent=30"] into a nested dict."""
+    state: dict = {}
+    for pair in pairs:
+        if "=" not in pair:
+            raise SystemExit(f"Expected key=value, got: {pair!r}")
+        key, raw_value = pair.split("=", 1)
+        value = _infer_value(raw_value)
+        parts = key.split(".")
+        cursor = state
+        for part in parts[:-1]:
+            cursor = cursor.setdefault(part, {})
+        cursor[parts[-1]] = value
+    return state
+
+
+class ShadowClient:
+    def __init__(self, host: str, username: str, password: str, timeout: float = 10.0):
+        self.base_url = f"http://{host}"
+        self.session = requests.Session()
+        self.session.auth = HTTPDigestAuth(username, password)
+        self.timeout = timeout
+
+    def inject_delta(self, shadow_name: str, state: dict, version: int = 1) -> dict:
+        body = {"name": shadow_name, "doc": {"version": version, "state": state}}
+        r = self.session.post(f"{self.base_url}/api/v1/shadow/inject-delta", json=body, timeout=self.timeout)
+        return self._result(r)
+
+    def inject_command(self, execution_id: str, payload: dict) -> dict:
+        body = {"executionId": execution_id, "payload": payload}
+        r = self.session.post(f"{self.base_url}/api/v1/shadow/inject-command", json=body, timeout=self.timeout)
+        return self._result(r)
+
+    def get_json(self, path: str, params: dict | None = None) -> dict:
+        r = self.session.get(f"{self.base_url}{path}", params=params, timeout=self.timeout)
+        return self._result(r)
+
+    @staticmethod
+    def _result(r: requests.Response) -> dict:
+        try:
+            data = r.json()
+        except ValueError:
+            data = {"raw": r.text}
+        if not r.ok:
+            print(f"HTTP {r.status_code}: {data}", file=sys.stderr)
+            raise SystemExit(1)
+        return data
+
+
+def _watch_udp(port: int, seconds: float, host_hint: str, raw: bool = False) -> None:
+    """Print syslog lines for a few seconds so a set/command is self-verifying.
+
+    Filtered to shadow/apply/command-relevant lines by default (see
+    WATCH_KEYWORDS) since the device's normal task-loop logging (meter
+    prints, publish-check chatter) would otherwise drown out the one or two
+    lines that actually confirm what got applied. Pass raw=True to see
+    everything received instead.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.settimeout(0.5)
+    try:
+        sock.bind(("0.0.0.0", port))
+    except OSError as e:
+        print(f"(skipping UDP watch: could not bind port {port}: {e})", file=sys.stderr)
+        print(f"Run utils/udp_log_listener.py separately against {host_hint} to see the result.", file=sys.stderr)
+        sock.close()
+        return
+
+    print(f"--- watching UDP log port {port} for {seconds:.0f}s"
+          f"{' (raw, unfiltered)' if raw else ''} ---")
+    deadline = time.time() + seconds
+    seen_any = False
+    try:
+        while time.time() < deadline:
+            try:
+                data, _ = sock.recvfrom(2048)
+            except socket.timeout:
+                continue
+            line = data.decode("utf-8", errors="ignore").strip()
+            if not line:
+                continue
+            seen_any = True
+            if raw or any(kw in line.lower() for kw in WATCH_KEYWORDS):
+                print(line)
+    finally:
+        sock.close()
+    if not seen_any:
+        print("(no log lines received - device may be logging elsewhere, offline, "
+              "or its UDP destination isn't pointed at this machine; see "
+              "utils/udp_log_listener.py --device-ip to configure it)")
+    print("--- end watch ---")
+
+
+def _do_set(client: ShadowClient, args, shadow_name: str, state: dict) -> None:
+    print(f"POST inject-delta name={shadow_name!r} state={state}")
+    result = client.inject_delta(shadow_name, state)
+    print(result)
+    if not args.no_watch:
+        _watch_udp(args.watch_port, args.watch_seconds, args.host, raw=args.watch_raw)
+
+
+def cmd_set(args):
+    state = _parse_kv_pairs(args.pairs)
+    client = ShadowClient(args.host, args.username, args.password)
+    _do_set(client, args, args.shadow, state)
+
+
+def cmd_set_json(args):
+    import json
+    try:
+        state = json.loads(args.json)
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"Invalid JSON: {e}")
+    client = ShadowClient(args.host, args.username, args.password)
+    _do_set(client, args, args.shadow, state)
+
+
+def cmd_channel(args):
+    fields = _parse_kv_pairs(args.pairs)
+    state = {str(args.index): fields}
+    client = ShadowClient(args.host, args.username, args.password)
+    _do_set(client, args, "channels", state)
+
+
+def cmd_meter_cadence(args):
+    state = {
+        "meter_publish_threshold_bytes": args.threshold_bytes,
+        "meter_publish_max_interval_ms": args.max_interval_ms,
+    }
+    client = ShadowClient(args.host, args.username, args.password)
+    _do_set(client, args, "system", state)
+
+
+def cmd_restore_cadence(args):
+    state = {
+        "meter_publish_threshold_bytes": FIRMWARE_DEFAULT_METER_THRESHOLD_BYTES,
+        "meter_publish_max_interval_ms": FIRMWARE_DEFAULT_METER_MAX_INTERVAL_MS,
+    }
+    client = ShadowClient(args.host, args.username, args.password)
+    _do_set(client, args, "system", state)
+
+
+def cmd_led(args):
+    if not 0 <= args.brightness <= 255:
+        raise SystemExit("brightness must be 0-255")
+    client = ShadowClient(args.host, args.username, args.password)
+    _do_set(client, args, "system", {"led_brightness": args.brightness})
+
+
+def cmd_power_data(args):
+    client = ShadowClient(args.host, args.username, args.password)
+    _do_set(client, args, "system", {"send_power_data": args.state == "on"})
+
+
+def cmd_grid_data(args):
+    client = ShadowClient(args.host, args.username, args.password)
+    _do_set(client, args, "system", {"send_grid_data": args.state == "on"})
+
+
+def cmd_log_level(args):
+    level = args.level.upper()
+    if level not in VALID_LOG_LEVELS:
+        raise SystemExit(f"level must be one of {sorted(VALID_LOG_LEVELS)}")
+    field = {"system": "mqtt_log_level", "print": "log_level_print", "save": "log_level_save"}[args.target]
+    client = ShadowClient(args.host, args.username, args.password)
+    _do_set(client, args, "system", {field: level})
+
+
+def cmd_get(args):
+    client = ShadowClient(args.host, args.username, args.password)
+    if args.what == "led":
+        print(client.get_json("/api/v1/led/brightness"))
+    elif args.what == "meter":
+        print("calibration + config:", client.get_json("/api/v1/ade7953/config"))
+        print("sample_time:", client.get_json("/api/v1/ade7953/sample-time"))
+    elif args.what == "channels":
+        print(client.get_json("/api/v1/ade7953/channel"))
+    elif args.what == "channel":
+        if args.index is None:
+            raise SystemExit("get channel requires --index")
+        print(client.get_json("/api/v1/ade7953/channel", params={"index": args.index}))
+    else:
+        raise SystemExit(f"No local GET for {args.what!r}. This device has no local read-back for "
+                          f"send_power_data/send_grid_data/meter_publish_*/log-levels; check the "
+                          f"result printed after a `set`, or watch utils/udp_log_listener.py, "
+                          f"or read the real shadow from the cloud with the AWS CLI.")
+
+
+def cmd_command(args):
+    client = ShadowClient(args.host, args.username, args.password)
+    execution_id = args.execution_id or f"local-{int(time.time())}"
+
+    if args.action == "restart":
+        if not args.yes:
+            raise SystemExit("This reboots the device. Re-run with --yes to confirm.")
+        payload = {"operation": "restart"}
+    elif args.action == "factory-reset":
+        if not args.confirm:
+            raise SystemExit("This wipes user NVS. Re-run with --confirm <DEVICE_ID> to confirm.")
+        payload = {"operation": "factory_reset", "confirm": args.confirm}
+    elif args.action == "energy-reset":
+        payload = {"operation": "energy_reset", "channels": args.channels}
+    else:
+        raise SystemExit(f"Unknown action: {args.action}")
+
+    print(f"POST inject-command executionId={execution_id!r} payload={payload}")
+    result = client.inject_command(execution_id, payload)
+    print(result)
+    if not args.no_watch:
+        _watch_udp(args.watch_port, args.watch_seconds, args.host, raw=args.watch_raw)
+
+
+def _add_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--host", required=True, help="Device IP (must be an esp32s3-dev build)")
+    parser.add_argument("-u", "--username", default=DEFAULT_USERNAME)
+    parser.add_argument("-p", "--password", default=DEFAULT_PASSWORD)
+    parser.add_argument("--no-watch", action="store_true", help="Skip the post-command UDP log watch")
+    parser.add_argument("--watch-raw", action="store_true", help="Show all log lines, not just shadow/apply-relevant ones")
+    parser.add_argument("--watch-port", type=int, default=DEFAULT_WATCH_PORT)
+    parser.add_argument("--watch-seconds", type=float, default=DEFAULT_WATCH_SECONDS)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Locally drive a dev device's shadow apply logic (no cloud round-trip).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("set", help="Generic delta on any writable shadow (system/meter/channels)")
+    p.add_argument("shadow", choices=["system", "meter", "channels"])
+    p.add_argument("pairs", nargs="+", help="key=value (dot notation for nested, e.g. ctSpecification.ratedCurrent=30)")
+    _add_common_args(p)
+    p.set_defaults(func=cmd_set)
+
+    p = sub.add_parser("set-json", help="Raw JSON state object for any writable shadow")
+    p.add_argument("shadow", choices=["system", "meter", "channels"])
+    p.add_argument("json", help='e.g. \'{"led_brightness": 20}\'')
+    _add_common_args(p)
+    p.set_defaults(func=cmd_set_json)
+
+    p = sub.add_parser("channel", help="Set fields on one channel (channels shadow, keyed by index)")
+    p.add_argument("index", type=int)
+    p.add_argument("pairs", nargs="+", help="key=value, e.g. label=\"Kitchen\" active=true")
+    _add_common_args(p)
+    p.set_defaults(func=cmd_channel)
+
+    p = sub.add_parser("meter-cadence", help="Shorthand: set both meter publish cadence fields")
+    p.add_argument("threshold_bytes", type=int)
+    p.add_argument("max_interval_ms", type=int)
+    _add_common_args(p)
+    p.set_defaults(func=cmd_meter_cadence)
+
+    p = sub.add_parser("restore-cadence", help=f"Shorthand: reset cadence to firmware defaults "
+                                                f"({FIRMWARE_DEFAULT_METER_THRESHOLD_BYTES}B / "
+                                                f"{FIRMWARE_DEFAULT_METER_MAX_INTERVAL_MS}ms)")
+    _add_common_args(p)
+    p.set_defaults(func=cmd_restore_cadence)
+
+    p = sub.add_parser("led", help="Shorthand: set led_brightness")
+    p.add_argument("brightness", type=int)
+    _add_common_args(p)
+    p.set_defaults(func=cmd_led)
+
+    p = sub.add_parser("power-data", help="Shorthand: set send_power_data")
+    p.add_argument("state", choices=["on", "off"])
+    _add_common_args(p)
+    p.set_defaults(func=cmd_power_data)
+
+    p = sub.add_parser("grid-data", help="Shorthand: set send_grid_data")
+    p.add_argument("state", choices=["on", "off"])
+    _add_common_args(p)
+    p.set_defaults(func=cmd_grid_data)
+
+    p = sub.add_parser("log-level", help="Shorthand: set mqtt_log_level / log_level_print / log_level_save")
+    p.add_argument("target", choices=["system", "print", "save"])
+    p.add_argument("level", help=f"One of {sorted(VALID_LOG_LEVELS)}")
+    _add_common_args(p)
+    p.set_defaults(func=cmd_log_level)
+
+    p = sub.add_parser("get", help="Best-effort local read (only fields with a non-shadow local GET)")
+    p.add_argument("what", choices=["led", "meter", "channels", "channel"])
+    p.add_argument("--index", type=int, help="Channel index (for `get channel`)")
+    _add_common_args(p)
+    p.set_defaults(func=cmd_get)
+
+    p = sub.add_parser("command", help="IoT Command (separate from shadow deltas, same injection path)")
+    p.add_argument("action", choices=["restart", "factory-reset", "energy-reset"])
+    p.add_argument("--execution-id", help="Defaults to a timestamp-based id")
+    p.add_argument("--yes", action="store_true", help="Confirm restart")
+    p.add_argument("--confirm", help="For factory-reset: must equal the device id")
+    p.add_argument("--channels", default="all", help="For energy-reset: 'all' or e.g. '0,2,5'")
+    _add_common_args(p)
+    p.set_defaults(func=cmd_command)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Makes the AWS IoT meter-publish byte-threshold and max-interval-ms configurable at runtime via the `system` device shadow (`meter_publish_threshold_bytes` / `meter_publish_max_interval_ms`), following the existing `send_power_data`/`send_grid_data` delta-apply-persist-ack pattern. Defaults match today's fixed behavior (5 KB / 60 s), so fleet cadence is unchanged until the cloud writes a desired value.
- Values are clamped (`std::clamp`) and persisted to NVS; device stays stateless w.r.t. any scheduling policy - it just obeys whatever two numbers are currently set (near-real-time for a demo, more aggressive batching for cost efficiency, etc).
- Adds `source/utils/shadow_cli.py`: a CLI for driving a dev device's shadow apply logic locally over HTTP (via the dev-only `inject-delta`/`inject-command` endpoints), with generic sets, channel config, IoT command injection, and self-verifying UDP log watch.
- Includes the full OpenSpec change (`configurable-meter-publish-rate`) with proposal/design/specs/tasks.

## Test plan
- [x] `pio test -e native` - 203/203 passing, no regressions
- [x] Hardware verification on bench device (`192.168.1.111`, dev build): default cadence unchanged, shadow-lowered values speed up publishing, out-of-range values clamp with a WARN and report the clamped value, setting persists across reboot via NVS
- [x] Real cloud round-trip verified via AWS CLI (`aws iot-data update-thing-shadow` against the dev account's `system` shadow): desired write applied correctly, version-conflict edge case confirmed to self-heal via existing reported-first-republish recovery logic
- [x] `shadow_cli.py` exercised end-to-end against the bench device: generic set, clamp path, per-channel field set/revert, `get meter`/`get channel`, `restore-cadence`, `energy-reset` command injection