### PR TITLE
feat(ade7953): per-channel startMeasuringUnixTimeMs reset boundary

### DIFF
--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -306,7 +306,7 @@
 #define CHANNEL_IS_PRODUCTION_KEY_LEGACY "is_prod_%u" // Format: is_prod_0 (10 chars)
 #define CHANNEL_IS_BATTERY_KEY_LEGACY "is_batt_%u" // Format: is_batt_0 (10 chars)
 
-// Per-channel "counters have been accumulating continuously since this timestamp" (issue #314, edge side).
+// Per-channel "counters have been accumulating continuously since this timestamp".
 // 0 = unset. Resolved to a real unix ms timestamp by the _energySaveTask drain the first time the
 // clock is synced while the value is still 0 - covers a fresh channel, a reset, and (once, on
 // upgrade) an existing device that never had this field before. Any other value is a real timestamp.

--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -311,11 +311,9 @@
 // clock is synced while the value is still 0 - covers a fresh channel, a reset, and (once, on
 // upgrade) an existing device that never had this field before. Any other value is a real timestamp.
 #define CHANNEL_START_MEASURING_KEY "start_meas_%u" // Format: start_meas_0 (13 chars)
-// Sanity bounds for externally-supplied (shadow delta / REST) values: rejects a plausible-seconds
-// value sent by mistake instead of ms (too small) or a microseconds/garbage value (too large).
-// 2020-01-01T00:00:00Z / 2100-01-01T00:00:00Z in ms - comfortably around any real device timestamp.
-#define MIN_PLAUSIBLE_START_MEASURING_UNIX_TIME_MS 1577836800000ULL
-#define MAX_PLAUSIBLE_START_MEASURING_UNIX_TIME_MS 4102444800000ULL
+// Plausibility of externally-supplied (shadow delta / REST) values is checked via
+// ShadowLogic::isPlausibleStartMeasuringUnixTimeMs, which defers to UnixTime::isValid
+// (lib/unix_time) - the same "is this a real unix timestamp" check meter timestamps use.
 
 // Default channel values
 #define DEFAULT_CHANNEL_ACTIVE false

--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -311,9 +311,11 @@
 // clock is synced while the value is still 0 - covers a fresh channel, a reset, and (once, on
 // upgrade) an existing device that never had this field before. Any other value is a real timestamp.
 #define CHANNEL_START_MEASURING_KEY "start_meas_%u" // Format: start_meas_0 (13 chars)
-// Sanity floor for externally-supplied (shadow delta) values: rejects a plausible-seconds value sent by
-// mistake instead of ms. 2020-01-01T00:00:00Z in ms - comfortably below any real device timestamp.
+// Sanity bounds for externally-supplied (shadow delta / REST) values: rejects a plausible-seconds
+// value sent by mistake instead of ms (too small) or a microseconds/garbage value (too large).
+// 2020-01-01T00:00:00Z / 2100-01-01T00:00:00Z in ms - comfortably around any real device timestamp.
 #define MIN_PLAUSIBLE_START_MEASURING_UNIX_TIME_MS 1577836800000ULL
+#define MAX_PLAUSIBLE_START_MEASURING_UNIX_TIME_MS 4102444800000ULL
 
 // Default channel values
 #define DEFAULT_CHANNEL_ACTIVE false
@@ -469,7 +471,7 @@ struct ChannelData
   ChannelRole role;
 
   // Device-reported "counters have been accumulating continuously since this timestamp" (unix ms).
-  // 0 = never set. See CHANNEL_START_MEASURING_KEY above for the full sentinel contract.
+  // 0 = unset. See CHANNEL_START_MEASURING_KEY above for the full contract.
   uint64_t startMeasuringUnixTimeMs;
 
   // Transient runtime flags (NOT persisted to NVS, NOT exported to JSON).

--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -629,7 +629,7 @@ namespace Ade7953
     void getChannelLabel(uint8_t channelIndex, char* buffer, size_t bufferSize); // No need for bool return, fallback is the default constructor value if getChannelData failed
     bool getChannelData(ChannelData &channelData, uint8_t channelIndex);
     bool setChannelData(const ChannelData &channelData, uint8_t channelIndex, bool* roleChanged = nullptr, bool armTransients = true);
-    void resetChannelData(uint8_t channelIndex);
+    bool resetChannelData(uint8_t channelIndex);
 
     // Channel data management - JSON operations
     bool getChannelDataAsJson(JsonDocument &jsonDocument, uint8_t channelIndex);

--- a/source/include/ade7953.h
+++ b/source/include/ade7953.h
@@ -306,6 +306,15 @@
 #define CHANNEL_IS_PRODUCTION_KEY_LEGACY "is_prod_%u" // Format: is_prod_0 (10 chars)
 #define CHANNEL_IS_BATTERY_KEY_LEGACY "is_batt_%u" // Format: is_batt_0 (10 chars)
 
+// Per-channel "counters have been accumulating continuously since this timestamp" (issue #314, edge side).
+// 0 = unset. Resolved to a real unix ms timestamp by the _energySaveTask drain the first time the
+// clock is synced while the value is still 0 - covers a fresh channel, a reset, and (once, on
+// upgrade) an existing device that never had this field before. Any other value is a real timestamp.
+#define CHANNEL_START_MEASURING_KEY "start_meas_%u" // Format: start_meas_0 (13 chars)
+// Sanity floor for externally-supplied (shadow delta) values: rejects a plausible-seconds value sent by
+// mistake instead of ms. 2020-01-01T00:00:00Z in ms - comfortably below any real device timestamp.
+#define MIN_PLAUSIBLE_START_MEASURING_UNIX_TIME_MS 1577836800000ULL
+
 // Default channel values
 #define DEFAULT_CHANNEL_ACTIVE false
 #define DEFAULT_CHANNEL_0_ACTIVE true // Channel 0 must always be active
@@ -459,6 +468,10 @@ struct ChannelData
   // Channel role
   ChannelRole role;
 
+  // Device-reported "counters have been accumulating continuously since this timestamp" (unix ms).
+  // 0 = never set. See CHANNEL_START_MEASURING_KEY above for the full sentinel contract.
+  uint64_t startMeasuringUnixTimeMs;
+
   // Transient runtime flags (NOT persisted to NVS, NOT exported to JSON).
   // Set on inactive->active transition (and on role change for the polarity check).
   // Used by the scheduler / meter task to give a freshly activated channel a
@@ -474,6 +487,7 @@ struct ChannelData
       phase(PHASE_1),
       ctSpecification(CtSpecification()),
       role(DEFAULT_CHANNEL_ROLE),
+      startMeasuringUnixTimeMs(0),
       _pendingPriorityRead(false),
       _pendingPolarityCheck(false)
     {
@@ -488,6 +502,7 @@ struct ChannelData
       phase(DEFAULT_CHANNEL_PHASE),
       ctSpecification(CtSpecification()),
       role(idx == 0 ? DEFAULT_CHANNEL_0_ROLE : DEFAULT_CHANNEL_ROLE),
+      startMeasuringUnixTimeMs(0),
       _pendingPriorityRead(false),
       _pendingPolarityCheck(false)
     {

--- a/source/include/customtime.h
+++ b/source/include/customtime.h
@@ -6,9 +6,10 @@
 #include <AdvancedLogger.h>
 #include <Arduino.h>
 #include <Preferences.h>
- 
+
 #include "constants.h"
 #include "utils.h"
+#include "unix_time.h"
 
 // Fallback servers, tried after the default gateway (see CustomTime::begin/_checkAndSyncTime) -
 // NTP_SERVER_1 is a DNS-dependent public pool, NTP_SERVER_2 a raw IP so it still works if DNS fails.
@@ -22,12 +23,6 @@
 #define TIMESTAMP_ISO_FORMAT "%04d-%02d-%02dT%02d:%02d:%02d.%03ldZ" // ISO 8601 format with milliseconds
 #define DATE_FORMAT "%Y-%m-%d"
 #define DATE_ISO_FORMAT "%04d-%02d-%02d"
-
-// Time utilities
-#define MINIMUM_UNIX_TIME_SECONDS 1000000000 // Corresponds to 2001
-#define MINIMUM_UNIX_TIME_MILLISECONDS 1000000000000 // Corresponds to 2001
-#define MAXIMUM_UNIX_TIME_SECONDS 4102444800 // Corresponds to 2100
-#define MAXIMUM_UNIX_TIME_MILLISECONDS 4102444800000 // Corresponds to 2100
 
 namespace CustomTime {
     bool begin();

--- a/source/lib/shadow_logic/shadow_logic.cpp
+++ b/source/lib/shadow_logic/shadow_logic.cpp
@@ -113,12 +113,12 @@ size_t parseChannelList(const char* spec, uint8_t channelCount,
     return written;
 }
 
-bool isPlausibleStartMeasuringUnixTimeMs(uint64_t valueMs, uint64_t minPlausibleMs, uint64_t maxPlausibleMs) {
-    return valueMs == 0 || (valueMs >= minPlausibleMs && valueMs <= maxPlausibleMs);
+bool isPlausibleStartMeasuringUnixTimeMs(uint64_t valueMs) {
+    return valueMs == 0 || UnixTime::isValid(valueMs, /*isMilliseconds=*/true);
 }
 
-bool shouldAdoptStartMeasuringUnixTimeMs(bool present, uint64_t candidateMs, uint64_t minPlausibleMs, uint64_t maxPlausibleMs) {
-    return present && isPlausibleStartMeasuringUnixTimeMs(candidateMs, minPlausibleMs, maxPlausibleMs);
+bool shouldAdoptStartMeasuringUnixTimeMs(bool present, uint64_t candidateMs) {
+    return present && isPlausibleStartMeasuringUnixTimeMs(candidateMs);
 }
 
 } // namespace ShadowLogic

--- a/source/lib/shadow_logic/shadow_logic.cpp
+++ b/source/lib/shadow_logic/shadow_logic.cpp
@@ -113,4 +113,8 @@ size_t parseChannelList(const char* spec, uint8_t channelCount,
     return written;
 }
 
+bool isPlausibleStartMeasuringUnixTimeMs(uint64_t valueMs, uint64_t minPlausibleMs) {
+    return valueMs == 0 || valueMs >= minPlausibleMs;
+}
+
 } // namespace ShadowLogic

--- a/source/lib/shadow_logic/shadow_logic.cpp
+++ b/source/lib/shadow_logic/shadow_logic.cpp
@@ -113,8 +113,12 @@ size_t parseChannelList(const char* spec, uint8_t channelCount,
     return written;
 }
 
-bool isPlausibleStartMeasuringUnixTimeMs(uint64_t valueMs, uint64_t minPlausibleMs) {
-    return valueMs == 0 || valueMs >= minPlausibleMs;
+bool isPlausibleStartMeasuringUnixTimeMs(uint64_t valueMs, uint64_t minPlausibleMs, uint64_t maxPlausibleMs) {
+    return valueMs == 0 || (valueMs >= minPlausibleMs && valueMs <= maxPlausibleMs);
+}
+
+bool shouldAdoptStartMeasuringUnixTimeMs(bool present, uint64_t candidateMs, uint64_t minPlausibleMs, uint64_t maxPlausibleMs) {
+    return present && isPlausibleStartMeasuringUnixTimeMs(candidateMs, minPlausibleMs, maxPlausibleMs);
 }
 
 } // namespace ShadowLogic

--- a/source/lib/shadow_logic/shadow_logic.h
+++ b/source/lib/shadow_logic/shadow_logic.h
@@ -86,11 +86,20 @@ size_t parseChannelList(const char* spec, uint8_t channelCount,
                          bool* invalidTokenSeen);
 
 // Sanity check for an externally-supplied (shadow delta / REST) value for the
-// per-channel "startMeasuringUnixTimeMs" field: 0 (never set) is
-// always accepted; anything else must be at or above minPlausibleMs, a floor
-// the caller sets comfortably below any real device timestamp. Catches the
-// most common unit mistake - a caller sending unix seconds instead of ms,
-// which would land 1000x too small - without hard-coding the floor here.
-bool isPlausibleStartMeasuringUnixTimeMs(uint64_t valueMs, uint64_t minPlausibleMs);
+// per-channel "startMeasuringUnixTimeMs" field: 0 (never set) is always
+// accepted; anything else must fall within [minPlausibleMs, maxPlausibleMs],
+// bounds the caller sets comfortably around any real device timestamp.
+// Catches unit mistakes in either direction - seconds instead of ms (too
+// small) or microseconds/garbage (too large) - without hard-coding the
+// bounds here.
+bool isPlausibleStartMeasuringUnixTimeMs(uint64_t valueMs, uint64_t minPlausibleMs, uint64_t maxPlausibleMs);
+
+// Decides whether an incoming JSON field value should overwrite the current
+// startMeasuringUnixTimeMs. Absent (present=false) always means "leave
+// unchanged" - this is what makes a config update that never mentions the
+// field safe, whether it's a partial (shadow delta) or full (bulk PUT)
+// update. Present-but-implausible also leaves it unchanged (caller should
+// warn using the candidate it already has).
+bool shouldAdoptStartMeasuringUnixTimeMs(bool present, uint64_t candidateMs, uint64_t minPlausibleMs, uint64_t maxPlausibleMs);
 
 } // namespace ShadowLogic

--- a/source/lib/shadow_logic/shadow_logic.h
+++ b/source/lib/shadow_logic/shadow_logic.h
@@ -85,4 +85,12 @@ size_t parseChannelList(const char* spec, uint8_t channelCount,
                          uint8_t* validIndices, size_t maxOut,
                          bool* invalidTokenSeen);
 
+// Sanity check for an externally-supplied (shadow delta / REST) value for the
+// per-channel "startMeasuringUnixTimeMs" field (issue #314): 0 (never set) is
+// always accepted; anything else must be at or above minPlausibleMs, a floor
+// the caller sets comfortably below any real device timestamp. Catches the
+// most common unit mistake - a caller sending unix seconds instead of ms,
+// which would land 1000x too small - without hard-coding the floor here.
+bool isPlausibleStartMeasuringUnixTimeMs(uint64_t valueMs, uint64_t minPlausibleMs);
+
 } // namespace ShadowLogic

--- a/source/lib/shadow_logic/shadow_logic.h
+++ b/source/lib/shadow_logic/shadow_logic.h
@@ -86,7 +86,7 @@ size_t parseChannelList(const char* spec, uint8_t channelCount,
                          bool* invalidTokenSeen);
 
 // Sanity check for an externally-supplied (shadow delta / REST) value for the
-// per-channel "startMeasuringUnixTimeMs" field (issue #314): 0 (never set) is
+// per-channel "startMeasuringUnixTimeMs" field: 0 (never set) is
 // always accepted; anything else must be at or above minPlausibleMs, a floor
 // the caller sets comfortably below any real device timestamp. Catches the
 // most common unit mistake - a caller sending unix seconds instead of ms,

--- a/source/lib/shadow_logic/shadow_logic.h
+++ b/source/lib/shadow_logic/shadow_logic.h
@@ -6,6 +6,8 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "unix_time.h"
+
 // Pure helpers for the AWS IoT Device Shadow config feature (issue #159).
 //
 // Everything here is free-standing: no Arduino, no ArduinoJson, no FreeRTOS, no
@@ -87,12 +89,11 @@ size_t parseChannelList(const char* spec, uint8_t channelCount,
 
 // Sanity check for an externally-supplied (shadow delta / REST) value for the
 // per-channel "startMeasuringUnixTimeMs" field: 0 (never set) is always
-// accepted; anything else must fall within [minPlausibleMs, maxPlausibleMs],
-// bounds the caller sets comfortably around any real device timestamp.
-// Catches unit mistakes in either direction - seconds instead of ms (too
-// small) or microseconds/garbage (too large) - without hard-coding the
-// bounds here.
-bool isPlausibleStartMeasuringUnixTimeMs(uint64_t valueMs, uint64_t minPlausibleMs, uint64_t maxPlausibleMs);
+// accepted; anything else must be a plausible real unix-ms timestamp per
+// UnixTime::isValid, the same bounds used for meter timestamps elsewhere -
+// catches unit mistakes in either direction (seconds instead of ms, or
+// microseconds/garbage) without a second, field-specific set of bounds.
+bool isPlausibleStartMeasuringUnixTimeMs(uint64_t valueMs);
 
 // Decides whether an incoming JSON field value should overwrite the current
 // startMeasuringUnixTimeMs. Absent (present=false) always means "leave
@@ -100,6 +101,6 @@ bool isPlausibleStartMeasuringUnixTimeMs(uint64_t valueMs, uint64_t minPlausible
 // field safe, whether it's a partial (shadow delta) or full (bulk PUT)
 // update. Present-but-implausible also leaves it unchanged (caller should
 // warn using the candidate it already has).
-bool shouldAdoptStartMeasuringUnixTimeMs(bool present, uint64_t candidateMs, uint64_t minPlausibleMs, uint64_t maxPlausibleMs);
+bool shouldAdoptStartMeasuringUnixTimeMs(bool present, uint64_t candidateMs);
 
 } // namespace ShadowLogic

--- a/source/lib/unix_time/unix_time.cpp
+++ b/source/lib/unix_time/unix_time.cpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#include "unix_time.h"
+
+namespace UnixTime {
+
+bool isValid(uint64_t unixTime, bool isMilliseconds) {
+    if (isMilliseconds) {
+        return unixTime >= MIN_MILLISECONDS && unixTime <= MAX_MILLISECONDS;
+    }
+    return unixTime >= MIN_SECONDS && unixTime <= MAX_SECONDS;
+}
+
+} // namespace UnixTime

--- a/source/lib/unix_time/unix_time.h
+++ b/source/lib/unix_time/unix_time.h
@@ -9,12 +9,12 @@
 // globals. src/customtime.cpp wraps this as CustomTime::isUnixTimeValid for
 // the rest of the firmware; this is the host-testable source of truth (see
 // test/test_unix_time) so the bounds math isn't silently reimplemented
-// elsewhere a "does this look like a real timestamp" question comes up (e.g.
-// ShadowLogic::isPlausibleStartMeasuringUnixTimeMs).
+// elsewhere whenever a "does this look like a real timestamp" question comes
+// up (e.g. ShadowLogic::isPlausibleStartMeasuringUnixTimeMs).
 namespace UnixTime {
 
-constexpr uint64_t MIN_SECONDS = 1000000000ULL;         // 2001-01-01T00:00:00Z
-constexpr uint64_t MIN_MILLISECONDS = 1000000000000ULL; // 2001-01-01T00:00:00Z
+constexpr uint64_t MIN_SECONDS = 1000000000ULL;         // 2001-09-09T01:46:40Z
+constexpr uint64_t MIN_MILLISECONDS = 1000000000000ULL; // 2001-09-09T01:46:40Z
 constexpr uint64_t MAX_SECONDS = 4102444800ULL;         // 2100-01-01T00:00:00Z
 constexpr uint64_t MAX_MILLISECONDS = 4102444800000ULL; // 2100-01-01T00:00:00Z
 

--- a/source/lib/unix_time/unix_time.h
+++ b/source/lib/unix_time/unix_time.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#pragma once
+
+#include <cstdint>
+
+// Pure plausibility check for a real device unix timestamp: no Arduino, no
+// globals. src/customtime.cpp wraps this as CustomTime::isUnixTimeValid for
+// the rest of the firmware; this is the host-testable source of truth (see
+// test/test_unix_time) so the bounds math isn't silently reimplemented
+// elsewhere a "does this look like a real timestamp" question comes up (e.g.
+// ShadowLogic::isPlausibleStartMeasuringUnixTimeMs).
+namespace UnixTime {
+
+constexpr uint64_t MIN_SECONDS = 1000000000ULL;         // 2001-01-01T00:00:00Z
+constexpr uint64_t MIN_MILLISECONDS = 1000000000000ULL; // 2001-01-01T00:00:00Z
+constexpr uint64_t MAX_SECONDS = 4102444800ULL;         // 2100-01-01T00:00:00Z
+constexpr uint64_t MAX_MILLISECONDS = 4102444800000ULL; // 2100-01-01T00:00:00Z
+
+// True if unixTime falls within [MIN, MAX] for the given unit - catches unit
+// mistakes (seconds sent as ms, or vice versa) and garbage/overflow values
+// that land far outside a plausible device-clock reading either way.
+bool isValid(uint64_t unixTime, bool isMilliseconds = true);
+
+} // namespace UnixTime

--- a/source/resources/swagger.yaml
+++ b/source/resources/swagger.yaml
@@ -2328,7 +2328,7 @@ paths:
                   type: integer
                   format: int64
                   minimum: 0
-                  description: "Reset boundary for this channel's energy counters, in unix ms. 0 = unset (no boundary). Omit to leave the current value unchanged; the device rejects any non-zero value outside a plausible range (year 2020-2100 in ms) and keeps the current value instead. Normally set by the device itself; write only to realign a device's boundary (e.g. after a firmware upgrade)."
+                  description: "Reset boundary for this channel's energy counters, in unix ms. 0 = unset (no boundary). Omit to leave the current value unchanged - do not echo back the value from a GET, since an explicit 0 IS treated as a real write and will wipe the boundary. Non-zero values outside a plausible range (year 2020-2100 in ms) are rejected (400 on PATCH, silently kept unchanged on a full PUT). Normally set by the device itself; write only to realign a device's boundary (e.g. after a firmware upgrade)."
                   example: 1717000000000
               minProperties: 2
             examples:
@@ -3470,7 +3470,7 @@ components:
           type: integer
           format: int64
           minimum: 0
-          description: "Reset boundary for this channel's energy counters, in unix ms. 0 = unset (no boundary). Always reported. On write, omit to leave the current value unchanged; the device rejects any non-zero value outside a plausible range (year 2020-2100 in ms) and keeps the current value instead. Normally set by the device itself; write only to realign a device's boundary (e.g. after a firmware upgrade)."
+          description: "Reset boundary for this channel's energy counters, in unix ms. 0 = unset (no boundary). Always reported. On write, omit to leave the current value unchanged - do not echo back the value from a GET, since an explicit 0 IS treated as a real write and will wipe the boundary. Non-zero values outside a plausible range (year 2020-2100 in ms) are rejected (400 on PATCH, silently kept unchanged on a full PUT). Normally set by the device itself; write only to realign a device's boundary (e.g. after a firmware upgrade)."
           example: 1717000000000
 
     MeterValues:

--- a/source/resources/swagger.yaml
+++ b/source/resources/swagger.yaml
@@ -2324,6 +2324,12 @@ paths:
                   type: string
                   enum: [load, grid, pv, battery, inverter]
                   description: "Channel role: load, grid (+ import/- export), pv (+ generation), battery (+ discharge/- charge), inverter (PV + battery DC-coupled)"
+                startMeasuringUnixTimeMs:
+                  type: integer
+                  format: int64
+                  minimum: 0
+                  description: "Reset boundary for this channel's energy counters, in unix ms. 0 = unset (no boundary). Omit to leave the current value unchanged; the device rejects any non-zero value outside a plausible range (year 2020-2100 in ms) and keeps the current value instead. Normally set by the device itself; write only to realign a device's boundary (e.g. after a firmware upgrade)."
+                  example: 1717000000000
               minProperties: 2
             examples:
               enable_channel:
@@ -3460,6 +3466,12 @@ components:
           description: "Channel role determining measurement behavior and sign convention"
           example: "load"
           default: "load"
+        startMeasuringUnixTimeMs:
+          type: integer
+          format: int64
+          minimum: 0
+          description: "Reset boundary for this channel's energy counters, in unix ms. 0 = unset (no boundary). Always reported. On write, omit to leave the current value unchanged; the device rejects any non-zero value outside a plausible range (year 2020-2100 in ms) and keeps the current value instead. Normally set by the device itself; write only to realign a device's boundary (e.g. after a firmware upgrade)."
+          example: 1717000000000
 
     MeterValues:
       type: object

--- a/source/resources/swagger.yaml
+++ b/source/resources/swagger.yaml
@@ -2328,7 +2328,7 @@ paths:
                   type: integer
                   format: int64
                   minimum: 0
-                  description: "Reset boundary for this channel's energy counters, in unix ms. 0 = unset (no boundary). Omit to leave the current value unchanged - do not echo back the value from a GET, since an explicit 0 IS treated as a real write and will wipe the boundary. Non-zero values outside a plausible range (year 2020-2100 in ms) are rejected (400 on PATCH, silently kept unchanged on a full PUT). Normally set by the device itself; write only to realign a device's boundary (e.g. after a firmware upgrade)."
+                  description: "Reset boundary for this channel's energy counters, in unix ms. 0 = unset (no boundary). Omit to leave the current value unchanged - do not echo back the value from a GET, since an explicit 0 IS treated as a real write and will wipe the boundary. Non-zero values outside a plausible range (year 2001-2100 in ms) are rejected (400 on PATCH, silently kept unchanged on a full PUT). Normally set by the device itself; write only to realign a device's boundary (e.g. after a firmware upgrade)."
                   example: 1717000000000
               minProperties: 2
             examples:
@@ -3470,7 +3470,7 @@ components:
           type: integer
           format: int64
           minimum: 0
-          description: "Reset boundary for this channel's energy counters, in unix ms. 0 = unset (no boundary). Always reported. On write, omit to leave the current value unchanged - do not echo back the value from a GET, since an explicit 0 IS treated as a real write and will wipe the boundary. Non-zero values outside a plausible range (year 2020-2100 in ms) are rejected (400 on PATCH, silently kept unchanged on a full PUT). Normally set by the device itself; write only to realign a device's boundary (e.g. after a firmware upgrade)."
+          description: "Reset boundary for this channel's energy counters, in unix ms. 0 = unset (no boundary). Always reported. On write, omit to leave the current value unchanged - do not echo back the value from a GET, since an explicit 0 IS treated as a real write and will wipe the boundary. Non-zero values outside a plausible range (year 2001-2100 in ms) are rejected (400 on PATCH, silently kept unchanged on a full PUT). Normally set by the device itself; write only to realign a device's boundary (e.g. after a firmware upgrade)."
           example: 1717000000000
 
     MeterValues:

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -2985,6 +2985,10 @@ namespace Ade7953
             LOG_DEBUG("Migrated channel %u role from old bool keys: %s", channelIndex, channelRoleToString(channelData.role));
         }
 
+        // Device-reported reset boundary (issue #314). 0 default = never set.
+        snprintf(key, sizeof(key), CHANNEL_START_MEASURING_KEY, channelIndex);
+        channelData.startMeasuringUnixTimeMs = preferences.getULong64(key, 0);
+
         preferences.end();
 
         // armTransients=false: this is a boot-time restore, not a user/API change.
@@ -3045,6 +3049,10 @@ namespace Ade7953
         // Channel role
         snprintf(key, sizeof(key), CHANNEL_ROLE_KEY, channelIndex);
         preferences.putUChar(key, static_cast<uint8_t>(channelData.role));
+
+        // Device-reported reset boundary (issue #314)
+        snprintf(key, sizeof(key), CHANNEL_START_MEASURING_KEY, channelIndex);
+        preferences.putULong64(key, channelData.startMeasuringUnixTimeMs);
 
         preferences.end();
 

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -5,6 +5,7 @@
 #include "taskprofiler.h"
 #include "duration_format.h"
 #include "grid_frequency.h"
+#include "shadow_logic.h"
 
 namespace Ade7953
 {
@@ -998,6 +999,10 @@ namespace Ade7953
         // Channel role
         jsonDocument["role"] = channelRoleToString(channelData.role);
 
+        // Device-reported reset boundary (issue #314). Always reported, including the
+        // 0/"never set" and 1/"pending, clock not synced yet" sentinels.
+        jsonDocument["startMeasuringUnixTimeMs"] = channelData.startMeasuringUnixTimeMs;
+
         LOG_VERBOSE("Successfully converted channel data to JSON for channel %u", channelData.index);
     }
 
@@ -1036,6 +1041,18 @@ namespace Ade7953
             if (jsonDocument["role"].is<const char*>()) {
                 channelData.role = channelRoleFromString(jsonDocument["role"].as<const char*>());
             }
+
+            // Device-reported reset boundary (issue #314). Rejected (field left unchanged) if
+            // present but implausible, e.g. unix seconds sent instead of ms.
+            if (jsonDocument["startMeasuringUnixTimeMs"].is<uint64_t>()) {
+                uint64_t candidate = jsonDocument["startMeasuringUnixTimeMs"].as<uint64_t>();
+                if (ShadowLogic::isPlausibleStartMeasuringUnixTimeMs(candidate, MIN_PLAUSIBLE_START_MEASURING_UNIX_TIME_MS)) {
+                    channelData.startMeasuringUnixTimeMs = candidate;
+                } else {
+                    LOG_WARNING("Rejected implausible startMeasuringUnixTimeMs %llu for channel %u (looks like seconds, not ms)",
+                                candidate, channelData.index);
+                }
+            }
         } else {
             // Full update - set all fields
             channelData.index = jsonDocument["index"].as<uint8_t>();
@@ -1053,6 +1070,14 @@ namespace Ade7953
 
             // Channel role
             channelData.role = channelRoleFromString(jsonDocument["role"].as<const char*>());
+
+            // Device-reported reset boundary (issue #314), same plausibility guard as the
+            // partial path. Rejected -> falls back to 0 (never set) rather than a bad value,
+            // consistent with a full replace treating an absent/invalid field as "unset".
+            uint64_t candidate = jsonDocument["startMeasuringUnixTimeMs"].as<uint64_t>();
+            channelData.startMeasuringUnixTimeMs =
+                ShadowLogic::isPlausibleStartMeasuringUnixTimeMs(candidate, MIN_PLAUSIBLE_START_MEASURING_UNIX_TIME_MS)
+                    ? candidate : 0;
         }
     }
 

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -3330,6 +3330,19 @@ namespace Ade7953
                 hasValidField = true;
             }
 
+            // Device-reported reset boundary validation. Rejects the whole partial update on an
+            // implausible value, consistent with every other field above - a standalone realign
+            // request (just index + this field) must count as a valid field on its own, otherwise
+            // it silently fails the "no valid fields found" check below.
+            if (jsonDocument["startMeasuringUnixTimeMs"].is<uint64_t>()) {
+                uint64_t val = jsonDocument["startMeasuringUnixTimeMs"].as<uint64_t>();
+                if (!ShadowLogic::isPlausibleStartMeasuringUnixTimeMs(val, MIN_PLAUSIBLE_START_MEASURING_UNIX_TIME_MS, MAX_PLAUSIBLE_START_MEASURING_UNIX_TIME_MS)) {
+                    LOG_WARNING("Invalid startMeasuringUnixTimeMs value: %llu", val);
+                    return false;
+                }
+                hasValidField = true;
+            }
+
             if (!hasValidField) {
                 LOG_WARNING("No valid fields found for partial update");
                 return false;

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -1010,8 +1010,7 @@ namespace Ade7953
         // Channel role
         jsonDocument["role"] = channelRoleToString(channelData.role);
 
-        // Device-reported reset boundary. Always reported, including the
-        // 0/"never set" and 1/"pending, clock not synced yet" sentinels.
+        // Device-reported reset boundary. Always reported, including the 0/"unset" value.
         jsonDocument["startMeasuringUnixTimeMs"] = channelData.startMeasuringUnixTimeMs;
 
         LOG_VERBOSE("Successfully converted channel data to JSON for channel %u", channelData.index);
@@ -1052,18 +1051,6 @@ namespace Ade7953
             if (jsonDocument["role"].is<const char*>()) {
                 channelData.role = channelRoleFromString(jsonDocument["role"].as<const char*>());
             }
-
-            // Device-reported reset boundary. Rejected (field left unchanged) if
-            // present but implausible, e.g. unix seconds sent instead of ms.
-            if (jsonDocument["startMeasuringUnixTimeMs"].is<uint64_t>()) {
-                uint64_t candidate = jsonDocument["startMeasuringUnixTimeMs"].as<uint64_t>();
-                if (ShadowLogic::isPlausibleStartMeasuringUnixTimeMs(candidate, MIN_PLAUSIBLE_START_MEASURING_UNIX_TIME_MS)) {
-                    channelData.startMeasuringUnixTimeMs = candidate;
-                } else {
-                    LOG_WARNING("Rejected implausible startMeasuringUnixTimeMs %llu for channel %u (looks like seconds, not ms)",
-                                candidate, channelData.index);
-                }
-            }
         } else {
             // Full update - set all fields
             channelData.index = jsonDocument["index"].as<uint8_t>();
@@ -1081,14 +1068,22 @@ namespace Ade7953
 
             // Channel role
             channelData.role = channelRoleFromString(jsonDocument["role"].as<const char*>());
+        }
 
-            // Device-reported reset boundary, same plausibility guard as the
-            // partial path. Rejected -> falls back to 0 (never set) rather than a bad value,
-            // consistent with a full replace treating an absent/invalid field as "unset".
-            uint64_t candidate = jsonDocument["startMeasuringUnixTimeMs"].as<uint64_t>();
-            channelData.startMeasuringUnixTimeMs =
-                ShadowLogic::isPlausibleStartMeasuringUnixTimeMs(candidate, MIN_PLAUSIBLE_START_MEASURING_UNIX_TIME_MS)
-                    ? candidate : 0;
+        // Device-reported reset boundary. Applies to both the partial and full paths above:
+        // channelData is always preloaded with the current value before this function runs (see
+        // setChannelDataFromJson), so absent or implausible (e.g. seconds/microseconds sent
+        // instead of ms) simply leaves it unchanged rather than fabricating a false reset.
+        bool startMeasuringPresent = jsonDocument["startMeasuringUnixTimeMs"].is<uint64_t>();
+        uint64_t startMeasuringCandidate = jsonDocument["startMeasuringUnixTimeMs"].as<uint64_t>();
+        if (ShadowLogic::shouldAdoptStartMeasuringUnixTimeMs(startMeasuringPresent, startMeasuringCandidate,
+                MIN_PLAUSIBLE_START_MEASURING_UNIX_TIME_MS, MAX_PLAUSIBLE_START_MEASURING_UNIX_TIME_MS)) {
+            channelData.startMeasuringUnixTimeMs = startMeasuringCandidate;
+        } else if (startMeasuringPresent) {
+            LOG_WARNING("Rejected implausible startMeasuringUnixTimeMs %llu for channel %u",
+                        startMeasuringCandidate, channelData.index);
+        } else if (!jsonDocument["startMeasuringUnixTimeMs"].isNull()) {
+            LOG_WARNING("Ignored startMeasuringUnixTimeMs for channel %u: wrong type (expected integer)", channelData.index);
         }
     }
 

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -192,7 +192,7 @@ namespace Ade7953
     // Energy data management
     static void _setEnergyFromPreferences(uint8_t channelIndex);
     static void _saveEnergyToPreferences(uint8_t channelIndex, bool forceSave = false); // Needed for saving data anyway on first setup (energy is 0 and not saved otherwise)
-    static void _clearStartMeasuring(uint8_t channelIndex); // issue #314: reset back to 0 (unset) on every reset
+    static void _clearStartMeasuring(uint8_t channelIndex); // reset back to 0 (unset) on every reset
     static void _saveHourlyEnergyToCsv(); // Not per channel so that we open the file only once
     static void _saveEnergyComplete();
     static bool _clearChannelHistoricalData(uint8_t channelIndex);
@@ -1000,7 +1000,7 @@ namespace Ade7953
         // Channel role
         jsonDocument["role"] = channelRoleToString(channelData.role);
 
-        // Device-reported reset boundary (issue #314). Always reported, including the
+        // Device-reported reset boundary. Always reported, including the
         // 0/"never set" and 1/"pending, clock not synced yet" sentinels.
         jsonDocument["startMeasuringUnixTimeMs"] = channelData.startMeasuringUnixTimeMs;
 
@@ -1043,7 +1043,7 @@ namespace Ade7953
                 channelData.role = channelRoleFromString(jsonDocument["role"].as<const char*>());
             }
 
-            // Device-reported reset boundary (issue #314). Rejected (field left unchanged) if
+            // Device-reported reset boundary. Rejected (field left unchanged) if
             // present but implausible, e.g. unix seconds sent instead of ms.
             if (jsonDocument["startMeasuringUnixTimeMs"].is<uint64_t>()) {
                 uint64_t candidate = jsonDocument["startMeasuringUnixTimeMs"].as<uint64_t>();
@@ -1072,7 +1072,7 @@ namespace Ade7953
             // Channel role
             channelData.role = channelRoleFromString(jsonDocument["role"].as<const char*>());
 
-            // Device-reported reset boundary (issue #314), same plausibility guard as the
+            // Device-reported reset boundary, same plausibility guard as the
             // partial path. Rejected -> falls back to 0 (never set) rather than a bad value,
             // consistent with a full replace treating an absent/invalid field as "unset".
             uint64_t candidate = jsonDocument["startMeasuringUnixTimeMs"].as<uint64_t>();
@@ -1128,7 +1128,7 @@ namespace Ade7953
     // Energy data management
     // ======================
 
-    // Clears startMeasuringUnixTimeMs back to 0 (unset) for a reset channel (issue #314). No
+    // Clears startMeasuringUnixTimeMs back to 0 (unset) for a reset channel. No
     // isTimeSynched() check here, deliberately: the _energySaveTask drain loop is the single
     // place that ever resolves 0 to a real timestamp, once the clock is synced.
     void _clearStartMeasuring(uint8_t channelIndex) {
@@ -1168,7 +1168,7 @@ namespace Ade7953
 
         for (uint8_t i = 0; i < globalHwProfile->totalChannelCount; i++) {
             _saveEnergyToPreferences(i);
-            _clearStartMeasuring(i); // issue #314
+            _clearStartMeasuring(i);
         }
 
         // Offload heavy file I/O to background task
@@ -1197,7 +1197,7 @@ namespace Ade7953
         releaseMutex(&_meterValuesMutex);
 
         _saveEnergyToPreferences(channelIndex, true); // Force save zeroed values
-        _clearStartMeasuring(channelIndex); // issue #314
+        _clearStartMeasuring(channelIndex);
 
         // Offload heavy file I/O to background task
         _spawnHistoryClearTask(channelIndex);
@@ -2293,7 +2293,7 @@ namespace Ade7953
                 if (drain) _saveChannelDataToPreferences(i);
             }
 
-            // Resolve unset start-measuring timestamps (issue #314): the first time the clock is
+            // Resolve unset start-measuring timestamps: the first time the clock is
             // synced while a channel's value is still 0, set it to now. Covers a fresh channel, a
             // reset, and (once, on upgrade) an existing device that never had this field before.
             // Not gated by isChannelActive - unlike the energy-save loop above - so a disabled
@@ -3053,7 +3053,7 @@ namespace Ade7953
             LOG_DEBUG("Migrated channel %u role from old bool keys: %s", channelIndex, channelRoleToString(channelData.role));
         }
 
-        // Device-reported reset boundary (issue #314). 0 default = never set.
+        // Device-reported reset boundary. 0 default = never set.
         snprintf(key, sizeof(key), CHANNEL_START_MEASURING_KEY, channelIndex);
         channelData.startMeasuringUnixTimeMs = preferences.getULong64(key, 0);
 
@@ -3118,7 +3118,7 @@ namespace Ade7953
         snprintf(key, sizeof(key), CHANNEL_ROLE_KEY, channelIndex);
         preferences.putUChar(key, static_cast<uint8_t>(channelData.role));
 
-        // Device-reported reset boundary (issue #314)
+        // Device-reported reset boundary
         snprintf(key, sizeof(key), CHANNEL_START_MEASURING_KEY, channelIndex);
         preferences.putULong64(key, channelData.startMeasuringUnixTimeMs);
 

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -192,6 +192,7 @@ namespace Ade7953
     // Energy data management
     static void _setEnergyFromPreferences(uint8_t channelIndex);
     static void _saveEnergyToPreferences(uint8_t channelIndex, bool forceSave = false); // Needed for saving data anyway on first setup (energy is 0 and not saved otherwise)
+    static void _clearStartMeasuring(uint8_t channelIndex); // issue #314: reset back to 0 (unset) on every reset
     static void _saveHourlyEnergyToCsv(); // Not per channel so that we open the file only once
     static void _saveEnergyComplete();
     static bool _clearChannelHistoricalData(uint8_t channelIndex);
@@ -1127,6 +1128,21 @@ namespace Ade7953
     // Energy data management
     // ======================
 
+    // Clears startMeasuringUnixTimeMs back to 0 (unset) for a reset channel (issue #314). No
+    // isTimeSynched() check here, deliberately: the _energySaveTask drain loop is the single
+    // place that ever resolves 0 to a real timestamp, once the clock is synced.
+    void _clearStartMeasuring(uint8_t channelIndex) {
+        if (!isChannelValid(channelIndex)) return;
+
+        if (acquireMutex(&_channelDataMutex)) {
+            _channelData[channelIndex].startMeasuringUnixTimeMs = 0;
+            releaseMutex(&_channelDataMutex);
+            _saveChannelDataToPreferences(channelIndex);
+        } else {
+            LOG_ERROR("Failed to acquire mutex to clear channel %u start-measuring timestamp", channelIndex);
+        }
+    }
+
     void resetEnergyValues() {
         if (!acquireMutex(&_meterValuesMutex)) {
             LOG_ERROR("Failed to acquire mutex for meter values");
@@ -1150,7 +1166,10 @@ namespace Ade7953
         preferences.clear();
         preferences.end();
 
-        for (uint8_t i = 0; i < globalHwProfile->totalChannelCount; i++) _saveEnergyToPreferences(i);
+        for (uint8_t i = 0; i < globalHwProfile->totalChannelCount; i++) {
+            _saveEnergyToPreferences(i);
+            _clearStartMeasuring(i); // issue #314
+        }
 
         // Offload heavy file I/O to background task
         _spawnHistoryClearTask(CLEAR_ALL_CHANNELS_SENTINEL);
@@ -1178,6 +1197,7 @@ namespace Ade7953
         releaseMutex(&_meterValuesMutex);
 
         _saveEnergyToPreferences(channelIndex, true); // Force save zeroed values
+        _clearStartMeasuring(channelIndex); // issue #314
 
         // Offload heavy file I/O to background task
         _spawnHistoryClearTask(channelIndex);
@@ -2271,6 +2291,29 @@ namespace Ade7953
                     releaseMutex(&_channelDataMutex);
                 }
                 if (drain) _saveChannelDataToPreferences(i);
+            }
+
+            // Resolve unset start-measuring timestamps (issue #314): the first time the clock is
+            // synced while a channel's value is still 0, set it to now. Covers a fresh channel, a
+            // reset, and (once, on upgrade) an existing device that never had this field before.
+            // Not gated by isChannelActive - unlike the energy-save loop above - so a disabled
+            // channel never gets stuck at 0 forever.
+            if (CustomTime::isTimeSynched()) {
+                uint64_t nowMs = CustomTime::getUnixTimeMilliseconds();
+                for (uint8_t i = 0; i < globalHwProfile->totalChannelCount; i++) {
+                    bool resolve = false;
+                    if (acquireMutex(&_channelDataMutex)) {
+                        if (_channelData[i].startMeasuringUnixTimeMs == 0) {
+                            _channelData[i].startMeasuringUnixTimeMs = nowMs;
+                            resolve = true;
+                        }
+                        releaseMutex(&_channelDataMutex);
+                    }
+                    if (resolve) {
+                        _saveChannelDataToPreferences(i);
+                        LOG_INFO("Channel %u startMeasuringUnixTimeMs resolved from unset to %llu", i, nowMs);
+                    }
+                }
             }
 
             if (ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(SAVE_ENERGY_INTERVAL)) > 0) {
@@ -3481,7 +3524,7 @@ namespace Ade7953
         bool needsMigration = false;
 
         snprintf(key, sizeof(key), ENERGY_ACTIVE_IMP_KEY, channelIndex);
-        // This may trigger getBytes(): not enough space in buffer: 4 < 8, but we will handle that by checking the returned value 
+        // This may trigger getBytes(): not enough space in buffer: 4 < 8, but we will handle that by checking the returned value
         double doubleValue = preferences.getDouble(key, -1.0); // Use -1.0 as sentinel (energy can't be negative)
         float floatValue = preferences.getFloat(key, -1.0f);
         LOG_DEBUG("Ch %d activeEnergyImported: getDouble=%.4f, getFloat=%.4f", channelIndex, doubleValue, floatValue);

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -1080,8 +1080,7 @@ namespace Ade7953
         // instead of ms) simply leaves it unchanged rather than fabricating a false reset.
         bool startMeasuringPresent = jsonDocument["startMeasuringUnixTimeMs"].is<uint64_t>();
         uint64_t startMeasuringCandidate = jsonDocument["startMeasuringUnixTimeMs"].as<uint64_t>();
-        if (ShadowLogic::shouldAdoptStartMeasuringUnixTimeMs(startMeasuringPresent, startMeasuringCandidate,
-                MIN_PLAUSIBLE_START_MEASURING_UNIX_TIME_MS, MAX_PLAUSIBLE_START_MEASURING_UNIX_TIME_MS)) {
+        if (ShadowLogic::shouldAdoptStartMeasuringUnixTimeMs(startMeasuringPresent, startMeasuringCandidate)) {
             channelData.startMeasuringUnixTimeMs = startMeasuringCandidate;
         } else if (startMeasuringPresent) {
             LOG_WARNING("Rejected implausible startMeasuringUnixTimeMs %llu for channel %u",
@@ -3336,7 +3335,7 @@ namespace Ade7953
             // it silently fails the "no valid fields found" check below.
             if (jsonDocument["startMeasuringUnixTimeMs"].is<uint64_t>()) {
                 uint64_t val = jsonDocument["startMeasuringUnixTimeMs"].as<uint64_t>();
-                if (!ShadowLogic::isPlausibleStartMeasuringUnixTimeMs(val, MIN_PLAUSIBLE_START_MEASURING_UNIX_TIME_MS, MAX_PLAUSIBLE_START_MEASURING_UNIX_TIME_MS)) {
+                if (!ShadowLogic::isPlausibleStartMeasuringUnixTimeMs(val)) {
                     LOG_WARNING("Invalid startMeasuringUnixTimeMs value: %llu", val);
                     return false;
                 }

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -891,10 +891,10 @@ namespace Ade7953
         return true;
     }
 
-    void resetChannelData(uint8_t channelIndex) {
+    bool resetChannelData(uint8_t channelIndex) {
         if (!isChannelValid(channelIndex)) {
             LOG_WARNING("Channel index out of bounds: %lu", channelIndex);
-            return;
+            return false;
         }
 
         // This is a config-only reset; it must not touch the energy-reset boundary
@@ -903,14 +903,18 @@ namespace Ade7953
         ChannelData current(channelIndex);
         if (!getChannelData(current, channelIndex)) {
             LOG_ERROR("Failed to read current data for channel %u before reset; aborting to avoid wiping startMeasuringUnixTimeMs", channelIndex);
-            return;
+            return false;
         }
 
         ChannelData channelData(channelIndex); // Constructor with index sets proper defaults
         channelData.startMeasuringUnixTimeMs = current.startMeasuringUnixTimeMs;
-        setChannelData(channelData, channelIndex);
+        if (!setChannelData(channelData, channelIndex)) {
+            LOG_ERROR("Failed to reset channel data for channel %lu", channelIndex);
+            return false;
+        }
 
         LOG_DEBUG("Successfully reset channel data for channel %lu", channelIndex);
+        return true;
     }
 
     // Channel data management - JSON operations

--- a/source/src/ade7953.cpp
+++ b/source/src/ade7953.cpp
@@ -897,7 +897,17 @@ namespace Ade7953
             return;
         }
 
+        // This is a config-only reset; it must not touch the energy-reset boundary
+        // (only resetEnergyValues / resetChannelEnergyValues own that). Read the current
+        // value first rather than defaulting to 0 on failure, which would silently wipe it.
+        ChannelData current(channelIndex);
+        if (!getChannelData(current, channelIndex)) {
+            LOG_ERROR("Failed to read current data for channel %u before reset; aborting to avoid wiping startMeasuringUnixTimeMs", channelIndex);
+            return;
+        }
+
         ChannelData channelData(channelIndex); // Constructor with index sets proper defaults
+        channelData.startMeasuringUnixTimeMs = current.startMeasuringUnixTimeMs;
         setChannelData(channelData, channelIndex);
 
         LOG_DEBUG("Successfully reset channel data for channel %lu", channelIndex);

--- a/source/src/customserver.cpp
+++ b/source/src/customserver.cpp
@@ -2231,7 +2231,10 @@ namespace CustomServer
                 _sendErrorResponse(request, HTTP_CODE_BAD_REQUEST, "Invalid channel index");
                 return;
             }
-            Ade7953::resetChannelData(channelIndex);
+            if (!Ade7953::resetChannelData(channelIndex)) {
+                _sendErrorResponse(request, HTTP_CODE_INTERNAL_SERVER_ERROR, "Failed to reset channel data");
+                return;
+            }
 
             LOG_INFO("ADE7953 channel %u data reset via API", channelIndex);
             _sendSuccessResponse(request, "ADE7953 channel data reset successfully");

--- a/source/src/customtime.cpp
+++ b/source/src/customtime.cpp
@@ -211,8 +211,7 @@ namespace CustomTime {
     }
 
     bool isUnixTimeValid(uint64_t unixTime, bool isMilliseconds) {
-        if (isMilliseconds) { return (unixTime >= MINIMUM_UNIX_TIME_MILLISECONDS && unixTime <= MAXIMUM_UNIX_TIME_MILLISECONDS); }
-        else { return (unixTime >= MINIMUM_UNIX_TIME_SECONDS && unixTime <= MAXIMUM_UNIX_TIME_SECONDS); }
+        return UnixTime::isValid(unixTime, isMilliseconds);
     }
 
     bool setUnixTime(uint64_t unixSeconds) {

--- a/source/test/test_shadow_logic/test_shadow_logic.cpp
+++ b/source/test/test_shadow_logic/test_shadow_logic.cpp
@@ -320,6 +320,33 @@ void test_parse_channel_list_null_invalid_flag_is_safe(void) {
 }
 
 // ============================================================================
+// isPlausibleStartMeasuringUnixTimeMs
+// ============================================================================
+
+static constexpr uint64_t FLOOR_2020_MS = 1577836800000ULL; // 2020-01-01T00:00:00Z
+
+void test_start_measuring_zero_is_always_plausible(void) {
+    TEST_ASSERT_TRUE(isPlausibleStartMeasuringUnixTimeMs(0, FLOOR_2020_MS));
+}
+
+void test_start_measuring_seconds_value_sent_by_mistake_is_rejected(void) {
+    // A unix-seconds "now" (~1.7e9) is ~1000x below a ms floor set around 2020 (~1.58e12).
+    TEST_ASSERT_FALSE(isPlausibleStartMeasuringUnixTimeMs(1700000000ULL, FLOOR_2020_MS));
+}
+
+void test_start_measuring_plausible_ms_value_is_accepted(void) {
+    TEST_ASSERT_TRUE(isPlausibleStartMeasuringUnixTimeMs(1700000000000ULL, FLOOR_2020_MS));
+}
+
+void test_start_measuring_exactly_at_floor_is_accepted(void) {
+    TEST_ASSERT_TRUE(isPlausibleStartMeasuringUnixTimeMs(FLOOR_2020_MS, FLOOR_2020_MS));
+}
+
+void test_start_measuring_one_below_floor_is_rejected(void) {
+    TEST_ASSERT_FALSE(isPlausibleStartMeasuringUnixTimeMs(FLOOR_2020_MS - 1, FLOOR_2020_MS));
+}
+
+// ============================================================================
 // Runner
 // ============================================================================
 
@@ -371,6 +398,12 @@ int main(int argc, char **argv) {
     RUN_TEST(test_parse_channel_list_respects_max_out);
     RUN_TEST(test_parse_channel_list_null_spec_is_safe);
     RUN_TEST(test_parse_channel_list_null_invalid_flag_is_safe);
+
+    RUN_TEST(test_start_measuring_zero_is_always_plausible);
+    RUN_TEST(test_start_measuring_seconds_value_sent_by_mistake_is_rejected);
+    RUN_TEST(test_start_measuring_plausible_ms_value_is_accepted);
+    RUN_TEST(test_start_measuring_exactly_at_floor_is_accepted);
+    RUN_TEST(test_start_measuring_one_below_floor_is_rejected);
 
     return UNITY_END();
 }

--- a/source/test/test_shadow_logic/test_shadow_logic.cpp
+++ b/source/test/test_shadow_logic/test_shadow_logic.cpp
@@ -320,30 +320,68 @@ void test_parse_channel_list_null_invalid_flag_is_safe(void) {
 }
 
 // ============================================================================
-// isPlausibleStartMeasuringUnixTimeMs
+// isPlausibleStartMeasuringUnixTimeMs / shouldAdoptStartMeasuringUnixTimeMs
 // ============================================================================
 
 static constexpr uint64_t FLOOR_2020_MS = 1577836800000ULL; // 2020-01-01T00:00:00Z
+static constexpr uint64_t CEIL_2100_MS = 4102444800000ULL;  // 2100-01-01T00:00:00Z
 
 void test_start_measuring_zero_is_always_plausible(void) {
-    TEST_ASSERT_TRUE(isPlausibleStartMeasuringUnixTimeMs(0, FLOOR_2020_MS));
+    TEST_ASSERT_TRUE(isPlausibleStartMeasuringUnixTimeMs(0, FLOOR_2020_MS, CEIL_2100_MS));
 }
 
 void test_start_measuring_seconds_value_sent_by_mistake_is_rejected(void) {
     // A unix-seconds "now" (~1.7e9) is ~1000x below a ms floor set around 2020 (~1.58e12).
-    TEST_ASSERT_FALSE(isPlausibleStartMeasuringUnixTimeMs(1700000000ULL, FLOOR_2020_MS));
+    TEST_ASSERT_FALSE(isPlausibleStartMeasuringUnixTimeMs(1700000000ULL, FLOOR_2020_MS, CEIL_2100_MS));
 }
 
 void test_start_measuring_plausible_ms_value_is_accepted(void) {
-    TEST_ASSERT_TRUE(isPlausibleStartMeasuringUnixTimeMs(1700000000000ULL, FLOOR_2020_MS));
+    TEST_ASSERT_TRUE(isPlausibleStartMeasuringUnixTimeMs(1700000000000ULL, FLOOR_2020_MS, CEIL_2100_MS));
 }
 
 void test_start_measuring_exactly_at_floor_is_accepted(void) {
-    TEST_ASSERT_TRUE(isPlausibleStartMeasuringUnixTimeMs(FLOOR_2020_MS, FLOOR_2020_MS));
+    TEST_ASSERT_TRUE(isPlausibleStartMeasuringUnixTimeMs(FLOOR_2020_MS, FLOOR_2020_MS, CEIL_2100_MS));
 }
 
 void test_start_measuring_one_below_floor_is_rejected(void) {
-    TEST_ASSERT_FALSE(isPlausibleStartMeasuringUnixTimeMs(FLOOR_2020_MS - 1, FLOOR_2020_MS));
+    TEST_ASSERT_FALSE(isPlausibleStartMeasuringUnixTimeMs(FLOOR_2020_MS - 1, FLOOR_2020_MS, CEIL_2100_MS));
+}
+
+void test_start_measuring_exactly_at_ceiling_is_accepted(void) {
+    TEST_ASSERT_TRUE(isPlausibleStartMeasuringUnixTimeMs(CEIL_2100_MS, FLOOR_2020_MS, CEIL_2100_MS));
+}
+
+void test_start_measuring_one_above_ceiling_is_rejected(void) {
+    TEST_ASSERT_FALSE(isPlausibleStartMeasuringUnixTimeMs(CEIL_2100_MS + 1, FLOOR_2020_MS, CEIL_2100_MS));
+}
+
+void test_start_measuring_microseconds_value_sent_by_mistake_is_rejected(void) {
+    // A unix-microseconds "now" (~1.7e15) is ~1000x above a ms ceiling set around 2100 (~4.1e12).
+    TEST_ASSERT_FALSE(isPlausibleStartMeasuringUnixTimeMs(1700000000000000ULL, FLOOR_2020_MS, CEIL_2100_MS));
+}
+
+void test_start_measuring_garbage_value_is_rejected(void) {
+    TEST_ASSERT_FALSE(isPlausibleStartMeasuringUnixTimeMs(9000000000000000000ULL, FLOOR_2020_MS, CEIL_2100_MS));
+}
+
+void test_should_adopt_when_present_and_plausible(void) {
+    TEST_ASSERT_TRUE(shouldAdoptStartMeasuringUnixTimeMs(true, 1700000000000ULL, FLOOR_2020_MS, CEIL_2100_MS));
+}
+
+void test_should_adopt_explicit_zero_when_present(void) {
+    // Explicit 0 is a legitimate write (e.g. echoing back the current value), not a wipe.
+    TEST_ASSERT_TRUE(shouldAdoptStartMeasuringUnixTimeMs(true, 0, FLOOR_2020_MS, CEIL_2100_MS));
+}
+
+void test_should_not_adopt_when_absent(void) {
+    // This is the case that was broken: an absent field must never be adopted as 0,
+    // regardless of what candidate value happens to be passed (as<uint64_t>() on a
+    // missing key returns 0, which is why "present" has to be checked separately).
+    TEST_ASSERT_FALSE(shouldAdoptStartMeasuringUnixTimeMs(false, 0, FLOOR_2020_MS, CEIL_2100_MS));
+}
+
+void test_should_not_adopt_when_present_but_implausible(void) {
+    TEST_ASSERT_FALSE(shouldAdoptStartMeasuringUnixTimeMs(true, 1700000000ULL, FLOOR_2020_MS, CEIL_2100_MS));
 }
 
 // ============================================================================
@@ -404,6 +442,14 @@ int main(int argc, char **argv) {
     RUN_TEST(test_start_measuring_plausible_ms_value_is_accepted);
     RUN_TEST(test_start_measuring_exactly_at_floor_is_accepted);
     RUN_TEST(test_start_measuring_one_below_floor_is_rejected);
+    RUN_TEST(test_start_measuring_exactly_at_ceiling_is_accepted);
+    RUN_TEST(test_start_measuring_one_above_ceiling_is_rejected);
+    RUN_TEST(test_start_measuring_microseconds_value_sent_by_mistake_is_rejected);
+    RUN_TEST(test_start_measuring_garbage_value_is_rejected);
+    RUN_TEST(test_should_adopt_when_present_and_plausible);
+    RUN_TEST(test_should_adopt_explicit_zero_when_present);
+    RUN_TEST(test_should_not_adopt_when_absent);
+    RUN_TEST(test_should_not_adopt_when_present_but_implausible);
 
     return UNITY_END();
 }

--- a/source/test/test_shadow_logic/test_shadow_logic.cpp
+++ b/source/test/test_shadow_logic/test_shadow_logic.cpp
@@ -323,65 +323,62 @@ void test_parse_channel_list_null_invalid_flag_is_safe(void) {
 // isPlausibleStartMeasuringUnixTimeMs / shouldAdoptStartMeasuringUnixTimeMs
 // ============================================================================
 
-static constexpr uint64_t FLOOR_2020_MS = 1577836800000ULL; // 2020-01-01T00:00:00Z
-static constexpr uint64_t CEIL_2100_MS = 4102444800000ULL;  // 2100-01-01T00:00:00Z
-
 void test_start_measuring_zero_is_always_plausible(void) {
-    TEST_ASSERT_TRUE(isPlausibleStartMeasuringUnixTimeMs(0, FLOOR_2020_MS, CEIL_2100_MS));
+    TEST_ASSERT_TRUE(isPlausibleStartMeasuringUnixTimeMs(0));
 }
 
 void test_start_measuring_seconds_value_sent_by_mistake_is_rejected(void) {
-    // A unix-seconds "now" (~1.7e9) is ~1000x below a ms floor set around 2020 (~1.58e12).
-    TEST_ASSERT_FALSE(isPlausibleStartMeasuringUnixTimeMs(1700000000ULL, FLOOR_2020_MS, CEIL_2100_MS));
+    // A unix-seconds "now" (~1.7e9) is ~1000x below the ms floor (~1e12).
+    TEST_ASSERT_FALSE(isPlausibleStartMeasuringUnixTimeMs(1700000000ULL));
 }
 
 void test_start_measuring_plausible_ms_value_is_accepted(void) {
-    TEST_ASSERT_TRUE(isPlausibleStartMeasuringUnixTimeMs(1700000000000ULL, FLOOR_2020_MS, CEIL_2100_MS));
+    TEST_ASSERT_TRUE(isPlausibleStartMeasuringUnixTimeMs(1700000000000ULL));
 }
 
 void test_start_measuring_exactly_at_floor_is_accepted(void) {
-    TEST_ASSERT_TRUE(isPlausibleStartMeasuringUnixTimeMs(FLOOR_2020_MS, FLOOR_2020_MS, CEIL_2100_MS));
+    TEST_ASSERT_TRUE(isPlausibleStartMeasuringUnixTimeMs(UnixTime::MIN_MILLISECONDS));
 }
 
 void test_start_measuring_one_below_floor_is_rejected(void) {
-    TEST_ASSERT_FALSE(isPlausibleStartMeasuringUnixTimeMs(FLOOR_2020_MS - 1, FLOOR_2020_MS, CEIL_2100_MS));
+    TEST_ASSERT_FALSE(isPlausibleStartMeasuringUnixTimeMs(UnixTime::MIN_MILLISECONDS - 1));
 }
 
 void test_start_measuring_exactly_at_ceiling_is_accepted(void) {
-    TEST_ASSERT_TRUE(isPlausibleStartMeasuringUnixTimeMs(CEIL_2100_MS, FLOOR_2020_MS, CEIL_2100_MS));
+    TEST_ASSERT_TRUE(isPlausibleStartMeasuringUnixTimeMs(UnixTime::MAX_MILLISECONDS));
 }
 
 void test_start_measuring_one_above_ceiling_is_rejected(void) {
-    TEST_ASSERT_FALSE(isPlausibleStartMeasuringUnixTimeMs(CEIL_2100_MS + 1, FLOOR_2020_MS, CEIL_2100_MS));
+    TEST_ASSERT_FALSE(isPlausibleStartMeasuringUnixTimeMs(UnixTime::MAX_MILLISECONDS + 1));
 }
 
 void test_start_measuring_microseconds_value_sent_by_mistake_is_rejected(void) {
-    // A unix-microseconds "now" (~1.7e15) is ~1000x above a ms ceiling set around 2100 (~4.1e12).
-    TEST_ASSERT_FALSE(isPlausibleStartMeasuringUnixTimeMs(1700000000000000ULL, FLOOR_2020_MS, CEIL_2100_MS));
+    // A unix-microseconds "now" (~1.7e15) is ~1000x above the ms ceiling (~4.1e12).
+    TEST_ASSERT_FALSE(isPlausibleStartMeasuringUnixTimeMs(1700000000000000ULL));
 }
 
 void test_start_measuring_garbage_value_is_rejected(void) {
-    TEST_ASSERT_FALSE(isPlausibleStartMeasuringUnixTimeMs(9000000000000000000ULL, FLOOR_2020_MS, CEIL_2100_MS));
+    TEST_ASSERT_FALSE(isPlausibleStartMeasuringUnixTimeMs(9000000000000000000ULL));
 }
 
 void test_should_adopt_when_present_and_plausible(void) {
-    TEST_ASSERT_TRUE(shouldAdoptStartMeasuringUnixTimeMs(true, 1700000000000ULL, FLOOR_2020_MS, CEIL_2100_MS));
+    TEST_ASSERT_TRUE(shouldAdoptStartMeasuringUnixTimeMs(true, 1700000000000ULL));
 }
 
 void test_should_adopt_explicit_zero_when_present(void) {
     // Explicit 0 is a legitimate write (e.g. echoing back the current value), not a wipe.
-    TEST_ASSERT_TRUE(shouldAdoptStartMeasuringUnixTimeMs(true, 0, FLOOR_2020_MS, CEIL_2100_MS));
+    TEST_ASSERT_TRUE(shouldAdoptStartMeasuringUnixTimeMs(true, 0));
 }
 
 void test_should_not_adopt_when_absent(void) {
     // This is the case that was broken: an absent field must never be adopted as 0,
     // regardless of what candidate value happens to be passed (as<uint64_t>() on a
     // missing key returns 0, which is why "present" has to be checked separately).
-    TEST_ASSERT_FALSE(shouldAdoptStartMeasuringUnixTimeMs(false, 0, FLOOR_2020_MS, CEIL_2100_MS));
+    TEST_ASSERT_FALSE(shouldAdoptStartMeasuringUnixTimeMs(false, 0));
 }
 
 void test_should_not_adopt_when_present_but_implausible(void) {
-    TEST_ASSERT_FALSE(shouldAdoptStartMeasuringUnixTimeMs(true, 1700000000ULL, FLOOR_2020_MS, CEIL_2100_MS));
+    TEST_ASSERT_FALSE(shouldAdoptStartMeasuringUnixTimeMs(true, 1700000000ULL));
 }
 
 // ============================================================================

--- a/source/test/test_unix_time/test_unix_time.cpp
+++ b/source/test/test_unix_time/test_unix_time.cpp
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+//
+// Host unit tests for the pure unix-timestamp plausibility check. Run with:
+//   pio test -e native          (from WSL - Windows native toolchain is unreliable)
+
+#include <unity.h>
+#include "unix_time.h"
+
+using namespace UnixTime;
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ============================================================================
+// isValid - milliseconds (default)
+// ============================================================================
+
+void test_ms_exactly_at_floor_is_valid(void) {
+    TEST_ASSERT_TRUE(isValid(MIN_MILLISECONDS));
+}
+
+void test_ms_one_below_floor_is_invalid(void) {
+    TEST_ASSERT_FALSE(isValid(MIN_MILLISECONDS - 1));
+}
+
+void test_ms_exactly_at_ceiling_is_valid(void) {
+    TEST_ASSERT_TRUE(isValid(MAX_MILLISECONDS));
+}
+
+void test_ms_one_above_ceiling_is_invalid(void) {
+    TEST_ASSERT_FALSE(isValid(MAX_MILLISECONDS + 1));
+}
+
+void test_ms_zero_is_invalid(void) {
+    // Unlike ShadowLogic::isPlausibleStartMeasuringUnixTimeMs, this function has no
+    // "0 means unset" special case - 0 is just an implausible timestamp here.
+    TEST_ASSERT_FALSE(isValid(0));
+}
+
+void test_ms_plausible_value_is_valid(void) {
+    TEST_ASSERT_TRUE(isValid(1700000000000ULL));
+}
+
+void test_ms_seconds_value_sent_by_mistake_is_invalid(void) {
+    TEST_ASSERT_FALSE(isValid(1700000000ULL)); // ~1000x below the ms floor
+}
+
+void test_ms_microseconds_value_sent_by_mistake_is_invalid(void) {
+    TEST_ASSERT_FALSE(isValid(1700000000000000ULL)); // ~1000x above the ms ceiling
+}
+
+// ============================================================================
+// isValid - seconds
+// ============================================================================
+
+void test_seconds_exactly_at_floor_is_valid(void) {
+    TEST_ASSERT_TRUE(isValid(MIN_SECONDS, false));
+}
+
+void test_seconds_one_below_floor_is_invalid(void) {
+    TEST_ASSERT_FALSE(isValid(MIN_SECONDS - 1, false));
+}
+
+void test_seconds_exactly_at_ceiling_is_valid(void) {
+    TEST_ASSERT_TRUE(isValid(MAX_SECONDS, false));
+}
+
+void test_seconds_one_above_ceiling_is_invalid(void) {
+    TEST_ASSERT_FALSE(isValid(MAX_SECONDS + 1, false));
+}
+
+void test_seconds_plausible_value_is_valid(void) {
+    TEST_ASSERT_TRUE(isValid(1700000000ULL, false));
+}
+
+void test_seconds_ms_value_sent_by_mistake_is_invalid(void) {
+    TEST_ASSERT_FALSE(isValid(1700000000000ULL, false)); // ~1000x above the seconds ceiling
+}
+
+// ============================================================================
+// Runner
+// ============================================================================
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_ms_exactly_at_floor_is_valid);
+    RUN_TEST(test_ms_one_below_floor_is_invalid);
+    RUN_TEST(test_ms_exactly_at_ceiling_is_valid);
+    RUN_TEST(test_ms_one_above_ceiling_is_invalid);
+    RUN_TEST(test_ms_zero_is_invalid);
+    RUN_TEST(test_ms_plausible_value_is_valid);
+    RUN_TEST(test_ms_seconds_value_sent_by_mistake_is_invalid);
+    RUN_TEST(test_ms_microseconds_value_sent_by_mistake_is_invalid);
+
+    RUN_TEST(test_seconds_exactly_at_floor_is_valid);
+    RUN_TEST(test_seconds_one_below_floor_is_invalid);
+    RUN_TEST(test_seconds_exactly_at_ceiling_is_valid);
+    RUN_TEST(test_seconds_one_above_ceiling_is_invalid);
+    RUN_TEST(test_seconds_plausible_value_is_valid);
+    RUN_TEST(test_seconds_ms_value_sent_by_mistake_is_invalid);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- Adds a per-channel `startMeasuringUnixTimeMs` field (edge side of EnergyMe-Srl/energyme-infra#314) so the cloud/portal can stop rendering pre-reset energy history as a false discontinuity.
- `0` = unset. The `_energySaveTask` drain resolves it to the current time the first time the clock is synced while it's still 0 - covers a fresh channel, an energy reset, and (once) an existing device's firmware upgrade.
- Reported/validated over JSON on both the partial (shadow delta) and full channel-config paths; implausible values (e.g. seconds instead of ms) are rejected via `ShadowLogic::isPlausibleStartMeasuringUnixTimeMs`.
- Every energy reset (`resetEnergyValues`, `resetChannelEnergyValues`) clears the field back to 0.

Note: existing already-deployed devices will pick up an "upgrade timestamp" as their boundary the first synced drain tick after this firmware lands, since the field defaults to 0 for them too. Jibril will manually realign real devices' values post-rollout, so this is an accepted rollout-window tradeoff, not a firmware bug.

## Test plan
- [x] Native unit tests (5 new `isPlausibleStartMeasuringUnixTimeMs` cases + full existing suite, 281 total) - all passing
- [x] On-device (bench `.174`, OTA'd): local REST energy-reset clears field to 0
- [x] Enable/disable a channel is a no-op for the field
- [x] Mocked shadow delta: implausible (seconds-scale) value rejected, plausible ms value accepted
- [x] Mocked `energy_reset` IoT Command clears field to 0
- [x] Real AWS IoT Core (dev) shadow desired-state push applied correctly, then nulled to converge
- [x] `_energySaveTask` drain confirmed resolving 0 -> real timestamp on real hardware, reported to the live shadow