### PR TITLE
fix(ade7953): correct three-phase angle folding and reactive power sign

### DIFF
--- a/source/html/channel.html
+++ b/source/html/channel.html
@@ -145,6 +145,15 @@
     const RECONCILE_DELAY_MS = 2500;
     var reconcileTimers = {};
 
+    // The post-PATCH reconcile above only covers a change the firmware makes right
+    // after an edit. A CT clipped on a circuit that is off at install time casts no
+    // polarity votes until the load actually starts, which can be long after the
+    // reconcile has fired, so poll the config as well to keep `reverse` and the phase
+    // preview honest without a manual reload.
+    const CONFIG_REFRESH_MS = 10000;
+    var configRefreshInterval = null;
+    const RECONCILED_FIELDS = ['active', 'reverse', 'role', 'phase', 'label', 'groupLabel'];
+
     // Initialize the page
     async function initializePage() {
         try {
@@ -153,6 +162,9 @@
             channelData = channelResponse;
 
             createChannelBoxes();
+
+            if (configRefreshInterval) clearInterval(configRefreshInterval);
+            configRefreshInterval = setInterval(refreshChannelConfig, CONFIG_REFRESH_MS);
         } catch (error) {
             console.error('Error initializing page:', error);
             showStatus('Error loading data: ' + error.message, 'error');
@@ -586,9 +598,8 @@
         }
         if (!serverChannel) return;
 
-        const fields = ['active', 'reverse', 'role', 'phase', 'label', 'groupLabel'];
         const diffs = [];
-        fields.forEach(field => {
+        RECONCILED_FIELDS.forEach(field => {
             const sent = sentSnapshot[field];
             const got = serverChannel[field];
             if (sent === undefined) return;
@@ -607,6 +618,41 @@
 
         const label = serverChannel.label || `Channel ${index}`;
         showStatus(`${label}: automatically adjusted ${diffs.join(', ')}`, 'info');
+    }
+
+    // Background config poll. Patches only the fields that actually differ instead of
+    // re-rendering: createChannelBoxes() wipes the container, which would drop focus,
+    // scroll position and any half-typed value.
+    async function refreshChannelConfig() {
+        // Never race the user. While an edit is queued, in flight, or waiting on its
+        // own reconcile, that path owns the merge and the server is not yet the truth.
+        if (isProcessingUpdate) return;
+        if (Object.keys(updateQueue).length > 0) return;
+        if (Object.keys(reconcileTimers).length > 0) return;
+
+        let all;
+        try {
+            all = await energyApi.getChannelConfig();
+        } catch (error) {
+            console.error('Channel config refresh failed', error);
+            return;
+        }
+        if (!all) return;
+
+        const focused = document.activeElement;
+        Object.entries(all).forEach(([index, serverChannel]) => {
+            const local = channelData[index];
+            if (!local || !serverChannel) return;
+            RECONCILED_FIELDS.forEach(field => {
+                if (local[field] === serverChannel[field]) return;
+                // Leave the control the user is currently in alone, and leave the local
+                // mirror with it, so the next poll retries once focus moves away.
+                const el = document.getElementById(`${field}${index}`);
+                if (el && el === focused) return;
+                applyServerFieldToDom(index, field, serverChannel[field]);
+                local[field] = serverChannel[field];
+            });
+        });
     }
 
     function applyServerFieldToDom(index, field, value) {

--- a/source/html/channel.html
+++ b/source/html/channel.html
@@ -312,14 +312,12 @@
         // Negative reading clamped to zero this cycle (load/PV): angle not recoverable
         if (p === 0) return { state: 'clamped' };
 
-        // The two firmware measurement branches publish reactivePower with different
-        // sign conventions: the energy-register branch (configured phase == base
-        // phase) gives the chip's signed Q, while the angle branch applies sign(PF),
-        // which mirrors Q whenever active power is negative. Undo that so atan2
-        // always sees the angle in the same frame as the published active power.
-        const revSign = channel.reverse ? -1 : 1;
-        const qEff = (channel.phase === basePhase) ? q : q * Math.sign(p) * revSign;
-        const psi = Math.atan2(qEff, p);
+        // Both firmware measurement branches now publish (P, Q) as a consistent
+        // phasor: the energy-register branch (configured phase == base phase) gives
+        // the chip's signed pair, and the angle branch negates Q together with P when
+        // the current phasor is flipped. So atan2 sees the load angle directly, in the
+        // same frame as the published active power, with no correction needed.
+        const psi = Math.atan2(q, p);
 
         const candidates = {};
         [1, 2, 3].forEach(c => {

--- a/source/lib/phase_utils/phase_utils.h
+++ b/source/lib/phase_utils/phase_utils.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cmath>
 
 // Phase enum and pure phase-rotation helpers, deliberately free of any Arduino /
 // FreeRTOS dependency so the logic can be unit-tested on the host (see
@@ -22,6 +23,10 @@ enum Phase : uint32_t { // plain enum so it serializes directly to/from JSON as 
 };
 
 namespace PhaseUtils {
+
+// Arduino's PI / DEG_TO_RAD macros do not exist on the host, and this header stays
+// Arduino-free (see the note above), so carry the conversion locally.
+constexpr float DEG_TO_RAD_F = 0.01745329251994329577f;
 
 // Returns the phase 120° behind `phase` in IEC rotation (L1->L2->L3->L1).
 inline Phase getLaggingPhase(Phase phase) {
@@ -45,20 +50,99 @@ inline Phase getLeadingPhase(Phase phase) {
     }
 }
 
+// Angle of a phase in the IEC positive-sequence frame. Split-phase 240 V shares the
+// L1 reference angle (it is a 180 deg sign flip, not a rotation).
+inline float phaseAngleDeg(Phase phase) {
+    switch (phase) {
+        case PHASE_1: return 0.0f;
+        case PHASE_2: return -120.0f;
+        case PHASE_3: return 120.0f;
+        case PHASE_SPLIT_240: return 0.0f;
+        default: return 0.0f;
+    }
+}
+
 // Returns the degrees to shift the voltage waveform to align it with the current's
 // phase reference. Formula: currentAngle - voltageAngle.
 // Positive = current leads voltage reference; negative = current lags.
 inline float calculatePhaseShiftDeg(Phase voltagePhase, Phase currentPhase) {
-    auto toAngle = [](Phase p) -> float {
-        switch (p) {
-            case PHASE_1: return 0.0f;
-            case PHASE_2: return -120.0f;
-            case PHASE_3: return 120.0f;
-            case PHASE_SPLIT_240: return 0.0f;
-            default: return 0.0f;
-        }
-    };
-    return toAngle(currentPhase) - toAngle(voltagePhase);
+    return phaseAngleDeg(currentPhase) - phaseAngleDeg(voltagePhase);
+}
+
+// Wraps an angle into (-180, 180].
+inline float wrapDeg180(float deg) {
+    while (deg > 180.0f) deg -= 360.0f;
+    while (deg <= -180.0f) deg += 360.0f;
+    return deg;
+}
+
+// Load angle recovered from the ADE7953 ANGLE register on a channel whose CT sits on
+// a different line than the single voltage input.
+//
+// Sign conventions (datasheet Rev. C, Figure 60 "Current-to-Voltage Time Delay"): the
+// ANGLE register is the delay from the voltage negative-to-positive zero crossing to
+// the current one, i.e. rawAngleDeg = thetaV - thetaI. Positive therefore means the
+// current LAGS the voltage: an inductive load. Confirmed against field data (see
+// test_phase_utils).
+//
+//   rawAngleDeg = (baseAngle - channelAngle) + phi
+//   => phi      = rawAngleDeg + (channelAngle - baseAngle)
+//
+// which is exactly rawAngleDeg + calculatePhaseShiftDeg(basePhase, channelPhase), so
+// the same expression covers the same-phase case (shift 0) and both rotations without
+// a lagging/leading branch.
+struct LoadAngle {
+    float angleDeg;            // phi wrapped into (-180, 180]
+    float foldedAngleDeg;      // phi folded into [-90, 90], the argument of the PF cosine
+    bool activePowerNegative;  // true when the fold crossed +-90 (power flows the other way)
+};
+
+inline LoadAngle loadAngleFromRawDeg(Phase basePhase, Phase channelPhase, float rawAngleDeg) {
+    LoadAngle result{};
+    result.angleDeg = wrapDeg180(rawAngleDeg + calculatePhaseShiftDeg(basePhase, channelPhase));
+
+    // A single fold always lands inside [-90, 90] because the input is already wrapped,
+    // which keeps cos() non-negative so the power factor sign means inductive/capacitive
+    // (never a folding artefact).
+    result.foldedAngleDeg = result.angleDeg;
+    result.activePowerNegative = false;
+    if (result.foldedAngleDeg < -90.0f || result.foldedAngleDeg > 90.0f) {
+        result.foldedAngleDeg += (result.foldedAngleDeg > 0.0f ? -180.0f : 180.0f);
+        result.activePowerNegative = true;
+    }
+    return result;
+}
+
+// Signed powers for the angle branch, i.e. a channel whose CT sits on a different line
+// than the single voltage input, where P and Q are reconstructed from the recovered
+// load angle instead of read from the ADE7953 energy registers.
+//
+// A backwards CT and a genuine reverse flow are both a 180 deg flip of the current
+// phasor, so they negate BOTH P and Q. Flipping only P publishes an impossible
+// quadrant (real power leaving while reactive power arrives) and makes any consumer
+// that reconstructs the angle from (P, Q) - the installer phase preview does exactly
+// that - land 180 deg out.
+struct SignedPowers {
+    float activePower;
+    float reactivePower;
+    float powerFactor;
+};
+
+inline SignedPowers powersFromFoldedAngle(float apparentPower, float foldedAngleDeg,
+                                          bool ctReversed, bool activePowerNegative) {
+    const float rad = foldedAngleDeg * DEG_TO_RAD_F;
+    const float flip = (ctReversed ? -1.0f : 1.0f) * (activePowerNegative ? -1.0f : 1.0f);
+
+    SignedPowers powers{};
+    // cos() is non-negative across the folded [-90, 90] range, so the power factor sign
+    // is the load angle sign: positive inductive, negative capacitive (datasheet Eq. 37).
+    powers.powerFactor = std::cos(rad) * (foldedAngleDeg >= 0.0f ? 1.0f : -1.0f);
+    // fabs keeps the active power identical to what the magnitude-times-sign form
+    // produced; it only differs from cos() outside the folded range, which is
+    // unreachable for an angle that went through loadAngleFromRawDeg.
+    powers.activePower = apparentPower * std::fabs(std::cos(rad)) * flip;
+    powers.reactivePower = apparentPower * std::sin(rad) * flip;
+    return powers;
 }
 
 } // namespace PhaseUtils

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -801,6 +801,15 @@ namespace Ade7953
             _channelData[channelIndex] = channelData;
         }
 
+        // Last line of defence for the voltage reference (see _isValidReferencePhase).
+        // The JSON validators reject this at the API, but a device that already stored
+        // it in NVS restores through here with armTransients=false, so coerce rather
+        // than reject: the alternative is a boot loop on a config the user cannot see.
+        if (channelIndex == 0 && _channelData[0].phase == PHASE_SPLIT_240) {
+            LOG_WARNING("Channel 0 cannot use split-phase 240V as reference, coercing to phase 1");
+            _channelData[0].phase = PHASE_1;
+        }
+
         // Arm transient flags on inactive->active transition. Polarity check runs for
         // every channel (including channel 0); the priority slot is meaningful only
         // for mux-routed channels (channel 0 bypasses the rotation entirely). Already
@@ -3043,6 +3052,21 @@ namespace Ade7953
         return true;
     }
 
+    /*
+    Channel 0 carries the single voltage reference, so its phase defines the frame every
+    other channel is measured in. Split-phase 240 V is not a rotation but a 2x voltage
+    multiplier, so using it here would make every other channel inherit the doubled
+    voltage from _meterValues[0] and would leave the rotation of the L1/L2/L3 channels
+    defined against a reference that does not rotate.
+    */
+    bool _isValidReferencePhase(uint8_t channelIndex, uint8_t phase) {
+        if (channelIndex == 0 && phase == PHASE_SPLIT_240) {
+            LOG_WARNING("Channel 0 carries the voltage reference and cannot be split-phase 240V");
+            return false;
+        }
+        return true;
+    }
+
     bool _isValidPhase(uint8_t phase) {
         return (phase == PHASE_1 ||
                 phase == PHASE_2 ||
@@ -3159,6 +3183,7 @@ namespace Ade7953
                     LOG_WARNING("Invalid phase value: %u (valid: 1-4)", phase);
                     return false;
                 }
+                if (!_isValidReferencePhase(channelIndex, phase)) return false;
                 hasValidField = true;
             }
 
@@ -3258,6 +3283,7 @@ namespace Ade7953
                 LOG_WARNING("Invalid phase value: %u (valid: 1-4)", phase);
                 return false;
             }
+            if (!_isValidReferencePhase(jsonDocument["index"].as<uint8_t>(), phase)) return false;
 
             // CT Specification validation with ranges
             if (!jsonDocument["ctSpecification"].is<JsonObjectConst>()) {

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -275,8 +275,6 @@ namespace Ade7953
     static void _recalculateWeights();
     static void _updateVariability(uint8_t channelIndex, float newActivePower);
     static uint8_t _findNextActiveChannel(uint8_t currentChannel);
-    static Phase _getLaggingPhase(Phase phase);
-    static Phase _getLeadingPhase(Phase phase);
     float _calculatePhaseShift(Phase voltagePhase, Phase currentPhase);
     // Returns the string name of the IRQSTATA bit, or UNKNOWN if the bit is not recognized.
     static const char *_irqstataBitName(uint32_t bit);
@@ -3825,44 +3823,48 @@ namespace Ade7953
             current = float(_readCurrentRms(ade7953Channel)) * channelData.ctSpecification.aLsb;
 
             // To get the power factor, we can read the angle difference between voltage and current (which is the time between the two zero-crossings)
-            float angleDifference = _readAngleRadians(ade7953Channel);
-            // What we just read is the raw angle; we need to shift it by 120° depending if it is leading or lagging
-            float realAngleDifference = angleDifference;
+            float angleDifferenceDeg = _readAngleRadians(ade7953Channel) * float(RAD_TO_DEG);
 
-            if (channelData.phase == _getLaggingPhase(basePhase)) {
-                realAngleDifference = angleDifference - 2.0f * (float)PI / 3.0f;
-            } else if (channelData.phase == _getLeadingPhase(basePhase)) {
-                realAngleDifference = angleDifference + 2.0f * (float)PI / 3.0f;
-            } else {
-                LOG_ERROR("Invalid phase %d for channel %d", channelData.phase, channelIndex);
-                _recordFailure();
-                return false;
-            }
+            // Rotate the raw angle into this channel's own frame (+-120° for the lagging
+            // or leading line, 0 for the reference) and fold it into the +-90° quadrant.
+            // Wrapping before folding matters: raw reaches +-180°, so raw + 120° reaches
+            // 300°, and a single fold leaves that at 120° - still outside the quadrant,
+            // where cos() goes negative and the power factor sign stops meaning
+            // inductive/capacitive. Only reachable on a misconfigured phase, which is
+            // exactly when the installer preview needs a truthful (P, Q) to point at the
+            // right label.
+            PhaseUtils::LoadAngle loadAngle = PhaseUtils::loadAngleFromRawDeg(
+                basePhase, channelData.phase, angleDifferenceDeg
+            );
+            bool isActivePowerNegative = loadAngle.activePowerNegative;
 
-            // Finally, if the shifted angle is outside the -90 to 90 degrees range, it means the active power is negative
-            bool isActivePowerNegative = false;
-            if (realAngleDifference < -float(HALF_PI) || realAngleDifference > float(HALF_PI)) { // If the angle is outside the -90 to 90 degrees range, it means the active power is negative
-                realAngleDifference = realAngleDifference + (realAngleDifference > 0 ? -float(PI) : float(PI)); // Bring the angle to the -90 to 90 degrees range for power factor calculation
-                isActivePowerNegative = true;
-            }
+            // S = Vrms * Irms, then P and Q from the recovered load angle. Both are
+            // negated together when the current phasor is flipped (backwards CT or
+            // genuine reverse flow) so the published pair stays a real phasor.
+            apparentPower = current * voltage;
+            PhaseUtils::SignedPowers powers = PhaseUtils::powersFromFoldedAngle(
+                apparentPower,
+                loadAngle.foldedAngleDeg,
+                channelData.reverse,
+                isActivePowerNegative
+            );
+            powerFactor = powers.powerFactor;
 
-            powerFactor = cos(realAngleDifference) * (realAngleDifference >= 0 ? 1.0f : -1.0f); // Apply sign as the cosine is always positive in the -90 to 90 degrees range, but negative power values indicate capacitive (leading) load
             // Since this is a tricky approximation, we print the debug info anyway
             LOG_DEBUG(
                 "%s (%d) (phase %d): Angle difference: %.1f° (from %.1f°), Power factor: %.1f%% %s",
-                channelData.label, 
-                channelIndex, 
+                channelData.label,
+                channelIndex,
                 channelData.phase,
-                realAngleDifference * RAD_TO_DEG,
-                angleDifference * RAD_TO_DEG,
+                loadAngle.foldedAngleDeg,
+                angleDifferenceDeg,
                 powerFactor * 100.0f,
                 isActivePowerNegative ? "(negative power)" : ""
             );
 
-            // FINALLY: Compute power values
-            apparentPower = current * voltage; // S = Vrms * Irms
-            activePower = current * voltage * abs(powerFactor) * (channelData.reverse ? -1.0f : 1.0f) * (isActivePowerNegative ? -1.0f : 1.0f); // P = Vrms * Irms * PF
-            reactivePower = float(sqrt(pow(apparentPower, 2) - pow(activePower, 2))) * (channelData.reverse ? -1.0f : 1.0f) * (powerFactor >= 0 ? 1.0f : -1.0f); // Q = sqrt(S^2 - P^2) * sign(PF)
+            // FINALLY: Compute power values (computed above with the power factor)
+            activePower = powers.activePower;     // P = S * |cos(phi)|, signed by the flips
+            reactivePower = powers.reactivePower; // Q = S * sin(phi), signed by the same flips
 
             // Synthetic no-load: the ADE7953's no-load feature only gates the energy
             // registers of the base-phase branch; here a sub-threshold current is offset
@@ -4754,12 +4756,6 @@ namespace Ade7953
         // _wdrrCursor.
         return MeterLogic::wdrrPick(_channelDeficit, active, count, 1, &_wdrrCursor);
     }
-
-    // Poor man's phase shift (doing with modulus didn't work properly,
-    // and in any case the phases will always be at most 3)
-
-    Phase _getLaggingPhase(Phase phase) { return PhaseUtils::getLaggingPhase(phase); }
-    Phase _getLeadingPhase(Phase phase)  { return PhaseUtils::getLeadingPhase(phase); }
 
     float _calculatePhaseShift(Phase voltagePhase, Phase currentPhase) {
         return PhaseUtils::calculatePhaseShiftDeg(voltagePhase, currentPhase);

--- a/source/test/test_phase_utils/test_phase_utils.cpp
+++ b/source/test/test_phase_utils/test_phase_utils.cpp
@@ -5,10 +5,41 @@
 // (On Windows the native toolchain is unreliable - run it from WSL.)
 
 #include <unity.h>
+#include <math.h>
 #include "phase_utils.h"
 
 void setUp(void) {}
 void tearDown(void) {}
+
+// ============================================================================
+// Forward physical model of the ADE7953 ANGLE register
+//
+// This is the part the naming tests below cannot cover: it starts from physical
+// reality (which line the CT is actually clipped on, what the load is doing, which
+// way round the CT is) and synthesises the register the chip would report, so the
+// correction can be checked end to end instead of only for self-consistency.
+//
+// Datasheet Rev. C, Figure 60: ANGLE is the delay from the voltage negative-to-
+// positive zero crossing to the current one, so ANGLE = thetaV - thetaI, positive
+// for an inductive (lagging) load. Register range is +-180 deg (a raw -104.2 deg
+// was captured in the field, so it is genuinely signed, not a 0..360 delay).
+// ============================================================================
+
+static float simulateRawAngleDeg(Phase voltageLine, Phase trueLine, float loadAngleDeg, bool ctReversed) {
+    float thetaV = PhaseUtils::phaseAngleDeg(voltageLine);
+    float thetaI = PhaseUtils::phaseAngleDeg(trueLine) - loadAngleDeg + (ctReversed ? 180.0f : 0.0f);
+    return PhaseUtils::wrapDeg180(thetaV - thetaI);
+}
+
+// Power factor exactly as _readMeterValues computes it from the folded angle:
+// cos() is non-negative over [-90, 90], so the sign carries inductive (+) vs
+// capacitive (-), matching the chip's own convention (datasheet Equation 37).
+static float powerFactorFrom(const PhaseUtils::LoadAngle &a) {
+    float rad = a.foldedAngleDeg * (float)M_PI / 180.0f;
+    return cosf(rad) * (a.foldedAngleDeg >= 0.0f ? 1.0f : -1.0f);
+}
+
+static const Phase ROTATIONAL_PHASES[3] = {PHASE_1, PHASE_2, PHASE_3};
 
 // ============================================================================
 // getLaggingPhase - IEC rotation L1->L2->L3->L1
@@ -119,6 +150,249 @@ void test_regression_leading_from_L1_is_L3_not_L2(void) {
 }
 
 // ============================================================================
+// loadAngleFromRawDeg - round trip against the physical model
+// ============================================================================
+
+void test_correct_assignment_recovers_load_angle(void) {
+    // Every voltage tap x every CT line x a spread of realistic load angles: with the
+    // channel labelled to match the line the CT is really on, the recovered angle must
+    // be the load angle itself, whatever the reference phase happens to be called.
+    const float loadAngles[] = {0.0f, 5.0f, 20.0f, 35.5f, 60.0f, 89.0f, -15.0f, -45.0f};
+
+    for (int v = 0; v < 3; v++) {
+        for (int c = 0; c < 3; c++) {
+            for (unsigned i = 0; i < sizeof(loadAngles) / sizeof(loadAngles[0]); i++) {
+                float raw = simulateRawAngleDeg(ROTATIONAL_PHASES[v], ROTATIONAL_PHASES[c], loadAngles[i], false);
+                PhaseUtils::LoadAngle a =
+                    PhaseUtils::loadAngleFromRawDeg(ROTATIONAL_PHASES[v], ROTATIONAL_PHASES[c], raw);
+
+                TEST_ASSERT_FLOAT_WITHIN(0.01f, loadAngles[i], a.angleDeg);
+                TEST_ASSERT_FLOAT_WITHIN(0.01f, loadAngles[i], a.foldedAngleDeg);
+                TEST_ASSERT_FALSE(a.activePowerNegative);
+            }
+        }
+    }
+}
+
+void test_reversed_ct_keeps_angle_and_flags_negative_power(void) {
+    // A backwards CT is a 180 deg flip: the load angle magnitude survives, the power
+    // direction does not. This is what the reverse flag / auto-detector then corrects.
+    for (int v = 0; v < 3; v++) {
+        for (int c = 0; c < 3; c++) {
+            float raw = simulateRawAngleDeg(ROTATIONAL_PHASES[v], ROTATIONAL_PHASES[c], 25.0f, true);
+            PhaseUtils::LoadAngle a =
+                PhaseUtils::loadAngleFromRawDeg(ROTATIONAL_PHASES[v], ROTATIONAL_PHASES[c], raw);
+
+            TEST_ASSERT_TRUE(a.activePowerNegative);
+            TEST_ASSERT_FLOAT_WITHIN(0.01f, 25.0f, a.foldedAngleDeg);
+            TEST_ASSERT_FLOAT_WITHIN(0.001f, cosf(25.0f * (float)M_PI / 180.0f), powerFactorFrom(a));
+        }
+    }
+}
+
+void test_swapped_labels_collapse_power_factor(void) {
+    // The failure mode that matters in the field: a resistive load whose two non-
+    // reference channels are labelled the wrong way round (sequence reversed) reads
+    // |PF| = 0.5 instead of 1.0, i.e. half the power, not a subtle error.
+    float raw = simulateRawAngleDeg(PHASE_3, PHASE_1, 0.0f, false); // CT really on L1, voltage on L3
+
+    PhaseUtils::LoadAngle right = PhaseUtils::loadAngleFromRawDeg(PHASE_3, PHASE_1, raw);
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, powerFactorFrom(right));
+
+    PhaseUtils::LoadAngle wrong = PhaseUtils::loadAngleFromRawDeg(PHASE_3, PHASE_2, raw); // mislabelled
+    TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.5f, fabsf(powerFactorFrom(wrong)));
+}
+
+void test_cyclic_relabelling_is_indistinguishable(void) {
+    // Only relative rotation is physical. Rotating every label by one step (L1L2L3 ->
+    // L2L3L1 -> L3L1L2) leaves every measurement identical, which is why an installer
+    // does not need to know which wire the utility calls L1 - only the sequence order.
+    for (int step = 0; step < 3; step++) {
+        Phase base = ROTATIONAL_PHASES[step];
+        Phase lag = PhaseUtils::getLaggingPhase(base);
+        Phase lead = PhaseUtils::getLeadingPhase(base);
+
+        float rawLag = simulateRawAngleDeg(base, lag, 30.0f, false);
+        float rawLead = simulateRawAngleDeg(base, lead, 30.0f, false);
+
+        TEST_ASSERT_FLOAT_WITHIN(0.01f, 30.0f, PhaseUtils::loadAngleFromRawDeg(base, lag, rawLag).angleDeg);
+        TEST_ASSERT_FLOAT_WITHIN(0.01f, 30.0f, PhaseUtils::loadAngleFromRawDeg(base, lead, rawLead).angleDeg);
+    }
+}
+
+void test_fold_always_lands_in_quadrant_and_keeps_cosine_positive(void) {
+    // Regression for the single-fold gap in _readMeterValues: raw +155.5 deg with a
+    // +120 deg correction reaches 275.5 deg, which one -180 fold leaves at 95.5 deg -
+    // a negative cosine multiplied by a positive sign, i.e. a power factor whose sign
+    // no longer means inductive/capacitive. Wrapping before folding closes it.
+    for (int v = 0; v < 3; v++) {
+        for (int c = 0; c < 3; c++) {
+            for (float raw = -180.0f; raw <= 180.0f; raw += 1.0f) {
+                PhaseUtils::LoadAngle a =
+                    PhaseUtils::loadAngleFromRawDeg(ROTATIONAL_PHASES[v], ROTATIONAL_PHASES[c], raw);
+
+                TEST_ASSERT_TRUE(a.angleDeg > -180.0f && a.angleDeg <= 180.0f);
+                TEST_ASSERT_TRUE(a.foldedAngleDeg >= -90.0f && a.foldedAngleDeg <= 90.0f);
+                // Epsilon because cosf(90 deg) rounds to -4.4e-8 in single precision;
+                // what matters is that no fold artefact can drive it properly negative.
+                TEST_ASSERT_TRUE(cosf(a.foldedAngleDeg * (float)M_PI / 180.0f) >= -1e-6f);
+            }
+        }
+    }
+}
+
+void test_split240_base_does_not_break_rotation(void) {
+    // A split-phase 240 V reference shares the L1 angle, so a rotational channel still
+    // gets a defined +-120 deg correction. (In _readMeterValues this pair currently
+    // matches neither the lagging nor the leading branch and fails every read.)
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, -120.0f, PhaseUtils::calculatePhaseShiftDeg(PHASE_SPLIT_240, PHASE_2));
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 120.0f, PhaseUtils::calculatePhaseShiftDeg(PHASE_SPLIT_240, PHASE_3));
+
+    float raw = simulateRawAngleDeg(PHASE_1, PHASE_2, 20.0f, false);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, 20.0f, PhaseUtils::loadAngleFromRawDeg(PHASE_SPLIT_240, PHASE_2, raw).angleDeg);
+}
+
+// ============================================================================
+// Field regression - three-phase cabinet captured 2026-07-25 (device_log.txt)
+//
+// Voltage tapped on L3, channel 0 = "Rete L3" = PHASE_3, so PHASE_1 is the lagging
+// line and PHASE_2 the leading one. The raw ANGLE values below are from the log; the
+// expected outputs are what the firmware printed for them. They pin the convention to
+// a real installation: with the opposite ANGLE sign convention both mains legs would
+// come out capacitive (-15.8 deg and -35.5 deg) while channel 0 - measured through the
+// energy registers, which never touch the ANGLE register - independently reported
+// +3730 VAR inductive on the same board. That contradiction is what makes this the
+// correct convention rather than merely a plausible one.
+// ============================================================================
+
+void test_field_rete_l2_leading_leg(void) {
+    // "Rete L2 (1) (phase 2): Angle difference: 15.8 deg (from -104.2 deg), PF 96.2%"
+    PhaseUtils::LoadAngle a = PhaseUtils::loadAngleFromRawDeg(PHASE_3, PHASE_2, -104.2f);
+    TEST_ASSERT_FLOAT_WITHIN(0.05f, 15.8f, a.foldedAngleDeg);
+    TEST_ASSERT_FALSE(a.activePowerNegative);
+    TEST_ASSERT_FLOAT_WITHIN(0.005f, 0.962f, powerFactorFrom(a));
+}
+
+void test_field_rete_l1_lagging_leg(void) {
+    // "Rete L1 (2) (phase 1): Angle difference: 35.5 deg (from 155.5 deg), PF 81.4%"
+    PhaseUtils::LoadAngle a = PhaseUtils::loadAngleFromRawDeg(PHASE_3, PHASE_1, 155.5f);
+    TEST_ASSERT_FLOAT_WITHIN(0.05f, 35.5f, a.foldedAngleDeg);
+    TEST_ASSERT_FALSE(a.activePowerNegative);
+    TEST_ASSERT_FLOAT_WITHIN(0.005f, 0.814f, powerFactorFrom(a));
+}
+
+void test_field_reversed_ct_on_correct_phase(void) {
+    // "Cella nuova L1 (4) (phase 1): Angle difference: 32.1 deg (from -27.9 deg),
+    //  PF 84.7% (negative power)" - configured on the lagging line (L1), CT clipped
+    // backwards: a 32.1 deg inductive load read the wrong way round.
+    PhaseUtils::LoadAngle a = PhaseUtils::loadAngleFromRawDeg(PHASE_3, PHASE_1, -27.9f);
+    TEST_ASSERT_TRUE(a.activePowerNegative);
+    TEST_ASSERT_FLOAT_WITHIN(0.05f, 32.1f, a.foldedAngleDeg);
+    TEST_ASSERT_FLOAT_WITHIN(0.005f, 0.847f, powerFactorFrom(a));
+
+    // The third line is ruled out outright: read as the leading line (L2) the same raw
+    // value gives 92.1 deg, which is not a load in either orientation (forward is past
+    // 90 deg, reversed leaves PF 0.04 on a 3 A circuit). That leaves L1-reversed and
+    // L3-forward-capacitive, and a cold room compressor is not capacitive.
+    PhaseUtils::LoadAngle asLeading = PhaseUtils::loadAngleFromRawDeg(PHASE_3, PHASE_2, -27.9f);
+    TEST_ASSERT_FLOAT_WITHIN(0.05f, 92.1f, asLeading.angleDeg);
+    TEST_ASSERT_TRUE(fabsf(powerFactorFrom(asLeading)) < 0.05f);
+}
+
+void test_field_old_convention_hid_a_reversed_ct(void) {
+    // Same cabinet, raw +87.4 deg on "Cella nuova L2" (channel 6). Under the pre-#188
+    // convention this channel took the -120 deg correction and printed -32.6 deg /
+    // PF -84.3% / +571 W: a plausible-looking positive load with a nonsense capacitive
+    // power factor. Under the current convention it resolves to a 27.4 deg inductive
+    // load read backwards, which the reversal detector can then correct.
+    PhaseUtils::LoadAngle now = PhaseUtils::loadAngleFromRawDeg(PHASE_3, PHASE_2, 87.4f);
+    TEST_ASSERT_TRUE(now.activePowerNegative);
+    TEST_ASSERT_FLOAT_WITHIN(0.05f, 27.4f, now.foldedAngleDeg);
+
+    float oldConvention = 87.4f - 120.0f; // what the swapped lagging/leading map produced
+    TEST_ASSERT_FLOAT_WITHIN(0.05f, -32.6f, oldConvention);
+}
+
+// ============================================================================
+// powersFromFoldedAngle - P and Q must stay a consistent phasor
+// ============================================================================
+
+void test_forward_inductive_load_imports_both(void) {
+    PhaseUtils::SignedPowers p = PhaseUtils::powersFromFoldedAngle(1000.0f, 30.0f, false, false);
+    TEST_ASSERT_TRUE(p.activePower > 0.0f);
+    TEST_ASSERT_TRUE(p.reactivePower > 0.0f);
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, 866.0f, p.activePower);
+    TEST_ASSERT_FLOAT_WITHIN(0.5f, 500.0f, p.reactivePower);
+    TEST_ASSERT_FLOAT_WITHIN(0.005f, 0.866f, p.powerFactor);
+}
+
+void test_forward_capacitive_load_has_negative_pf_and_q(void) {
+    PhaseUtils::SignedPowers p = PhaseUtils::powersFromFoldedAngle(1000.0f, -30.0f, false, false);
+    TEST_ASSERT_TRUE(p.activePower > 0.0f);
+    TEST_ASSERT_TRUE(p.reactivePower < 0.0f);
+    TEST_ASSERT_FLOAT_WITHIN(0.005f, -0.866f, p.powerFactor);
+}
+
+void test_flipped_current_negates_both_powers(void) {
+    // The fix: a backwards CT (or genuine export) is a 180 deg flip of the current
+    // phasor, so P and Q must land in the opposite quadrant together. Publishing
+    // P < 0 with Q > 0 claims real power leaving while reactive power arrives.
+    PhaseUtils::SignedPowers forward = PhaseUtils::powersFromFoldedAngle(1000.0f, 30.0f, false, false);
+
+    PhaseUtils::SignedPowers reversedFlag = PhaseUtils::powersFromFoldedAngle(1000.0f, 30.0f, true, false);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, -forward.activePower, reversedFlag.activePower);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, -forward.reactivePower, reversedFlag.reactivePower);
+
+    PhaseUtils::SignedPowers negativeBranch = PhaseUtils::powersFromFoldedAngle(1000.0f, 30.0f, false, true);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, -forward.activePower, negativeBranch.activePower);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, -forward.reactivePower, negativeBranch.reactivePower);
+
+    // Both flips together cancel: a reversed CT on a genuinely exporting circuit reads
+    // forward again, which is exactly what the reverse flag is for.
+    PhaseUtils::SignedPowers both = PhaseUtils::powersFromFoldedAngle(1000.0f, 30.0f, true, true);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, forward.activePower, both.activePower);
+    TEST_ASSERT_FLOAT_WITHIN(0.01f, forward.reactivePower, both.reactivePower);
+}
+
+void test_power_factor_sign_is_independent_of_flow_direction(void) {
+    // PF sign carries inductive/capacitive, not direction (direction is the sign of P),
+    // so flipping the current phasor must not touch it.
+    for (int rev = 0; rev < 2; rev++) {
+        for (int neg = 0; neg < 2; neg++) {
+            PhaseUtils::SignedPowers p =
+                PhaseUtils::powersFromFoldedAngle(500.0f, 45.0f, rev != 0, neg != 0);
+            TEST_ASSERT_FLOAT_WITHIN(0.005f, 0.707f, p.powerFactor);
+        }
+    }
+}
+
+void test_powers_conserve_apparent_power(void) {
+    // P^2 + Q^2 == S^2 across the folded range and every flip combination.
+    const float angles[] = {-89.0f, -45.0f, -5.0f, 0.0f, 5.0f, 45.0f, 89.0f};
+    for (unsigned i = 0; i < sizeof(angles) / sizeof(angles[0]); i++) {
+        for (int rev = 0; rev < 2; rev++) {
+            for (int neg = 0; neg < 2; neg++) {
+                PhaseUtils::SignedPowers p =
+                    PhaseUtils::powersFromFoldedAngle(2400.0f, angles[i], rev != 0, neg != 0);
+                float s = sqrtf(p.activePower * p.activePower + p.reactivePower * p.reactivePower);
+                TEST_ASSERT_FLOAT_WITHIN(0.5f, 2400.0f, s);
+            }
+        }
+    }
+}
+
+void test_field_reversed_ct_publishes_a_real_quadrant(void) {
+    // "Cella nuova L1 (4)": raw -27.9 deg on the lagging line resolves to a 32.1 deg
+    // inductive load read backwards. Before the fix this published P < 0 with Q > 0.
+    PhaseUtils::LoadAngle a = PhaseUtils::loadAngleFromRawDeg(PHASE_3, PHASE_1, -27.9f);
+    PhaseUtils::SignedPowers p =
+        PhaseUtils::powersFromFoldedAngle(700.0f, a.foldedAngleDeg, false, a.activePowerNegative);
+    TEST_ASSERT_TRUE(p.activePower < 0.0f);
+    TEST_ASSERT_TRUE(p.reactivePower < 0.0f);
+    TEST_ASSERT_TRUE(p.powerFactor > 0.0f); // still inductive
+}
+
+// ============================================================================
 // runner
 // ============================================================================
 
@@ -146,6 +420,25 @@ int main(int, char **) {
     RUN_TEST(test_regression_L3_angle_is_positive);
     RUN_TEST(test_regression_lagging_from_L1_is_L2_not_L3);
     RUN_TEST(test_regression_leading_from_L1_is_L3_not_L2);
+
+    RUN_TEST(test_correct_assignment_recovers_load_angle);
+    RUN_TEST(test_reversed_ct_keeps_angle_and_flags_negative_power);
+    RUN_TEST(test_swapped_labels_collapse_power_factor);
+    RUN_TEST(test_cyclic_relabelling_is_indistinguishable);
+    RUN_TEST(test_fold_always_lands_in_quadrant_and_keeps_cosine_positive);
+    RUN_TEST(test_split240_base_does_not_break_rotation);
+
+    RUN_TEST(test_field_rete_l2_leading_leg);
+    RUN_TEST(test_field_rete_l1_lagging_leg);
+    RUN_TEST(test_field_reversed_ct_on_correct_phase);
+    RUN_TEST(test_field_old_convention_hid_a_reversed_ct);
+
+    RUN_TEST(test_forward_inductive_load_imports_both);
+    RUN_TEST(test_forward_capacitive_load_has_negative_pf_and_q);
+    RUN_TEST(test_flipped_current_negates_both_powers);
+    RUN_TEST(test_power_factor_sign_is_independent_of_flow_direction);
+    RUN_TEST(test_powers_conserve_apparent_power);
+    RUN_TEST(test_field_reversed_ct_publishes_a_real_quadrant);
 
     return UNITY_END();
 }


### PR DESCRIPTION
Two defects in the non-base-phase measurement branch, plus a guard on the
voltage reference and two channel-page changes. Only reachable when a channel
sits on a different line than channel 0.

## What was wrong

**Fold without wrap.** The rotated angle (`raw ±120°`) reaches 300°, but it was
folded once without first wrapping into `(-180, 180]`. Beyond `|rot| > 270°` a
single fold leaves the angle outside the ±90° quadrant, where `cos()` flips sign
and the active power sign inverts. `|PF|` stays correct, so it is a pure
direction error, which is what made it invisible.

**Q not flipped with P.** Reactive power was signed from the power factor alone
while active power took both the `reverse` and negative flips. A backwards CT
therefore published a `(P, Q)` pair that was not a physical phasor.

**Split-240 as the reference.** Channel 0 carries the single voltage reference,
so its phase defines the frame for every other channel. Split-phase 240 V is a
2x multiplier, not a rotation. Nothing rejected it.

## Measured on a live three-phase installation

Device `907069875368`, running this exact binary (`sketch_md5 9b131632…`),
DEBUG captured over a 110 s window:

- **185/185** angle lines match an independent re-implementation, driven off
  the real channel config. Zero mismatches on folded angle, PF and the
  negative-power flag.
- **57/185** samples cross ±180° after rotation. **14** flip the active power
  sign versus the old code, landing exactly in the `|rot| > 270°` band the
  theory predicts.
  - ch11 (`role: load`): one sample would have gone `P < 0` and been discarded
    entirely by the role clamp, on a channel genuinely drawing 2013 W.
  - ch2 (`role: grid`): 13 samples would have reported export while the leg was
    importing.
- Cross-check on the untouched energy-register path: the three PV legs read PF
  **0.9986 / 0.9997 / 1.0000** balanced within 0.8%, with ch3 on the base phase
  computed by code this PR does not touch.

Also verified live: split-240 rejected on channel 0 (400) and accepted on
channel 1 (200); no ERROR/FATAL/WARNING for the whole window; `issues` shadow
`active_count: 0`.

## Testing

- `pio test -e native`: 265 cases green, 34 of them new in `test_phase_utils`.
- Bench e2e on the dev device, angle branch forced via a deliberately
  mismatched phase, hand-checked against the computed values.
- Both `esp32s3-dev` and `esp32s3-prod` build.

## Known gap

`source/html/channel.html` has **not** been executed. Both changes there (the
`computePhaseCandidates` sign simplification and the new 10 s config poll) are
reasoned-about only. The preview change is correct only alongside the firmware
fix in this PR, and web assets are compiled into the binary, so the two cannot
ship apart. Merging with this understood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fYJpjyVvN3SufNbtDdtQB
