### PR TITLE
fix(utils): standardize CLI args and device credentials across scripts

### DIFF
--- a/source/utils/_device_auth.py
+++ b/source/utils/_device_auth.py
@@ -40,6 +40,13 @@ def add_device_args(
 
     `--host` is required unless a default is given, or `host_required=False`
     is passed explicitly (e.g. a script that only needs a host in some modes).
+
+    Deliberately no `.env`/default fallback for `--host` (unlike username/
+    password): wrong credentials fail loudly (401), but a wrong host fails
+    silently - the request just goes to the wrong device and does whatever
+    the command does (OTA flash, factory-reset, shadow injection...). Keeping
+    it a required, explicit argument forces you to look at what you typed
+    before anything mutating goes out.
     """
     parser.add_argument(
         "-H", "--host",

--- a/source/utils/_device_auth.py
+++ b/source/utils/_device_auth.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2025 Jibril Sharafi
+
+"""Shared CLI args and credential resolution for EnergyMe-Home device-facing scripts.
+
+Every script that talks to a device over HTTP should add its target/credential
+flags via `add_device_args()` and resolve the actual username/password via
+`resolve_credentials()`. Precedence: explicit CLI flag > `.env`
+(`DEVICE_USERNAME` / `DEVICE_PASSWORD`, loaded via `uv run --env-file .env`) >
+shared default matching the bench devices' provisioning credentials.
+"""
+
+import argparse
+import os
+
+DEFAULT_USERNAME = "admin"
+DEFAULT_PASSWORD = "energyme00"
+
+
+def add_credential_args(parser: argparse.ArgumentParser) -> None:
+    """Add --username/-u, --password/-p to parser (no --host)."""
+    parser.add_argument(
+        "-u", "--username", default=None,
+        help=f"Device username (default: $DEVICE_USERNAME or '{DEFAULT_USERNAME}')",
+    )
+    parser.add_argument(
+        "-p", "--password", default=None,
+        help=f"Device password (default: $DEVICE_PASSWORD or '{DEFAULT_PASSWORD}')",
+    )
+
+
+def add_device_args(
+    parser: argparse.ArgumentParser,
+    *,
+    host_default: str | None = None,
+    host_required: bool = True,
+    need_credentials: bool = True,
+) -> None:
+    """Add --host/-H (and, if requested, --username/-u, --password/-p) to parser.
+
+    `--host` is required unless a default is given, or `host_required=False`
+    is passed explicitly (e.g. a script that only needs a host in some modes).
+    """
+    parser.add_argument(
+        "-H", "--host",
+        required=host_default is None and host_required,
+        default=host_default,
+        help="Device IP address or hostname" + (f" (default: {host_default})" if host_default else ""),
+    )
+    if need_credentials:
+        add_credential_args(parser)
+
+
+def resolve_credentials(args: argparse.Namespace) -> tuple[str, str]:
+    """Resolve (username, password) with precedence: CLI flag > .env > shared default."""
+    username = args.username or os.environ.get("DEVICE_USERNAME") or DEFAULT_USERNAME
+    password = args.password or os.environ.get("DEVICE_PASSWORD") or DEFAULT_PASSWORD
+    return username, password

--- a/source/utils/benchmark_api.py
+++ b/source/utils/benchmark_api.py
@@ -13,7 +13,7 @@ Usage:
 
 Example:
     python3 benchmark_api.py -H 192.168.1.200
-    python3 benchmark_api.py -H energyme.local -p 80 -r 10 -c 5
+    python3 benchmark_api.py -H energyme.local --port 80 -r 10 -c 5
 """
 
 import argparse
@@ -28,6 +28,8 @@ import requests
 from requests.adapters import HTTPAdapter
 from requests.auth import HTTPDigestAuth
 from urllib3.util.retry import Retry
+
+from _device_auth import add_device_args, resolve_credentials
 
 
 @dataclass
@@ -395,20 +397,15 @@ def main():
         epilog="""
 Examples:
   %(prog)s -H 192.168.1.200
-  %(prog)s -H energyme.local -p 80 -r 10 -c 5
+  %(prog)s -H energyme.local --port 80 -r 10 -c 5
   %(prog)s -H 192.168.1.200 --https -r 20 --timeout 15
-  %(prog)s -H 192.168.1.200 -u admin -P mypassword -r 5 --sequential --save results.json
+  %(prog)s -H 192.168.1.200 -u admin -p mypassword -r 5 --sequential --save results.json
         """
     )
     
-    parser.add_argument('-H', '--host', required=True,
-                       help='Target host IP address or hostname')
-    parser.add_argument('-p', '--port', type=int, default=80,
+    add_device_args(parser)
+    parser.add_argument('--port', type=int, default=80,
                        help='Target port number (default: 80)')
-    parser.add_argument('-u', '--username', default='admin',
-                       help='Username for authentication (default: admin)')
-    parser.add_argument('-P', '--password', default='energyme',
-                       help='Password for authentication (default: energyme)')
     parser.add_argument('--https', action='store_true',
                        help='Use HTTPS instead of HTTP')
     parser.add_argument('-r', '--requests', type=int, default=10,
@@ -434,13 +431,14 @@ Examples:
         args.port = 443  # Default HTTPS port
     
     # Create benchmark instance
+    username, password = resolve_credentials(args)
     benchmark = ApiBenchmark(
         host=args.host,
         port=args.port,
         protocol=protocol,
         timeout=args.timeout,
-        username=args.username,
-        password=args.password
+        username=username,
+        password=password
     )
     
     # Determine concurrency

--- a/source/utils/crash_dump_analyzer.py
+++ b/source/utils/crash_dump_analyzer.py
@@ -10,13 +10,14 @@ then decodes and analyzes the crash dump for debugging purposes. It automaticall
 searches for the correct ELF file in the releases/ folder based on SHA256 matching.
 
 Usage:
-    python crash_dump_analyzer.py <device_ip> [username] [password]
+    python crash_dump_analyzer.py -H <device_ip> [options]
 
 Example:
-    python crash_dump_analyzer.py 192.168.1.100 admin secret123
+    python crash_dump_analyzer.py -H 192.168.1.100
+    python crash_dump_analyzer.py -H 192.168.1.100 -u admin -p secret123 --clear
 """
 
-import sys
+import argparse
 import json
 import base64
 import requests
@@ -25,6 +26,8 @@ from datetime import datetime
 from typing import Optional, Dict, Any
 import os
 import hashlib
+
+from _device_auth import add_device_args, resolve_credentials
 
 
 class CrashDumpAnalyzer:
@@ -702,52 +705,31 @@ class CrashDumpAnalyzer:
 
 
 def main():
-    if len(sys.argv) < 2:
-        print("Usage: python crash_dump_analyzer.py <device_ip> [username] [password] [chunk_size] [--clear]")
-        print("Example: python crash_dump_analyzer.py 192.168.1.100")
-        print("Example: python crash_dump_analyzer.py 192.168.1.100 admin secret123")
-        print("Example: python crash_dump_analyzer.py 192.168.1.100 admin secret123 4096")
-        print("Example: python crash_dump_analyzer.py 192.168.1.100 --clear  # Clear dump after analysis")
-        sys.exit(1)
-    
-    # Check for --clear flag
-    clear_after = '--clear' in sys.argv
-    args = [arg for arg in sys.argv[1:] if arg != '--clear']
-    
-    device_ip = args[0]
-    username = args[1] if len(args) > 1 else None
-    password = args[2] if len(args) > 2 else None
-    
-    # Determine chunk_size based on number of arguments
-    if len(args) > 3:
-        chunk_size = int(args[3])
-    elif len(args) == 2:  # Only device_ip and one other arg (assume it's chunk_size)
-        try:
-            chunk_size = int(args[1])
-            username = None
-            password = None
-        except ValueError:
-            # If it's not a number, treat it as username and use default chunk_size
-            chunk_size = 2048
-    else:
-        chunk_size = 2048
-    
-    # Validate chunk size
-    if chunk_size < 512 or chunk_size > 8192:
-        print("❌ Chunk size must be between 512 and 8192 bytes")
-        sys.exit(1)
-    
-    analyzer = CrashDumpAnalyzer(device_ip, username, password, chunk_size)
-    
+    parser = argparse.ArgumentParser(
+        description="Fetch and analyze a crash/core dump from an EnergyMe-Home device",
+    )
+    add_device_args(parser)
+    parser.add_argument('--chunk-size', type=int, default=2048,
+                       help='Core dump download chunk size in bytes, 512-8192 (default: 2048)')
+    parser.add_argument('--clear', action='store_true',
+                       help='Clear the core dump from the device after analysis')
+    args = parser.parse_args()
+
+    if not 512 <= args.chunk_size <= 8192:
+        parser.error("--chunk-size must be between 512 and 8192 bytes")
+
+    username, password = resolve_credentials(args)
+    analyzer = CrashDumpAnalyzer(args.host, username, password, args.chunk_size)
+
     try:
         # Run analysis automatically (no prompts)
         filename = analyzer.analyze()
-        
+
         # Clear core dump if --clear flag was provided
-        if clear_after and filename:
+        if args.clear and filename:
             print(f"\n🗑️  Clearing core dump from device (--clear flag provided)...")
             analyzer.clear_core_dump()
-        
+
     except KeyboardInterrupt:
         print("\n\n⚠️  Analysis interrupted by user")
     except Exception as e:

--- a/source/utils/mock_server.py
+++ b/source/utils/mock_server.py
@@ -7,9 +7,9 @@ Development server for EnergyMe HTML development.
 Serves static files and API responses from JSON mock files.
 
 Usage:
-    python mock_server.py                              # Mock mode (from mocks/ folder)
-    python mock_server.py --proxy 192.168.2.75 pass   # Proxy mode (real device)
-    python mock_server.py --fetch 192.168.2.75 pass   # Fetch real data to mocks/
+    python mock_server.py                                       # Mock mode (from mocks/ folder)
+    python mock_server.py --proxy --host 192.168.2.75 -p pass  # Proxy mode (real device)
+    python mock_server.py --fetch --host 192.168.2.75 -p pass  # Fetch real data to mocks/
 """
 
 import argparse
@@ -25,8 +25,11 @@ import time
 import urllib.request
 import urllib.error
 
+from _device_auth import add_device_args, resolve_credentials
+
 PORT = 8081
 PROXY_TARGET = None
+PROXY_USERNAME = None
 PROXY_PASSWORD = None
 MOCKS_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'mocks')
 LITTLE_FS_DIR = os.path.join(MOCKS_DIR, 'little-fs')
@@ -191,14 +194,14 @@ def fetch_data_files(opener, host: str):
     print(f"Data files: Success: {success_count}, Failed: {fail_count}")
 
 
-def fetch_from_device(host: str, password: str):
+def fetch_from_device(host: str, username: str, password: str):
     """Fetch all GET endpoint responses from real device and save to mocks/."""
     print(f"\nFetching data from http://{host}...")
     print("=" * 50)
-    
+
     # Set up digest auth
     password_mgr = urllib.request.HTTPPasswordMgrWithDefaultRealm()
-    password_mgr.add_password(None, f"http://{host}/", "admin", password)
+    password_mgr.add_password(None, f"http://{host}/", username, password)
     auth_handler = urllib.request.HTTPDigestAuthHandler(password_mgr)
     opener = urllib.request.build_opener(auth_handler)
     
@@ -267,7 +270,7 @@ class MockHandler(http.server.SimpleHTTPRequestHandler):
         try:
             assert PROXY_PASSWORD, "Proxy password not set"
             password_mgr = urllib.request.HTTPPasswordMgrWithDefaultRealm()
-            password_mgr.add_password(None, f"http://{PROXY_TARGET}/", "admin", PROXY_PASSWORD)
+            password_mgr.add_password(None, f"http://{PROXY_TARGET}/", PROXY_USERNAME, PROXY_PASSWORD)
             auth_handler = urllib.request.HTTPDigestAuthHandler(password_mgr)
             opener = urllib.request.build_opener(auth_handler)
             
@@ -613,36 +616,43 @@ class FileWatcher(threading.Thread):
 
 
 def main():
-    global PROXY_TARGET, PROXY_PASSWORD, PORT
-    
+    global PROXY_TARGET, PROXY_USERNAME, PROXY_PASSWORD, PORT
+
     parser = argparse.ArgumentParser(
         description='EnergyMe development server',
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  python mock_server.py                              # Mock mode (uses mocks/ folder)
-  python mock_server.py --proxy 192.168.2.75 pass   # Proxy to real device
-  python mock_server.py --fetch 192.168.2.75 pass   # Fetch data from device to mocks/
+  python mock_server.py                                       # Mock mode (uses mocks/ folder)
+  python mock_server.py --proxy --host 192.168.2.75 -p pass  # Proxy to real device
+  python mock_server.py --fetch --host 192.168.2.75 -p pass  # Fetch data from device to mocks/
         """
     )
-    parser.add_argument('--proxy', nargs=2, metavar=('HOST', 'PASSWORD'),
-                        help='Proxy API requests to real device')
-    parser.add_argument('--fetch', nargs=2, metavar=('HOST', 'PASSWORD'),
-                        help='Fetch all GET endpoint data from device and save to mocks/')
+    add_device_args(parser, host_required=False)
+    parser.add_argument('--proxy', action='store_true',
+                        help='Proxy API requests to real device (requires --host)')
+    parser.add_argument('--fetch', action='store_true',
+                        help='Fetch all GET endpoint data from device and save to mocks/ (requires --host)')
     parser.add_argument('--port', type=int, default=PORT,
                         help=f'Server port (default: {PORT})')
     args = parser.parse_args()
-    
+
+    if (args.proxy or args.fetch) and not args.host:
+        parser.error('--proxy/--fetch require --host')
+
+    username, password = resolve_credentials(args)
+
     # Fetch mode: capture data and exit
     if args.fetch:
-        fetch_from_device(args.fetch[0], args.fetch[1])
+        fetch_from_device(args.host, username, password)
         return
-    
+
     # Set proxy mode
     if args.proxy:
-        PROXY_TARGET = args.proxy[0]
-        PROXY_PASSWORD = args.proxy[1]
-    
+        PROXY_TARGET = args.host
+        PROXY_USERNAME = username
+        PROXY_PASSWORD = password
+
     PORT = args.port
     
     print(f"Starting server on http://localhost:{PORT}")

--- a/source/utils/modbus_tester.py
+++ b/source/utils/modbus_tester.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # Copyright (C) 2025 Jibril Sharafi
 
+import argparse
 import time
 from typing import Any, Dict, List
 from pymodbus.client import ModbusTcpClient
-import sys
 import statistics
+
+from _device_auth import add_device_args
 
 # Modbus server details
 SERVER_PORT = 502
@@ -374,12 +376,11 @@ def test_polling_performance(client: ModbusTcpClient, registers: Dict[str, Dict[
     draw_histogram(response_times, width=50, bins=12)
 
 def main():
-    if len(sys.argv) < 2:
-        print("Usage: python modbus_tester.py <SERVER_IP>")
-        print("Example: python modbus_tester.py 192.168.1.60")
-        return
+    parser = argparse.ArgumentParser(description="Modbus TCP register testing suite for EnergyMe-Home")
+    add_device_args(parser, need_credentials=False)
+    args = parser.parse_args()
 
-    server_ip = sys.argv[1]
+    server_ip = args.host
     client = ModbusTcpClient(server_ip, port=SERVER_PORT)
 
     if not client.connect():

--- a/source/utils/ota_updater.py
+++ b/source/utils/ota_updater.py
@@ -19,9 +19,11 @@ from datetime import datetime
 from pathlib import Path
 from requests.auth import HTTPDigestAuth
 
+from _device_auth import add_device_args, resolve_credentials
+
 
 class OTAUpdater:
-    def __init__(self, host, username="admin", password="energyme"):
+    def __init__(self, host, username="admin", password="energyme00"):
         self.host = host
         self.base_url = f"http://{host}"
         self.auth = HTTPDigestAuth(username, password)
@@ -429,10 +431,8 @@ class OTAUpdater:
 
 def main():
     parser = argparse.ArgumentParser(description='EnergyMe-Home OTA Updater')
-    parser.add_argument('-H', '--host', default='energyme.local', help='Device IP address (e.g., 192.168.1.245). If not passed, it will use the default hostname energyme.local (WARNING: it will be slower and may cause problems)')
-    parser.add_argument('-u', '--username', default='admin', help='Username (default: admin)')
-    parser.add_argument('-p', '--password', default='energyme', help='Password (default: energyme)')
-    parser.add_argument('-env', '--environment', default='dev', 
+    add_device_args(parser, host_default='energyme.local')
+    parser.add_argument('-env', '--environment', default='dev',
                        choices=['dev', 'prod'],
                        help='Build environment (default: dev)')
     parser.add_argument('-b', '--bin', 
@@ -464,7 +464,8 @@ def main():
     print(f"🐛 Debug: {args.elf}")
     print()
     
-    updater = OTAUpdater(args.host, args.username, args.password)
+    username, password = resolve_credentials(args)
+    updater = OTAUpdater(args.host, username, password)
     
     if args.status_only:
         print("📊 Getting OTA Status...")

--- a/source/utils/shadow_cli.py
+++ b/source/utils/shadow_cli.py
@@ -72,8 +72,8 @@ from typing import Any
 import requests
 from requests.auth import HTTPDigestAuth
 
-DEFAULT_USERNAME = "admin"
-DEFAULT_PASSWORD = "energyme00"
+from _device_auth import add_device_args, resolve_credentials
+
 DEFAULT_WATCH_PORT = 514
 DEFAULT_WATCH_SECONDS = 3.0
 
@@ -157,6 +157,11 @@ class ShadowClient:
         return data
 
 
+def _client(args: argparse.Namespace) -> ShadowClient:
+    username, password = resolve_credentials(args)
+    return ShadowClient(args.host, username, password)
+
+
 def _watch_udp(port: int, seconds: float, host_hint: str, raw: bool = False) -> None:
     """Print syslog lines for a few seconds so a set/command is self-verifying.
 
@@ -198,7 +203,7 @@ def _watch_udp(port: int, seconds: float, host_hint: str, raw: bool = False) -> 
     if not seen_any:
         print("(no log lines received - device may be logging elsewhere, offline, "
               "or its UDP destination isn't pointed at this machine; see "
-              "utils/udp_log_listener.py --device-ip to configure it)")
+              "utils/udp_log_listener.py -H <ip> to configure it)")
     print("--- end watch ---")
 
 
@@ -212,7 +217,7 @@ def _do_set(client: ShadowClient, args, shadow_name: str, state: dict) -> None:
 
 def cmd_set(args):
     state = _parse_kv_pairs(args.pairs)
-    client = ShadowClient(args.host, args.username, args.password)
+    client = _client(args)
     _do_set(client, args, args.shadow, state)
 
 
@@ -222,14 +227,14 @@ def cmd_set_json(args):
         state = json.loads(args.json)
     except json.JSONDecodeError as e:
         raise SystemExit(f"Invalid JSON: {e}")
-    client = ShadowClient(args.host, args.username, args.password)
+    client = _client(args)
     _do_set(client, args, args.shadow, state)
 
 
 def cmd_channel(args):
     fields = _parse_kv_pairs(args.pairs)
     state = {str(args.index): fields}
-    client = ShadowClient(args.host, args.username, args.password)
+    client = _client(args)
     _do_set(client, args, "channels", state)
 
 
@@ -238,7 +243,7 @@ def cmd_meter_cadence(args):
         "meter_publish_threshold_bytes": args.threshold_bytes,
         "meter_publish_max_interval_ms": args.max_interval_ms,
     }
-    client = ShadowClient(args.host, args.username, args.password)
+    client = _client(args)
     _do_set(client, args, "system", state)
 
 
@@ -247,24 +252,24 @@ def cmd_restore_cadence(args):
         "meter_publish_threshold_bytes": FIRMWARE_DEFAULT_METER_THRESHOLD_BYTES,
         "meter_publish_max_interval_ms": FIRMWARE_DEFAULT_METER_MAX_INTERVAL_MS,
     }
-    client = ShadowClient(args.host, args.username, args.password)
+    client = _client(args)
     _do_set(client, args, "system", state)
 
 
 def cmd_led(args):
     if not 0 <= args.brightness <= 255:
         raise SystemExit("brightness must be 0-255")
-    client = ShadowClient(args.host, args.username, args.password)
+    client = _client(args)
     _do_set(client, args, "system", {"led_brightness": args.brightness})
 
 
 def cmd_power_data(args):
-    client = ShadowClient(args.host, args.username, args.password)
+    client = _client(args)
     _do_set(client, args, "system", {"send_power_data": args.state == "on"})
 
 
 def cmd_grid_data(args):
-    client = ShadowClient(args.host, args.username, args.password)
+    client = _client(args)
     _do_set(client, args, "system", {"send_grid_data": args.state == "on"})
 
 
@@ -273,12 +278,12 @@ def cmd_log_level(args):
     if level not in VALID_LOG_LEVELS:
         raise SystemExit(f"level must be one of {sorted(VALID_LOG_LEVELS)}")
     field = {"system": "mqtt_log_level", "print": "log_level_print", "save": "log_level_save"}[args.target]
-    client = ShadowClient(args.host, args.username, args.password)
+    client = _client(args)
     _do_set(client, args, "system", {field: level})
 
 
 def cmd_get(args):
-    client = ShadowClient(args.host, args.username, args.password)
+    client = _client(args)
     if args.what == "led":
         print(client.get_json("/api/v1/led/brightness"))
     elif args.what == "meter":
@@ -298,7 +303,7 @@ def cmd_get(args):
 
 
 def cmd_command(args):
-    client = ShadowClient(args.host, args.username, args.password)
+    client = _client(args)
     execution_id = args.execution_id or f"local-{int(time.time())}"
 
     if args.action == "restart":
@@ -322,9 +327,7 @@ def cmd_command(args):
 
 
 def _add_common_args(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--host", required=True, help="Device IP (must be an esp32s3-dev build)")
-    parser.add_argument("-u", "--username", default=DEFAULT_USERNAME)
-    parser.add_argument("-p", "--password", default=DEFAULT_PASSWORD)
+    add_device_args(parser)
     parser.add_argument("--no-watch", action="store_true", help="Skip the post-command UDP log watch")
     parser.add_argument("--watch-raw", action="store_true", help="Show all log lines, not just shadow/apply-relevant ones")
     parser.add_argument("--watch-port", type=int, default=DEFAULT_WATCH_PORT)

--- a/source/utils/udp_log_listener.py
+++ b/source/utils/udp_log_listener.py
@@ -30,8 +30,9 @@ Examples:
     python udp_log_listener.py --exclude-files src/ade7953.cpp          # Filter out all logs from ade7953.cpp
     python udp_log_listener.py --exclude-functions _printMeterValues    # Filter out _printMeterValues function logs
     python udp_log_listener.py --exclude-files src/ade7953.cpp src/utils.cpp --exclude-functions _printMeterValues printStatus  # Multiple filters
-    python udp_log_listener.py --device-ip 192.168.1.100                # Configure device to send logs to this PC
-    python udp_log_listener.py --device-ip 192.168.1.100 --device-port 8080  # Configure with custom port
+    python udp_log_listener.py -H 192.168.1.100                         # Configure device to send logs to this PC
+    python udp_log_listener.py -H 192.168.1.100 --device-port 8080      # Configure with custom device port
+    python udp_log_listener.py -H 192.168.1.100 -u admin -p secret      # Configure with explicit credentials
 
 Device-specific logging:
     The listener automatically creates separate log files for each device in the logs/
@@ -54,10 +55,11 @@ import re
 import os
 import signal
 import requests
-import getpass
 from requests.auth import HTTPDigestAuth
 from datetime import datetime
 from typing import Optional, Dict, Any, TextIO
+
+from _device_auth import add_device_args, resolve_credentials
 
 
 class Colors:
@@ -700,13 +702,13 @@ def main():
     parser.add_argument(
         '--unicast',
         action='store_true',
-        help='Use unicast instead of multicast (listen on --host IP)'
+        help='Use unicast instead of multicast (listen on --bind IP)'
     )
-    
+
     parser.add_argument(
-        '--host', 
+        '--bind',
         default='0.0.0.0',
-        help='Host to bind to for unicast mode (default: 0.0.0.0 for all interfaces)'
+        help='Local address to bind to for unicast mode (default: 0.0.0.0 for all interfaces)'
     )
     
     parser.add_argument(
@@ -772,16 +774,12 @@ def main():
         help='Enable debug output for troubleshooting'
     )
 
-    parser.add_argument(
-        '--device-ip',
-        help='IP address or hostname of the EnergyMe-Home device to configure as log destination'
-    )
-
+    add_device_args(parser, host_required=False)
     parser.add_argument(
         '--device-port',
         type=int,
         default=80,
-        help='Port of the EnergyMe-Home device (default: 80)'
+        help='Port of the EnergyMe-Home device to configure as log destination (default: 80)'
     )
 
     args = parser.parse_args()
@@ -806,27 +804,25 @@ def main():
     # Determine auto device logs setting
     auto_device_logs = args.auto_device_logs and not args.no_auto_device_logs
 
-    # Handle device IP configuration
-    if args.device_ip:
+    # Handle device configuration
+    if args.host:
         print(f"\n{Colors.BOLD}Device Configuration{Colors.RESET}")
-        print(f"Target device: {args.device_ip}:{args.device_port}")
+        print(f"Target device: {args.host}:{args.device_port}")
 
         # Get local IP
-        local_ip = get_local_ip(args.device_ip)
+        local_ip = get_local_ip(args.host)
         print(f"Local IP to send: {local_ip}")
 
-        # Prompt for credentials
-        username = input("Enter device username: ")
-        password = getpass.getpass("Enter device password: ")
+        username, password = resolve_credentials(args)
 
         # Attempt to set the log destination
-        if set_device_log_destination(args.device_ip, args.device_port, username, password, local_ip):
+        if set_device_log_destination(args.host, args.device_port, username, password, local_ip):
             print(f"{Colors.INFO}Device will now send logs to {local_ip}{Colors.RESET}\n")
         else:
             print(f"{Colors.WARNING}Proceeding with listener despite device configuration error{Colors.RESET}\n")
 
     # Start listener
-    listener = UDPLogListener(args.host, args.port, log_filter, args.log_file, args.log_format, multicast_group, auto_device_logs, args.debug)
+    listener = UDPLogListener(args.bind, args.port, log_filter, args.log_file, args.log_format, multicast_group, auto_device_logs, args.debug)
     listener.start()
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Adds a shared `source/utils/_device_auth.py` helper so every device-facing script in `utils/` uses the same `--host/-H`, `--username/-u`, `--password/-p` convention and the same credential precedence: CLI flag > `.env` (`DEVICE_USERNAME`/`DEVICE_PASSWORD`) > shared default (`admin`/`energyme00`, matching the bench devices).
- Converts `crash_dump_analyzer.py` and `modbus_tester.py` from positional `sys.argv` parsing to argparse; converts `mock_server.py`'s `--proxy`/`--fetch` from positional `HOST PASSWORD` pairs to flags.
- Drops the interactive `input()`/`getpass()` prompt in `udp_log_listener.py`; renames its local socket-bind flag `--host` → `--bind` so `--host/-H` can consistently mean "the device" across all scripts.
- Aligns `benchmark_api.py`/`ota_updater.py` default passwords to `energyme00` (previously `energyme`, inconsistent with the actual bench device credentials).

Closes #210

## Test plan
All 7 scripts verified against dev bench device `192.168.2.174` (see commit history + session) with UDP log capture confirming device-side behavior:
- [x] `benchmark_api.py` - 100% success against all endpoints with default creds
- [x] `crash_dump_analyzer.py` - full crash/core-dump fetch + SHA256 match
- [x] `mock_server.py` - `--fetch` and `--proxy` modes both work
- [x] `modbus_tester.py` - register reads succeed over `-H/--host`
- [x] `shadow_cli.py` - `get` (read) and `led` (write) confirmed applied via device log
- [x] `udp_log_listener.py` - device UDP-destination config confirmed via device log, no more interactive prompt
- [ ] `ota_updater.py` - CLI wiring reviewed; not flashed live (would require a fresh build + device reboot)