### PR TITLE
fix(auth): rate-limit failed logins and lock out brute-force guessing

### DIFF
--- a/openspec/changes/auth-bruteforce-lockout/.openspec.yaml
+++ b/openspec/changes/auth-bruteforce-lockout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-07

--- a/openspec/changes/auth-bruteforce-lockout/design.md
+++ b/openspec/changes/auth-bruteforce-lockout/design.md
@@ -1,0 +1,97 @@
+## Context
+
+See `proposal.md` - Why, and issue #197. Constraints that shape the approach:
+
+- **The chain is synchronous and order-sensitive.** `AsyncMiddlewareChain::_runChain` (`Middleware.cpp:56-71`) walks the list front to back; a middleware short-circuits by not calling `next()`. `AsyncAuthenticationMiddleware::run` (`:143`) does exactly that on failure, which is why anything registered after it never sees a 401.
+- **A middleware can observe the outcome.** `CustomMiddleware` (`customserver.h`) already calls `next()` and then inspects `request->getResponse()->code()`. That is the hook for "did this request fail authentication", and it means one middleware can both gate and record.
+- **The request path is the AsyncTCP task.** Same rule the provisioning filters and the default-password guard established: no allocation, no NVS, no logging on the hot path.
+- **Digest nonces are not validated.** `AsyncWebServerRequest::authenticate` passes `nonce = NULL` (`WebRequest.cpp:1138`), and `checkDigestAuthentication` only compares the nonce when it is non-null (`WebAuthentication.cpp:202`). So a stale nonce cannot produce a spurious 401 - which removes the main source of false-positive lockouts.
+- **Every digest handshake begins with a 401.** The client's first request carries no `Authorization` header and is challenged. A browser does this on every fresh session. Counting those as failed logins would lock out the legitimate owner within a few page loads.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make password guessing rate-limited rather than unbounded, at fixed memory cost.
+- Never lock out someone who is browsing normally, and never require physical access or a reboot to recover from a lockout.
+- Keep the failed-login decision in host-testable pure logic.
+
+**Non-Goals:**
+
+- Defeating a distributed attacker. A per-IP table cannot, and the generic budget is what remains against that.
+- Protecting the credential in transit. Digest over plain HTTP is unchanged, as is the plaintext password in `auth_ns`.
+- Any persistence. Lockout state is deliberately RAM-only (see D5).
+- CAPTCHA, account lockout notifications, or anything needing a second channel.
+
+## Decisions
+
+### D1. Reorder to `rateLimit` -> `digestAuth`
+
+The minimal fix for the reported bug. It is also the conventional order - a cheap global throttle before an expensive credential check - and it means every request, authenticated or not, is counted once.
+
+Final chain: `customMiddleware` -> `authLockout` -> `rateLimit` -> `digestAuth` -> `defaultPasswordGuard`.
+
+`defaultPasswordGuard` stays last so it still sees only authenticated callers (its own D2 from the previous change). `authLockout` goes first among the throttles because a locked-out source should cost the least possible work.
+
+### D2. One middleware, gating before and recording after
+
+`AuthLockoutMiddleware::run` consults the table; if the source is locked it sends `429` with `Retry-After` and does not call `next()`. Otherwise it calls `next()` and then inspects the response code, recording a failure or a success.
+
+Placing it *before* `digestAuth` is what saves the MD5 computation for a locked-out source, and inspecting the response *after* `next()` is what lets a single middleware see the auth outcome. Two middlewares (one before, one after) would work identically but would double the per-request `std::function` cost the chain already imposes.
+
+*Alternative considered:* wrapping `AsyncAuthenticationMiddleware` in a subclass. Rejected - `allowed()` is not virtual in a useful place, and subclassing a library type couples this to its internals more tightly than reading a status code does.
+
+### D3. Only a 401 with an `Authorization` header counts
+
+This is the decision the whole feature turns on. `request->hasHeader("Authorization")` distinguishes:
+
+| Request | Response | Counts? |
+|---|---|---|
+| No credentials (handshake leg 1, or a scanner) | 401 challenge | **No** |
+| Credentials, wrong | 401 challenge | **Yes** |
+| Credentials, right | 2xx/3xx/403 | Clears the source |
+
+Counting credential-less 401s would lock out every normal user, because that is how digest works. Not counting them costs nothing defensively: to *test* a password an attacker must send one, so the guessing path is exactly the path that counts. Unauthenticated flooding is still bounded by `rateLimit`, which now runs.
+
+A `403` from the default-password guard means authentication succeeded, so it clears the source rather than counting against it.
+
+### D4. Escalating, self-expiring, bounded
+
+`AUTH_LOCKOUT_MAX_FAILURES` consecutive failures lock the source for `AUTH_LOCKOUT_BASE_SECONDS`, doubling on each subsequent lockout up to `AUTH_LOCKOUT_MAX_SECONDS`. Any success clears the entry entirely.
+
+Escalation is what makes sustained guessing unproductive without making a typo expensive: the first lockout is short enough to be an annoyance, the tenth is long enough to be useless. The ceiling exists so that no source is ever permanently barred - a locked-out owner must always be able to wait it out, because the alternatives (reboot, physical button) are exactly what someone locked out of their own meter cannot conveniently reach.
+
+### D5. Fixed table, RAM only, no persistence
+
+`AUTH_LOCKOUT_TABLE_SIZE` entries in `.bss`, linear scan, oldest-activity eviction when full. No heap and no growth under a many-source attack.
+
+Deliberately not persisted across reboot. Persisting would mean an NVS write on the failed-login path - the exact hot path an attacker controls - which turns a brute-force attempt into a flash-wear attack. A reboot clearing the table is an accepted weakness: an attacker who can reboot the device at will has better options than guessing passwords.
+
+Eviction under a many-source flood means an attacker can push a real lockout out of the table. That is a real limitation, mitigated only by `rateLimit` running now; the table is a defence against guessing, not against flooding.
+
+### D6. The state machine is pure and tested; the firmware calls it
+
+`source/lib/auth_lockout/` holds the table and its transitions with no Arduino dependency, tested natively. `customserver.cpp` supplies the clock and the source address. Same reasoning as `web_auth_gate`: the rule that decides whether someone is locked out is exactly the rule worth testing exhaustively, and it must not exist in two places.
+
+Addresses are compared as `uint32_t`, so the library needs no networking types.
+
+### D7. Loopback is never locked out
+
+`_performHealthCheck` probes `/api/v1/health` from `127.0.0.1`. That route skips the whole chain, so the lockout cannot reach it - but the exemption is stated in the pure logic anyway, because the consequence of getting it wrong is the restart-loop-into-rollback failure documented in the previous change, and one structural guarantee is not enough for that.
+
+## Risks / Trade-offs
+
+- **Locking out the legitimate owner.** -> Only credentialed failures count, a success clears instantly, lockouts expire on their own, and the first one is short. The failure mode is a wait, never a lockout requiring physical recovery.
+- **NAT: one address, many users.** -> Accepted. One user's mistakes can throttle a colleague behind the same address. The alternative is no per-source limit at all, and the residential deployment this targets is one household per address.
+- **Table exhaustion under a distributed flood.** -> Documented in D5. `rateLimit` is the backstop; the table is not a flood defence.
+- **`getResponse()` returning null after `next()`.** -> Treated as "no outcome observed", recording neither failure nor success, so an unusual path cannot accidentally lock anyone out.
+- **Clock source.** -> `millis64()` as used elsewhere in this file; monotonic and unaffected by NTP steps, which matters because a wall-clock jump could otherwise extend or void a lockout.
+- **The reorder changes existing behaviour**: a client over budget now sees `429` where it previously saw `401`. Intended, and the substance of #197's first point.
+
+## Migration Plan
+
+None. No persisted state, no API shape change, no configuration. Devices gain the behaviour on update and lose it on rollback; nothing is written that an older firmware would have to understand.
+
+## Open Questions
+
+None. The threshold, base duration and ceiling are tuning values recorded as constants in the header, chosen to make a typo cheap and sustained guessing useless; they can be changed without touching the specs or the task breakdown.

--- a/openspec/changes/auth-bruteforce-lockout/design.md
+++ b/openspec/changes/auth-bruteforce-lockout/design.md
@@ -75,6 +75,14 @@ Eviction under a many-source flood means an attacker can push a real lockout out
 
 Addresses are compared as `uint32_t`, so the library needs no networking types.
 
+### D7a. Upload routes must gate on the lockout before authenticating
+
+Upload and body callbacks run *during* body parsing (`WebRequest.cpp:612/783`), before `_runMiddlewareChain` (`:233`). The OTA and restore routes therefore do their own authentication inside the handler (`_rejectUploadIfNotPermitted`) - they have to, because a middleware auth check arrives after `Update.begin()` has already erased the partition. But that in-handler check runs *ahead of* this lockout middleware.
+
+Adversarial testing found the consequence: without an explicit gate, an attacker moves password guessing to the upload routes, where every attempt runs a full digest check regardless of lock state, and a correct guess reaches `Update.begin()` before the middleware's `429` can mask it. The lockout would be masking the response code while doing nothing to actually throttle the guessing.
+
+So `_rejectUploadIfNotPermitted` calls `authLockout.isSourceLocked()` first, before reading the password or authenticating, and refuses a locked source with `429` there. The middleware still records the failure afterwards from the `401` the handler leaves set, so recording is not duplicated. `isSourceLocked` is a pure query with no side effect - unit-tested as such, because a defence that mutated state merely by being checked would be a footgun for exactly this kind of early call.
+
 ### D7. Loopback is never locked out
 
 `_performHealthCheck` probes `/api/v1/health` from `127.0.0.1`. That route skips the whole chain, so the lockout cannot reach it - but the exemption is stated in the pure logic anyway, because the consequence of getting it wrong is the restart-loop-into-rollback failure documented in the previous change, and one structural guarantee is not enough for that.
@@ -82,7 +90,7 @@ Addresses are compared as `uint32_t`, so the library needs no networking types.
 ## Risks / Trade-offs
 
 - **Locking out the legitimate owner.** -> Only credentialed failures count, a success clears instantly, lockouts expire on their own, and the first one is short. The failure mode is a wait, never a lockout requiring physical recovery.
-- **NAT: one address, many users.** -> Accepted. One user's mistakes can throttle a colleague behind the same address. The alternative is no per-source limit at all, and the residential deployment this targets is one household per address.
+- **NAT / reverse proxy: one address, many users.** -> Accepted for the local-first default, where each LAN client is a distinct IP. The lockout keys on `client->remoteIP()` - the socket peer as the device sees it - and deliberately ignores `X-Forwarded-For`/`X-Real-IP` (an attacker sets those freely; adversarial testing confirmed spoofing them collapses onto the one real socket IP and cannot forge table entries). The consequence is the mirror image: if the device is ever placed behind a reverse proxy or a CGNAT that collapses many clients to one source IP, they share a single lockout entry, and one client's failures can throttle another. Do not deploy this device behind shared-egress infrastructure; if a trusted proxy is ever introduced, the middleware would need to consult a forwarded-for header *only* from that trusted proxy, never from a raw client. This is a property of per-IP keying, not a defect, and the honest tradeoff against header spoofing.
 - **Table exhaustion under a distributed flood.** -> Documented in D5. `rateLimit` is the backstop; the table is not a flood defence.
 - **`getResponse()` returning null after `next()`.** -> Treated as "no outcome observed", recording neither failure nor success, so an unusual path cannot accidentally lock anyone out.
 - **Clock source.** -> `millis64()` as used elsewhere in this file; monotonic and unaffected by NTP steps, which matters because a wall-clock jump could otherwise extend or void a lockout.

--- a/openspec/changes/auth-bruteforce-lockout/design.md
+++ b/openspec/changes/auth-bruteforce-lockout/design.md
@@ -25,13 +25,29 @@ See `proposal.md` - Why, and issue #197. Constraints that shape the approach:
 
 ## Decisions
 
-### D1. Reorder to `rateLimit` -> `digestAuth`
+### D1. Reorder so the throttles run before `digestAuth`
 
-The minimal fix for the reported bug. It is also the conventional order - a cheap global throttle before an expensive credential check - and it means every request, authenticated or not, is counted once.
+The reported bug is that `digestAuth` short-circuits with `requestAuthentication()` instead of calling `next()` (`Middleware.cpp:143`), so anything after it never runs on a 401. Moving the throttles ahead of it is the fix, and it is the conventional order anyway - cheap checks before the expensive credential check.
 
-Final chain: `customMiddleware` -> `authLockout` -> `rateLimit` -> `digestAuth` -> `defaultPasswordGuard`.
+Final chain: `customMiddleware` -> `authLockout` -> `unauthRateLimit` -> `digestAuth` -> `defaultPasswordGuard`.
 
 `defaultPasswordGuard` stays last so it still sees only authenticated callers (its own D2 from the previous change). `authLockout` goes first among the throttles because a locked-out source should cost the least possible work.
+
+### D1a. The generic ceiling throttles unauthenticated requests only
+
+The pre-existing `AsyncRateLimitMiddleware` is a *global* sliding-window counter (one `std::list` for the whole server, confirmed in `Middleware.cpp`), 6000 requests / 600 s. Applying that to authenticated traffic is wrong for a local-first meter: the authenticated caller is the owner, and a global budget shared across the dashboard, Home Assistant, the Modbus poller and automation would let one busy legitimate client `429` another. Rate-limiting *failed authentication* is the right thing; rate-limiting *authenticated usage of one's own device* is not.
+
+So a thin `UnauthenticatedRateLimitMiddleware` wraps the library limiter and delegates to it only when the request carries no `Authorization` header. That is exactly the DoS surface worth bounding - credential-less probes and floods - and it deliberately excludes brute-force guesses, which carry credentials and are the lockout's job. A generous global ceiling is then harmless: it only ever sees handshake first-legs and unauthenticated traffic, never the owner's real work.
+
+*Alternative considered:* keying the ceiling per-IP instead of scoping it by auth state. Rejected as more machinery for less benefit - the lockout already provides the per-IP guarantee where it matters (failed logins), and the remaining job of the global ceiling is purely volumetric DoS protection, which does not need per-IP accounting.
+
+### D1b. A lockout is logged and raised as a device issue
+
+A silent security control is backwards - the owner should be able to see that someone hammered `admin`. `recordFailure` returns true only on the failure that crosses the threshold, so the middleware logs (WARNING, with the source IP) and bumps `statistics.webServerAuthLockouts` exactly once per lockout, never per failed request.
+
+The device issue goes through the existing registry (#145), which is derive-from-facts: the lockout only increments a counter, and the registry tick pulses `Code::AuthBruteForce` on any new lockout in the window. Like `PanicReboot` it lingers in `ClearedUnacked` until acked, so an attack that has since stopped is still visible - in `GET /api/v1/system/issues` and, via the shadow, the cloud. This is deliberate architecture, not a shortcut: modules never call into the registry, so the lockout exposes a fact and the registry decides the issue.
+
+This also answers the honest limitation that the lockout only *slows* guessing (about 5 attempts per 15-minute ceiling per IP, so a determined attacker with days can still grind a weak password). Online guessing cannot be made impossible without a permanent lockout, which is itself a DoS on the owner. The layered answer is: slow it (this change), force a non-default password (the prior change), and make it visible so the owner can react (this decision).
 
 ### D2. One middleware, gating before and recording after
 
@@ -90,7 +106,7 @@ So `_rejectUploadIfNotPermitted` calls `authLockout.isSourceLocked()` first, bef
 ## Risks / Trade-offs
 
 - **Locking out the legitimate owner.** -> Only credentialed failures count, a success clears instantly, lockouts expire on their own, and the first one is short. The failure mode is a wait, never a lockout requiring physical recovery.
-- **NAT / reverse proxy: one address, many users.** -> Accepted for the local-first default, where each LAN client is a distinct IP. The lockout keys on `client->remoteIP()` - the socket peer as the device sees it - and deliberately ignores `X-Forwarded-For`/`X-Real-IP` (an attacker sets those freely; adversarial testing confirmed spoofing them collapses onto the one real socket IP and cannot forge table entries). The consequence is the mirror image: if the device is ever placed behind a reverse proxy or a CGNAT that collapses many clients to one source IP, they share a single lockout entry, and one client's failures can throttle another. Do not deploy this device behind shared-egress infrastructure; if a trusted proxy is ever introduced, the middleware would need to consult a forwarded-for header *only* from that trusted proxy, never from a raw client. This is a property of per-IP keying, not a defect, and the honest tradeoff against header spoofing.
+- **Shared source IP: one address, many users.** -> Does not arise for the threat this defends against. A brute-force attacker against a local-first meter is a host *on the LAN*, and every LAN host has its own distinct address - there is no NAT between it and the device. CGNAT and reverse proxies live on the internet-egress path, not on the local segment, so they do not collapse a local attacker's identity. The lockout keys on `client->remoteIP()` - the socket peer as the device sees it - and deliberately ignores `X-Forwarded-For`/`X-Real-IP` (an attacker sets those freely; adversarial testing confirmed spoofing them collapses onto the one real socket IP and cannot forge table entries). The only way distinct users end up sharing one lockout entry is a deliberately non-default deployment: the device placed *behind* a reverse proxy on the LAN, or exposed to the internet through one. In that case a trusted proxy would need to inject a forwarded-for header the device consults *only* from that proxy, never from a raw client. For the intended deployment this is a non-issue; it is noted only so the assumption is explicit.
 - **Table exhaustion under a distributed flood.** -> Documented in D5. `rateLimit` is the backstop; the table is not a flood defence.
 - **`getResponse()` returning null after `next()`.** -> Treated as "no outcome observed", recording neither failure nor success, so an unusual path cannot accidentally lock anyone out.
 - **Clock source.** -> `millis64()` as used elsewhere in this file; monotonic and unaffected by NTP steps, which matters because a wall-clock jump could otherwise extend or void a lockout.

--- a/openspec/changes/auth-bruteforce-lockout/proposal.md
+++ b/openspec/changes/auth-bruteforce-lockout/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+The web password is the only thing standing between a LAN host and the whole device, and nothing slows down guessing it. `_setupMiddleware()` registers `digestAuth` before `rateLimit`, and `AsyncAuthenticationMiddleware::run()` short-circuits with `requestAuthentication()` instead of calling `next()` (`Middleware.cpp:143`) - so the limiter is not merely badly tuned on the failed-login path, it is unreachable. Measured on the bench device: **400 consecutive failed logins, 400 × 401, zero 429**. Issue #197 reports the same at ~19 req/s sustained over 9.4 minutes.
+
+The generic budget would be inadequate even if it ran. `WEBSERVER_MAX_REQUESTS`/`WEBSERVER_WINDOW_SIZE_SECONDS` is 6000 requests per 600 s shared across every endpoint - about 10 req/s with no escalation, which barely inconveniences a dictionary attack.
+
+This matters more now than it did last week. #221 made the device refuse to operate on the shipped default password, so the expected end state is a user-chosen password - and a user-chosen password is exactly the thing worth guessing.
+
+## What Changes
+
+- Move `rateLimit` ahead of `digestAuth` so a failed login consumes the generic abuse budget like every other request. Chain becomes `customMiddleware` -> `rateLimit` -> `digestAuth` -> `defaultPasswordGuard`, which is also the conventional order: cheap global throttle first, then authentication, then authorization.
+- Add a per-source-IP lockout that counts **only genuine credential failures**. A 401 answering a request that carried no `Authorization` header is the ordinary first leg of every digest handshake - counting those would lock out the legitimate owner after a few page loads. Only a 401 for a request that *did* carry credentials is a failed login.
+- Lock an IP out for an escalating window after `AUTH_LOCKOUT_MAX_FAILURES` consecutive failures, answering `429` with `Retry-After` before the digest MD5 is computed. A successful login clears that IP immediately.
+- Put the lockout state machine in `source/lib/auth_lockout/` as pure logic with native tests, and have the firmware call it - the same discipline `web_auth_gate` follows, for the same reason.
+
+## Capabilities
+
+### New Capabilities
+- `auth-brute-force-protection`: how the device resists password guessing on the local web interface - what counts as a failed login, when a source is locked out, how long for, how it recovers, and what must never be locked out.
+
+### Modified Capabilities
+- `web-authentication`: the middleware ordering it documents changes, and the authentication contract gains a new failure mode (`429` before the credential check). The existing requirement that an unauthenticated caller learns nothing about the device's password state must continue to hold - a lockout response must not become a new oracle.
+
+## Impact
+
+**Code**
+- `source/lib/auth_lockout/` + `source/test/test_auth_lockout/`: new pure state machine and its Unity tests.
+- `source/src/customserver.cpp`: middleware reorder in `_setupMiddleware()`; a new middleware that consults the table before `digestAuth` and records the outcome after it.
+- `source/include/customserver.h`: the new middleware class and its tuning constants.
+
+**Behaviour**
+- A device under attack answers `429` instead of `401` once an IP crosses the threshold. Legitimate users are unaffected unless they get the password wrong `AUTH_LOCKOUT_MAX_FAILURES` times in a row, and a single success clears the count.
+- The reorder means a client that exhausts the 6000/600 s budget now gets `429` on requests that previously returned `401`. That is the intended fix, not a regression.
+
+**Memory**
+- One fixed-size table in `.bss`, `AUTH_LOCKOUT_TABLE_SIZE` entries of ~24 bytes. No heap, no task, nothing on the request path but a linear scan of a handful of entries.
+
+**Security**
+- Does not change what a correct password grants, and does not add a way to learn whether a username or password was closer to correct.
+- Deliberately out of scope: the password is still stored in plaintext in `auth_ns`; digest auth is still unencrypted over HTTP; and a distributed attacker with many source addresses is only limited by the generic budget, not by the per-IP lockout. NAT means one lockout can affect several users behind one address - accepted, because the alternative is no per-source limit at all.
+
+**Related**
+- Closes #197. Builds directly on the middleware chain established by #221.

--- a/openspec/changes/auth-bruteforce-lockout/proposal.md
+++ b/openspec/changes/auth-bruteforce-lockout/proposal.md
@@ -8,10 +8,12 @@ This matters more now than it did last week. #221 made the device refuse to oper
 
 ## What Changes
 
-- Move `rateLimit` ahead of `digestAuth` so a failed login consumes the generic abuse budget like every other request. Chain becomes `customMiddleware` -> `rateLimit` -> `digestAuth` -> `defaultPasswordGuard`, which is also the conventional order: cheap global throttle first, then authentication, then authorization.
 - Add a per-source-IP lockout that counts **only genuine credential failures**. A 401 answering a request that carried no `Authorization` header is the ordinary first leg of every digest handshake - counting those would lock out the legitimate owner after a few page loads. Only a 401 for a request that *did* carry credentials is a failed login.
 - Lock an IP out for an escalating window after `AUTH_LOCKOUT_MAX_FAILURES` consecutive failures, answering `429` with `Retry-After` before the digest MD5 is computed. A successful login clears that IP immediately.
 - Put the lockout state machine in `source/lib/auth_lockout/` as pure logic with native tests, and have the firmware call it - the same discipline `web_auth_gate` follows, for the same reason.
+- Register `authLockout` first, then the generic ceiling, then `digestAuth`. This is also the root fix for #197's headline bug: `digestAuth` short-circuits on failure without calling `next()`, so the limiter that sat after it was structurally unreachable on a 401.
+- Scope the generic request ceiling to **unauthenticated requests only**. On a local-first meter the authenticated caller is the owner; a global budget shared across the dashboard, Home Assistant, Modbus poller and automation is a misfeature, and would let one busy legitimate client `429` another. Only credential-less traffic (probes and floods, the real DoS surface) counts toward it. Brute-force guessing carries credentials, so it skips the ceiling and is handled by the lockout - which is the correct division: throttle failed *authentication*, never authenticated *usage*.
+- **Make the defence observable.** A lockout is logged (WARNING with the source IP) and raises a device issue (`auth_brute_force`) through the existing registry (#145), so a sustained attack is visible in the REST API and the cloud shadow rather than silent. Logged and raised exactly once per lockout, not per failed request. This is the honest answer to "an attacker can still grind slowly": online guessing cannot be made impossible without a permanent lockout (itself a DoS on the owner), so the layered defence is slow it, force a non-default password (the prior change), and *surface* it so the owner can act.
 
 ## Capabilities
 
@@ -20,6 +22,7 @@ This matters more now than it did last week. #221 made the device refuse to oper
 
 ### Modified Capabilities
 - `web-authentication`: the middleware ordering it documents changes, and the authentication contract gains a new failure mode (`429` before the credential check). The existing requirement that an unauthenticated caller learns nothing about the device's password state must continue to hold - a lockout response must not become a new oracle.
+- `crash-reporting` / issue registry (#145): a new device issue code (`auth_brute_force`) is added. No existing issue behaviour changes; this is an additive catalog entry, so it does not need its own spec delta beyond being recorded here.
 
 ## Impact
 

--- a/openspec/changes/auth-bruteforce-lockout/specs/auth-brute-force-protection/spec.md
+++ b/openspec/changes/auth-bruteforce-lockout/specs/auth-brute-force-protection/spec.md
@@ -93,6 +93,44 @@ Being locked out SHALL NOT prevent the device from operating, restarting cleanly
 - **WHEN** the owner is locked out and power-cycles the device
 - **THEN** it comes back ready to accept a correct password
 
+### Requirement: Throttling applies to failed authentication, not to authenticated use
+
+The device SHALL NOT rate-limit a caller that has authenticated. Any generic request ceiling SHALL apply only to unauthenticated requests. A request supplying valid credentials SHALL NOT be refused on account of request volume, however fast the authenticated caller sends them.
+
+#### Scenario: Owner's dashboard and automation
+
+- **WHEN** an authenticated client sends a rapid burst of requests - a dashboard refreshing, an automation polling
+- **THEN** none are refused for volume, because throttling authenticated use of one's own device is not the goal
+
+#### Scenario: Unauthenticated flood
+
+- **WHEN** a source sends a flood of requests without credentials
+- **THEN** the generic ceiling bounds them, protecting the device from being overwhelmed
+
+#### Scenario: Guessing does not consume the generic budget
+
+- **WHEN** an attacker sends credentialed password guesses
+- **THEN** they are governed by the failed-login lockout, not the generic ceiling, so the ceiling cannot be exhausted by guessing in a way that would refuse the legitimate owner
+
+### Requirement: A lockout is observable to the owner
+
+When the device locks a source out, it SHALL record the event so the owner can see that guessing occurred: a log entry identifying the source, and a device issue surfaced through the same channels as other device issues, including after the attack has stopped. The event SHALL be recorded once per lockout, not once per failed request.
+
+#### Scenario: Sustained attack while the owner is away
+
+- **WHEN** a source is locked out for repeated failed logins and the attack later stops
+- **THEN** a device issue remains visible until the owner acknowledges it, so an attack that happened while they were away is not lost
+
+#### Scenario: One record per lockout
+
+- **WHEN** a locked-out source keeps sending requests during its lockout
+- **THEN** the lockout is recorded once, not once per request, so the log and the issue reflect events rather than volume
+
+#### Scenario: Log identifies the source
+
+- **WHEN** a lockout is logged
+- **THEN** the entry names the source address, so the owner can tell where the guessing came from
+
 ### Requirement: A lockout discloses nothing about the password
 
 The response to a locked-out source SHALL NOT reveal whether any attempted password was closer to correct, whether the username exists, or what state the device's password is in.

--- a/openspec/changes/auth-bruteforce-lockout/specs/auth-brute-force-protection/spec.md
+++ b/openspec/changes/auth-bruteforce-lockout/specs/auth-brute-force-protection/spec.md
@@ -1,0 +1,108 @@
+## Purpose
+
+Defines how the device resists password guessing against its local web interface: what the device treats as a failed login, when it stops answering a source at all, how long that lasts, how a legitimate user recovers, and which callers must never be locked out.
+
+## ADDED Requirements
+
+### Requirement: Repeated failed logins are throttled
+
+The device SHALL limit how fast a single source address can test passwords. After a bounded number of consecutive failed logins from one source, it SHALL refuse further requests from that source for a period, without evaluating the supplied credentials.
+
+The refusal SHALL tell the client how long to wait, and SHALL cost the device less work than checking the credentials would have.
+
+#### Scenario: Sustained password guessing
+
+- **WHEN** a source sends failed login after failed login
+- **THEN** the device stops answering that source with a credential check and starts refusing it outright, so guessing rate is bounded by the lockout rather than by how fast requests can be sent
+
+#### Scenario: Refusal names the wait
+
+- **WHEN** a source is refused because it is locked out
+- **THEN** the response states how long to wait before retrying
+
+#### Scenario: Locked-out request is cheap
+
+- **WHEN** a locked-out source sends another request
+- **THEN** the device refuses it without performing the credential computation
+
+### Requirement: Only a genuine credential failure counts as a failed login
+
+A request that supplies no credentials at all is the ordinary opening move of an authentication handshake, not a failed login, and SHALL NOT count toward the lockout. Only a request that supplied credentials and was rejected SHALL count.
+
+#### Scenario: Ordinary browser sign-in
+
+- **WHEN** a user opens the web interface repeatedly, each time causing the browser's credential-less first request to be challenged
+- **THEN** none of those challenges count toward a lockout, and the user is never locked out for browsing normally
+
+#### Scenario: Unauthenticated scanning
+
+- **WHEN** a host on the network requests protected pages without ever supplying credentials
+- **THEN** it is challenged each time and is not locked out by this requirement, because it is not guessing passwords - only the device's general request budget limits it
+
+#### Scenario: Wrong password supplied
+
+- **WHEN** a request carries credentials that do not match
+- **THEN** it counts toward the lockout for that source
+
+### Requirement: A successful login clears the source immediately
+
+A correct password SHALL reset the failure count for that source, so a user who mistypes and then succeeds is not penalised afterwards.
+
+#### Scenario: Mistyped then corrected
+
+- **WHEN** a user fails several times, below the threshold, and then signs in successfully
+- **THEN** their failure count is cleared and the next mistake starts from zero
+
+### Requirement: Lockout expires on its own and lengthens under repeated abuse
+
+A lockout SHALL end without any action from the user or the device's owner. A source that resumes failing after its lockout expires SHALL be locked out for longer than before, up to a bounded maximum, so that persistent guessing becomes progressively less productive while an honest mistake costs only a short wait.
+
+#### Scenario: Honest mistake
+
+- **WHEN** a user locks themselves out by mistyping
+- **THEN** the lock expires after a short wait and they can try again, with no reset, no reboot, and no physical access
+
+#### Scenario: Persistent attacker
+
+- **WHEN** a source waits out its lockout and immediately resumes failing
+- **THEN** each subsequent lockout is longer than the last, up to a fixed ceiling
+
+#### Scenario: Lockout never becomes permanent
+
+- **WHEN** a source has been locked out many times
+- **THEN** the lockout duration stops growing at a bounded maximum, so no source is ever permanently barred
+
+### Requirement: Throttling never disables the device or its own probes
+
+The device's own liveness probe SHALL never be locked out. Tracking SHALL use a fixed amount of memory regardless of how many distinct sources attack it, and SHALL NOT allocate on the request path.
+
+Being locked out SHALL NOT prevent the device from operating, restarting cleanly, or being recovered by physical means.
+
+#### Scenario: Attack from many source addresses
+
+- **WHEN** requests arrive from more distinct sources than the device can track
+- **THEN** it keeps working within its fixed memory budget rather than growing without bound, and continues to throttle what it can still see
+
+#### Scenario: Device self-check during an attack
+
+- **WHEN** the device is under sustained password guessing
+- **THEN** its own health probe continues to succeed and it does not restart itself
+
+#### Scenario: Owner locked out and impatient
+
+- **WHEN** the owner is locked out and power-cycles the device
+- **THEN** it comes back ready to accept a correct password
+
+### Requirement: A lockout discloses nothing about the password
+
+The response to a locked-out source SHALL NOT reveal whether any attempted password was closer to correct, whether the username exists, or what state the device's password is in.
+
+#### Scenario: Attacker reads the refusal
+
+- **WHEN** an attacker inspects the locked-out response
+- **THEN** it conveys only that they are being throttled and when to retry
+
+#### Scenario: Guessing the shipped default
+
+- **WHEN** an attacker guesses passwords against a device
+- **THEN** the throttling response is the same whether or not any guess was correct-but-refused for another reason

--- a/openspec/changes/auth-bruteforce-lockout/specs/web-authentication/spec.md
+++ b/openspec/changes/auth-bruteforce-lockout/specs/web-authentication/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: The device refuses to operate while the shipped default password is active
+
+While the stored web password equals the shipped default, the device SHALL refuse every authenticated request except those on a fixed allowlist. Refusal SHALL NOT depend on the client rendering, executing, or honouring anything the device sends; a request made with a command-line HTTP client SHALL be refused exactly as a browser request is.
+
+The allowlist SHALL be limited to what a user needs in order to leave the state: the health endpoint, reading the authentication status, changing the password, the gate page itself, and the static assets that gate page needs to render.
+
+A caller that is being throttled for repeated failed logins SHALL be refused for that reason before its credentials are examined, and therefore before this requirement is evaluated. Throttling takes precedence over the lockdown, and neither refusal SHALL disclose the device's password state to a caller that has not authenticated.
+
+#### Scenario: API request with correct default credentials
+
+- **WHEN** a client authenticates with the default password and requests any API route outside the allowlist
+- **THEN** the device responds `403` with a machine-readable body identifying the default password as the reason, and the request's side effect does not occur
+
+#### Scenario: Firmware upload with correct default credentials
+
+- **WHEN** a client authenticates with the default password and posts firmware to the OTA endpoint
+- **THEN** the upload is refused and no partition is written
+
+#### Scenario: Command-line client
+
+- **WHEN** the refused request is made by a client that never fetches the web interface
+- **THEN** it is refused identically, because enforcement does not depend on the client
+
+#### Scenario: Wrong password while the default is active
+
+- **WHEN** a client supplies neither the default nor any other correct password
+- **THEN** the device responds with the normal authentication challenge, not the lockdown refusal, so the lockdown does not disclose the device's password state to an unauthenticated caller
+
+#### Scenario: Guessing the default password repeatedly
+
+- **WHEN** a client guesses passwords against a device that is on the shipped default, and crosses the failed-login threshold
+- **THEN** it is throttled rather than challenged, and the throttling response says nothing about whether the device is on its default password
+
+#### Scenario: Password has been changed
+
+- **WHEN** the stored password differs from the shipped default
+- **THEN** no request is refused on account of this requirement and the device behaves exactly as it did before this capability existed

--- a/openspec/changes/auth-bruteforce-lockout/tasks.md
+++ b/openspec/changes/auth-bruteforce-lockout/tasks.md
@@ -1,0 +1,51 @@
+## 1. The lockout state machine as pure, tested logic
+
+- [ ] 1.1 Create `source/lib/auth_lockout/auth_lockout.{h,cpp}`: a fixed-size `Table` of entries keyed by `uint32_t` address, with `init()`, `isLocked(table, ip, nowMs, &retryAfterSeconds)`, `recordFailure(table, ip, nowMs)`, `recordSuccess(table, ip, nowMs)`. No Arduino headers, no networking types, must compile for `native` (design D6).
+- [ ] 1.2 Implement escalation: `AUTH_LOCKOUT_MAX_FAILURES` consecutive failures lock for `AUTH_LOCKOUT_BASE_SECONDS`, doubling per subsequent lockout, capped at `AUTH_LOCKOUT_MAX_SECONDS` (design D4). Success clears the entry outright.
+- [ ] 1.3 Exempt loopback in the pure logic, not only structurally (design D7).
+- [ ] 1.4 Oldest-activity eviction when the table is full, so a many-source flood cannot grow memory (design D5).
+- [ ] 1.5 Write `source/test/test_auth_lockout/test_auth_lockout.cpp`: threshold boundary (N-1 failures does not lock, N does); success clears at every point below the threshold; lockout expires exactly at its deadline; escalation doubles and then stops at the ceiling; loopback never locks; eviction under more sources than slots; `millis64()` wraparound is not assumed to matter but is covered; retryAfter is never zero or negative while locked.
+- [ ] 1.6 `pio test -e native` green before touching any firmware file.
+
+## 2. Fix the ordering bug
+
+- [ ] 2.1 Move `server.addMiddleware(&rateLimit)` ahead of `server.addMiddleware(&digestAuth)` in `_setupMiddleware()` so a failed login consumes the generic budget (design D1). This alone is the fix for issue #197's first point.
+- [ ] 2.2 Confirm `defaultPasswordGuard` stays last, so it still only ever sees authenticated callers.
+
+## 3. The lockout middleware
+
+- [ ] 3.1 Add `AuthLockoutMiddleware` to `source/include/customserver.h` with the tuning constants. `run()` consults the table, sends `429` + `Retry-After` without calling `next()` when locked, otherwise calls `next()` and inspects `request->getResponse()` (design D2).
+- [ ] 3.2 Count a failure **only** when the response is `401` *and* the request carried an `Authorization` header (design D3). A credential-less `401` is the ordinary first leg of every digest handshake and must never count - getting this wrong locks out every normal user.
+- [ ] 3.3 Treat any non-401 outcome as a success that clears the source, including the `403` from the default-password guard, which means authentication succeeded. Treat a null response as "no outcome observed" and record nothing.
+- [ ] 3.4 Register it first among the throttles, before `rateLimit` and `digestAuth`, so a locked-out source costs the least work.
+- [ ] 3.5 Verify by inspection that no threshold or duration logic is restated in `customserver.cpp` - it must call the library.
+
+## 4. Build and unit verification
+
+- [ ] 4.1 `pio test -e native` - green including the new suite.
+- [ ] 4.2 `pio run -e esp32s3-dev` - compiles clean, no new warnings.
+- [ ] 4.3 cppcheck clean on `lib/auth_lockout/`.
+
+## 5. Hardware verification (bench device)
+
+- [ ] 5.1 OTA the build and confirm normal operation first - a legitimate user must be provably unaffected before anything adversarial is run.
+- [ ] 5.2 Reproduce the original bug is gone: repeated failed logins now produce `429`, where the pre-fix measurement was 400 failed logins with zero 429.
+- [ ] 5.3 **The false-positive test, which matters more than the attack tests**: sign in correctly many times in a row, in fresh sessions so each one starts with a credential-less 401, and confirm no lockout ever occurs.
+- [ ] 5.4 Confirm a lockout expires on its own, and that a correct password immediately after expiry works.
+- [ ] 5.5 Confirm escalation: lock out, wait, fail again, and observe a longer second lockout.
+- [ ] 5.6 Confirm the device stays healthy throughout - uptime continuous, no restart, `/api/v1/health` answering, since the previous change's failure mode was a restart loop ending in firmware rollback.
+
+## 6. Adversarial testing by agents
+
+Run agents whose brief is to *break* this, not to confirm it works. Each gets the device address and credentials and is told to report a bypass, not a pass.
+
+- [ ] 6.1 Agent A - **bypass the lockout**: vary source appearance (headers like `X-Forwarded-For`, `X-Real-IP`, spoofed `Host`), alternate paths and methods, mix credential-less and credentialed requests to keep the counter from advancing, and try to find any route that checks credentials without going through the lockout middleware (upload/body routes are the known-dangerous class here - they check auth inside the handler, so confirm they consult the lockout too or explain why not).
+- [ ] 6.2 Agent B - **lock out the legitimate owner (denial of service)**: try to get a valid user locked out by a third party, exhaust the table with many synthetic sources to evict a real attacker's entry, and probe whether the lockout can be made permanent or long enough to constitute a DoS.
+- [ ] 6.3 Agent C - **information disclosure and timing**: determine whether the `429`, the `401`, or response timing reveals whether a password was correct, whether the device is on its default password, or whether a username exists.
+- [ ] 6.4 Triage every finding: reproduce it, decide real vs theoretical, fix or document with the reason. Do not mark this done on an agent's say-so alone.
+- [ ] 6.5 Confirm the device survived the adversarial run: no crash, no restart, no NVS damage, still reachable, and a correct password still works.
+
+## 7. Land it
+
+- [ ] 7.1 Commit in small chunks: the pure lib + tests; the ordering fix; the middleware; any fixes from adversarial testing.
+- [ ] 7.2 PR to `development` with `Closes #197`, labels `bug` + `robustness`, no milestone. Record the pre-fix and post-fix measurements, and what the attacker agents did and did not manage.

--- a/openspec/changes/auth-bruteforce-lockout/tasks.md
+++ b/openspec/changes/auth-bruteforce-lockout/tasks.md
@@ -49,3 +49,10 @@ Run agents whose brief is to *break* this, not to confirm it works. Each gets th
 
 - [x] 7.1 Committed in chunks: the pure lib + tests; the ordering fix + middleware; the upload-route fix from adversarial testing.
 - [x] 7.2 PR #223 to `development`, `Closes #197`, labels bug + robustness, no milestone. Records the 400x401/zero-429 pre-fix measurement, the post-fix 429 behaviour, and what all three attacker agents did and did not manage.
+
+## 8. Refinements (from review discussion)
+
+- [x] 8.1 Scope the generic ceiling to unauthenticated requests only (`UnauthenticatedRateLimitMiddleware`), so authenticated owner traffic is never throttled (design D1a). Verified: 60 rapid authenticated GETs all 200, no 429.
+- [x] 8.2 Log a lockout (WARNING with source IP) and count it once via `recordFailure`'s new lockout-edge return (design D1b). Verified on hardware.
+- [x] 8.3 Raise `Code::AuthBruteForce` in the issue registry on any new lockout in the window; pulse-and-linger like PanicReboot (design D1b). Verified: issue appears as `auth_brute_force` / `cleared_unacked` with a human message after a lockout.
+- [x] 8.4 `pio test -e native` green (434 cases incl. the new lockout-edge and issue_logic coverage); `pio run -e esp32s3-dev` clean.

--- a/openspec/changes/auth-bruteforce-lockout/tasks.md
+++ b/openspec/changes/auth-bruteforce-lockout/tasks.md
@@ -48,4 +48,4 @@ Run agents whose brief is to *break* this, not to confirm it works. Each gets th
 ## 7. Land it
 
 - [x] 7.1 Committed in chunks: the pure lib + tests; the ordering fix + middleware; the upload-route fix from adversarial testing.
-- [ ] 7.2 PR to `development` with `Closes #197`, labels `bug` + `robustness`, no milestone. Record the pre-fix and post-fix measurements, and what the attacker agents did and did not manage.
+- [x] 7.2 PR #223 to `development`, `Closes #197`, labels bug + robustness, no milestone. Records the 400x401/zero-429 pre-fix measurement, the post-fix 429 behaviour, and what all three attacker agents did and did not manage.

--- a/openspec/changes/auth-bruteforce-lockout/tasks.md
+++ b/openspec/changes/auth-bruteforce-lockout/tasks.md
@@ -1,51 +1,51 @@
 ## 1. The lockout state machine as pure, tested logic
 
-- [ ] 1.1 Create `source/lib/auth_lockout/auth_lockout.{h,cpp}`: a fixed-size `Table` of entries keyed by `uint32_t` address, with `init()`, `isLocked(table, ip, nowMs, &retryAfterSeconds)`, `recordFailure(table, ip, nowMs)`, `recordSuccess(table, ip, nowMs)`. No Arduino headers, no networking types, must compile for `native` (design D6).
-- [ ] 1.2 Implement escalation: `AUTH_LOCKOUT_MAX_FAILURES` consecutive failures lock for `AUTH_LOCKOUT_BASE_SECONDS`, doubling per subsequent lockout, capped at `AUTH_LOCKOUT_MAX_SECONDS` (design D4). Success clears the entry outright.
-- [ ] 1.3 Exempt loopback in the pure logic, not only structurally (design D7).
-- [ ] 1.4 Oldest-activity eviction when the table is full, so a many-source flood cannot grow memory (design D5).
-- [ ] 1.5 Write `source/test/test_auth_lockout/test_auth_lockout.cpp`: threshold boundary (N-1 failures does not lock, N does); success clears at every point below the threshold; lockout expires exactly at its deadline; escalation doubles and then stops at the ceiling; loopback never locks; eviction under more sources than slots; `millis64()` wraparound is not assumed to matter but is covered; retryAfter is never zero or negative while locked.
-- [ ] 1.6 `pio test -e native` green before touching any firmware file.
+- [x] 1.1 Create `source/lib/auth_lockout/auth_lockout.{h,cpp}`: a fixed-size `Table` of entries keyed by `uint32_t` address, with `init()`, `isLocked(table, ip, nowMs, &retryAfterSeconds)`, `recordFailure(table, ip, nowMs)`, `recordSuccess(table, ip, nowMs)`. No Arduino headers, no networking types, must compile for `native` (design D6).
+- [x] 1.2 Implement escalation: `AUTH_LOCKOUT_MAX_FAILURES` consecutive failures lock for `AUTH_LOCKOUT_BASE_SECONDS`, doubling per subsequent lockout, capped at `AUTH_LOCKOUT_MAX_SECONDS` (design D4). Success clears the entry outright.
+- [x] 1.3 Exempt loopback in the pure logic, not only structurally (design D7).
+- [x] 1.4 Oldest-activity eviction when the table is full, so a many-source flood cannot grow memory (design D5).
+- [x] 1.5 Write `source/test/test_auth_lockout/test_auth_lockout.cpp`: threshold boundary (N-1 failures does not lock, N does); success clears at every point below the threshold; lockout expires exactly at its deadline; escalation doubles and then stops at the ceiling; loopback never locks; eviction under more sources than slots; `millis64()` wraparound is not assumed to matter but is covered; retryAfter is never zero or negative while locked.
+- [x] 1.6 `pio test -e native` green before touching any firmware file.
 
 ## 2. Fix the ordering bug
 
-- [ ] 2.1 Move `server.addMiddleware(&rateLimit)` ahead of `server.addMiddleware(&digestAuth)` in `_setupMiddleware()` so a failed login consumes the generic budget (design D1). This alone is the fix for issue #197's first point.
-- [ ] 2.2 Confirm `defaultPasswordGuard` stays last, so it still only ever sees authenticated callers.
+- [x] 2.1 Move `server.addMiddleware(&rateLimit)` ahead of `server.addMiddleware(&digestAuth)` in `_setupMiddleware()` so a failed login consumes the generic budget (design D1). This alone is the fix for issue #197's first point.
+- [x] 2.2 Confirm `defaultPasswordGuard` stays last, so it still only ever sees authenticated callers.
 
 ## 3. The lockout middleware
 
-- [ ] 3.1 Add `AuthLockoutMiddleware` to `source/include/customserver.h` with the tuning constants. `run()` consults the table, sends `429` + `Retry-After` without calling `next()` when locked, otherwise calls `next()` and inspects `request->getResponse()` (design D2).
-- [ ] 3.2 Count a failure **only** when the response is `401` *and* the request carried an `Authorization` header (design D3). A credential-less `401` is the ordinary first leg of every digest handshake and must never count - getting this wrong locks out every normal user.
-- [ ] 3.3 Treat any non-401 outcome as a success that clears the source, including the `403` from the default-password guard, which means authentication succeeded. Treat a null response as "no outcome observed" and record nothing.
-- [ ] 3.4 Register it first among the throttles, before `rateLimit` and `digestAuth`, so a locked-out source costs the least work.
-- [ ] 3.5 Verify by inspection that no threshold or duration logic is restated in `customserver.cpp` - it must call the library.
+- [x] 3.1 Add `AuthLockoutMiddleware` to `source/include/customserver.h` with the tuning constants. `run()` consults the table, sends `429` + `Retry-After` without calling `next()` when locked, otherwise calls `next()` and inspects `request->getResponse()` (design D2).
+- [x] 3.2 Count a failure **only** when the response is `401` *and* the request carried an `Authorization` header (design D3). A credential-less `401` is the ordinary first leg of every digest handshake and must never count - getting this wrong locks out every normal user.
+- [x] 3.3 Treat any non-401 outcome as a success that clears the source, including the `403` from the default-password guard, which means authentication succeeded. Treat a null response as "no outcome observed" and record nothing.
+- [x] 3.4 Register it first among the throttles, before `rateLimit` and `digestAuth`, so a locked-out source costs the least work.
+- [x] 3.5 Verify by inspection that no threshold or duration logic is restated in `customserver.cpp` - it must call the library.
 
 ## 4. Build and unit verification
 
-- [ ] 4.1 `pio test -e native` - green including the new suite.
-- [ ] 4.2 `pio run -e esp32s3-dev` - compiles clean, no new warnings.
-- [ ] 4.3 cppcheck clean on `lib/auth_lockout/`.
+- [x] 4.1 `pio test -e native` - green including the new suite.
+- [x] 4.2 `pio run -e esp32s3-dev` - compiles clean, no new warnings.
+- [x] 4.3 cppcheck clean on `lib/auth_lockout/`.
 
 ## 5. Hardware verification (bench device)
 
-- [ ] 5.1 OTA the build and confirm normal operation first - a legitimate user must be provably unaffected before anything adversarial is run.
-- [ ] 5.2 Reproduce the original bug is gone: repeated failed logins now produce `429`, where the pre-fix measurement was 400 failed logins with zero 429.
-- [ ] 5.3 **The false-positive test, which matters more than the attack tests**: sign in correctly many times in a row, in fresh sessions so each one starts with a credential-less 401, and confirm no lockout ever occurs.
-- [ ] 5.4 Confirm a lockout expires on its own, and that a correct password immediately after expiry works.
-- [ ] 5.5 Confirm escalation: lock out, wait, fail again, and observe a longer second lockout.
-- [ ] 5.6 Confirm the device stays healthy throughout - uptime continuous, no restart, `/api/v1/health` answering, since the previous change's failure mode was a restart loop ending in firmware rollback.
+- [x] 5.1 OTA the build and confirm normal operation first - a legitimate user must be provably unaffected before anything adversarial is run.
+- [x] 5.2 Reproduce the original bug is gone: repeated failed logins now produce `429`, where the pre-fix measurement was 400 failed logins with zero 429.
+- [x] 5.3 **The false-positive test, which matters more than the attack tests**: sign in correctly many times in a row, in fresh sessions so each one starts with a credential-less 401, and confirm no lockout ever occurs.
+- [x] 5.4 Confirm a lockout expires on its own, and that a correct password immediately after expiry works.
+- [x] 5.5 Confirm escalation: lock out, wait, fail again, and observe a longer second lockout.
+- [x] 5.6 Confirm the device stays healthy throughout - uptime continuous, no restart, `/api/v1/health` answering, since the previous change's failure mode was a restart loop ending in firmware rollback.
 
 ## 6. Adversarial testing by agents
 
 Run agents whose brief is to *break* this, not to confirm it works. Each gets the device address and credentials and is told to report a bypass, not a pass.
 
-- [ ] 6.1 Agent A - **bypass the lockout**: vary source appearance (headers like `X-Forwarded-For`, `X-Real-IP`, spoofed `Host`), alternate paths and methods, mix credential-less and credentialed requests to keep the counter from advancing, and try to find any route that checks credentials without going through the lockout middleware (upload/body routes are the known-dangerous class here - they check auth inside the handler, so confirm they consult the lockout too or explain why not).
-- [ ] 6.2 Agent B - **lock out the legitimate owner (denial of service)**: try to get a valid user locked out by a third party, exhaust the table with many synthetic sources to evict a real attacker's entry, and probe whether the lockout can be made permanent or long enough to constitute a DoS.
-- [ ] 6.3 Agent C - **information disclosure and timing**: determine whether the `429`, the `401`, or response timing reveals whether a password was correct, whether the device is on its default password, or whether a username exists.
-- [ ] 6.4 Triage every finding: reproduce it, decide real vs theoretical, fix or document with the reason. Do not mark this done on an agent's say-so alone.
-- [ ] 6.5 Confirm the device survived the adversarial run: no crash, no restart, no NVS damage, still reachable, and a correct password still works.
+- [x] 6.1 Agent A - **bypass**: could not defeat the single-IP throttle. Header/Host spoofing, credential-less interleave, cross-path accumulation, health-reset all correctly handled - the key is the unspoofable socket IP. **Found one real gap**: the upload routes authenticated before the lockout gate (they run during body parse, ahead of the middleware), so guessing could move there unthrottled and a correct guess would reach Update.begin(). Fixed in d5b4860 and re-verified. The only residual bypass is 8-slot table eviction, which needs >=8 genuine source IPs and is documented (D5).
+- [x] 6.2 Agent B - **DoS**: could not produce one against the local-first deployment. Keyed on the unspoofable socket IP (header spoofing collapses onto one entry), escalation capped at 15 min, state RAM-only, health probe exempt and never degraded. The reverse-proxy / CGNAT shared-IP caveat is real and now documented in design D-Risks.
+- [x] 6.3 Agent C - **disclosure**: the headline 401-vs-403 default-password oracle is REFUTED - the digestAuth-before-guard ordering means 403 only reaches an already-authenticated caller, so an unauthenticated guesser always gets 401 (design D2 holds). No username oracle (wrong-user and wrong-pass are byte-identical), no usable timing oracle. Retry-After magnitude leaks a source's own escalation tier - per-source, minor, accepted. Separately surfaced the pre-existing digest-replay weakness (nonce issued but never validated), filed as #222 - out of scope for #197.
+- [x] 6.4 Triaged: the upload-route gap was reproduced and fixed (d5b4860); the 401-vs-403 oracle was traced in code and refuted; the digest-replay finding was verified real but pre-existing and filed as #222; the shared-IP and table-eviction limits are documented, not defects.
+- [x] 6.5 Survived: across three concurrent attacker agents plus follow-up testing, crashCount 0, lastResetWasCrash false (the resets are OTA reboots), health answered 200 throughout, and a correct password works. No NVS damage.
 
 ## 7. Land it
 
-- [ ] 7.1 Commit in small chunks: the pure lib + tests; the ordering fix; the middleware; any fixes from adversarial testing.
+- [x] 7.1 Committed in chunks: the pure lib + tests; the ordering fix + middleware; the upload-route fix from adversarial testing.
 - [ ] 7.2 PR to `development` with `Closes #197`, labels `bug` + `robustness`, no milestone. Record the pre-fix and post-fix measurements, and what the attacker agents did and did not manage.

--- a/source/include/customserver.h
+++ b/source/include/customserver.h
@@ -29,6 +29,7 @@
 #include "utils.h"
 #include "led.h"
 #include "web_auth_gate.h"
+#include "auth_lockout.h"
 
 // Rate limiting
 #define WEBSERVER_MAX_REQUESTS 6000
@@ -132,6 +133,68 @@ public:
                         response->code());
         }
     }
+};
+
+// Throttles repeated failed logins per source address.
+//
+// Both halves of the job in one middleware: it refuses a locked-out source before the chain
+// continues, and it reads the outcome afterwards to decide whether that was a failed login.
+// Registered ahead of digestAuth, so a locked-out source never costs a digest MD5.
+//
+// The thresholds and durations are NOT here - they live in lib/auth_lockout and are unit
+// tested on the host. This class supplies the clock and the address and acts on the answer.
+class AuthLockoutMiddleware : public AsyncMiddleware {
+public:
+    void run(AsyncWebServerRequest *request, ArMiddlewareNext next) override {
+        AsyncClient *client = request->client();
+        if (client == nullptr) { next(); return; }
+
+        uint32_t address = (uint32_t)client->remoteIP();
+        uint64_t nowMs = _clock ? _clock() : 0;
+
+        uint32_t retryAfterSeconds = 0;
+        if (AuthLockout::isLocked(_table, address, nowMs, retryAfterSeconds)) {
+            AsyncWebServerResponse *response = request->beginResponse(HTTP_CODE_TOO_MANY_REQUESTS, "application/json",
+                "{\"success\":false,\"error\":\"Too many failed login attempts. Try again later.\"}");
+            response->addHeader("Retry-After", String(retryAfterSeconds));
+            request->send(response);
+            return;
+        }
+
+        next();
+
+        AsyncWebServerResponse *response = request->getResponse();
+        if (response == nullptr) return;  // no outcome observed - record nothing
+
+        if (response->code() == HTTP_CODE_UNAUTHORIZED) {
+            // THE decision this whole feature turns on. Every digest handshake opens with a
+            // credential-less request that is answered 401; a browser does this on every fresh
+            // session. Counting those would lock out the legitimate owner within a few page
+            // loads. Only a rejection of credentials that were actually supplied is a failed
+            // login - and an attacker must supply credentials to test a password, so nothing
+            // defensive is given up. Credential-less flooding is the rate limiter's job.
+            if (request->hasHeader("Authorization")) AuthLockout::recordFailure(_table, address, nowMs);
+            return;
+        }
+
+        // Anything else means authentication succeeded, including the 403 from the
+        // default-password guard, which only ever fires on an authenticated caller.
+        AuthLockout::recordSuccess(_table, address, nowMs);
+    }
+
+    // The clock is injected rather than called directly: this header is pulled in by
+    // translation units where utils.h has not been seen yet, and a monotonic millisecond
+    // clock is exactly the sort of thing worth being able to substitute anyway.
+    void begin(std::function<uint64_t()> clock) {
+        _clock = clock;
+        AuthLockout::init(_table);
+    }
+
+private:
+    // Touched only from the AsyncTCP task - every middleware and handler runs there - so it is
+    // not shared state and takes no mutex. Do not read it from another task without adding one.
+    AuthLockout::Table _table;
+    std::function<uint64_t()> _clock = nullptr;
 };
 
 // Refuses to serve a device that is still holding the shipped default web password.

--- a/source/include/customserver.h
+++ b/source/include/customserver.h
@@ -209,8 +209,14 @@ public:
             return;
         }
 
-        // Anything else means authentication succeeded, including the 403 from the
-        // default-password guard, which only ever fires on an authenticated caller.
+        // A throttle is not an authentication outcome. A credential-less flood can trip the
+        // unauthenticated rate limiter, and that 429 comes back here - reading it as a success
+        // would let a source clear its own accumulated failures without ever authenticating.
+        // Record nothing; the auth verdict is simply unknown for a throttled request.
+        if (response->code() == HTTP_CODE_TOO_MANY_REQUESTS) return;
+
+        // Everything else got past digestAuth, so authentication succeeded - including the 403
+        // from the default-password guard, which only ever fires on an authenticated caller.
         AuthLockout::recordSuccess(_table, address, nowMs);
     }
 

--- a/source/include/customserver.h
+++ b/source/include/customserver.h
@@ -135,6 +135,32 @@ public:
     }
 };
 
+// Applies the generic request ceiling to UNAUTHENTICATED requests only.
+//
+// A local-first meter's authenticated caller is its owner; throttling their dashboard, Home
+// Assistant, Modbus poller and automation against a shared global budget is a misfeature, and
+// the global limiter would let one busy legitimate client 429 another. So authenticated
+// traffic (anything carrying an Authorization header) is never rate-limited here. What remains
+// is the actual DoS surface - credential-less request floods that could wedge the AsyncTCP
+// task - which is exactly what the ceiling should bound.
+//
+// This is not the brute-force defence: a wrong-password guess carries an Authorization header,
+// so it skips this and is handled by the per-source lockout instead. This only sees the
+// credential-less first legs of handshakes and unauthenticated probes/floods, which is why a
+// generous global ceiling is harmless here.
+class UnauthenticatedRateLimitMiddleware : public AsyncMiddleware {
+public:
+    void setInner(AsyncRateLimitMiddleware *inner) { _inner = inner; }
+
+    void run(AsyncWebServerRequest *request, ArMiddlewareNext next) override {
+        if (request->hasHeader("Authorization") || _inner == nullptr) { next(); return; }
+        _inner->run(request, next);
+    }
+
+private:
+    AsyncRateLimitMiddleware *_inner = nullptr;
+};
+
 // Throttles repeated failed logins per source address.
 //
 // Both halves of the job in one middleware: it refuses a locked-out source before the chain
@@ -173,7 +199,13 @@ public:
             // loads. Only a rejection of credentials that were actually supplied is a failed
             // login - and an attacker must supply credentials to test a password, so nothing
             // defensive is given up. Credential-less flooding is the rate limiter's job.
-            if (request->hasHeader("Authorization")) AuthLockout::recordFailure(_table, address, nowMs);
+            if (request->hasHeader("Authorization") && AuthLockout::recordFailure(_table, address, nowMs)) {
+                // Log and count once, on the failure that crosses the threshold - so a
+                // sustained attack is visible in the log and, via the counter, surfaces as a
+                // device issue the owner (and the cloud shadow) can see.
+                statistics.webServerAuthLockouts++;
+                LOG_WARNING("Locked out %s after repeated failed logins", request->client()->remoteIP().toString().c_str());
+            }
             return;
         }
 

--- a/source/include/customserver.h
+++ b/source/include/customserver.h
@@ -190,6 +190,19 @@ public:
         AuthLockout::init(_table);
     }
 
+    // For handlers that run BEFORE the middleware chain. Upload and body callbacks fire during
+    // body parsing, so this middleware has not gated the request yet - which means an upload
+    // handler that does its own auth (as the OTA and restore routes must, since middleware auth
+    // arrives after the image is already written) would run a full password check on every
+    // attempt regardless of lock state, and a correct guess would reach Update.begin() before
+    // the masking 429. Those handlers call this first to apply the same throttle at the point
+    // where they authenticate. True when the source is locked; retryAfterSeconds is then set.
+    bool isSourceLocked(AsyncWebServerRequest *request, uint32_t &retryAfterSeconds) {
+        AsyncClient *client = request->client();
+        if (client == nullptr) { retryAfterSeconds = 0; return false; }
+        return AuthLockout::isLocked(_table, (uint32_t)client->remoteIP(), _clock ? _clock() : 0, retryAfterSeconds);
+    }
+
 private:
     // Touched only from the AsyncTCP task - every middleware and handler runs there - so it is
     // not shared state and takes no mutex. Do not read it from another task without adding one.

--- a/source/include/customserver.h
+++ b/source/include/customserver.h
@@ -209,15 +209,15 @@ public:
             return;
         }
 
-        // A throttle is not an authentication outcome. A credential-less flood can trip the
-        // unauthenticated rate limiter, and that 429 comes back here - reading it as a success
-        // would let a source clear its own accumulated failures without ever authenticating.
-        // Record nothing; the auth verdict is simply unknown for a throttled request.
-        if (response->code() == HTTP_CODE_TOO_MANY_REQUESTS) return;
-
-        // Everything else got past digestAuth, so authentication succeeded - including the 403
-        // from the default-password guard, which only ever fires on an authenticated caller.
-        AuthLockout::recordSuccess(_table, address, nowMs);
+        // Clearing a source requires a real authentication success: the request both carried
+        // credentials AND got past digestAuth (a non-401 outcome, including the 403 from the
+        // default-password guard, which only fires on an authenticated caller). A request with
+        // no Authorization header is never that - it is a handshake opening leg, an open-route
+        // hit, or a 429 from the unauthenticated rate limiter - so it records nothing. Without
+        // this guard, a credential-less request that trips the global limiter comes back 429,
+        // is read as "success", and clears a source's accumulated failures, letting an attacker
+        // interleave floods to stay below the lockout threshold forever.
+        if (request->hasHeader("Authorization")) AuthLockout::recordSuccess(_table, address, nowMs);
     }
 
     // The clock is injected rather than called directly: this header is pulled in by

--- a/source/include/structs.h
+++ b/source/include/structs.h
@@ -38,6 +38,7 @@ struct Statistics { // This will be global and we accept the very small race con
 
   uint64_t webServerRequests;
   uint64_t webServerRequestsError;
+  uint64_t webServerAuthLockouts; // A source crossed the failed-login threshold and was locked out
 
   uint64_t logVerbose;
   uint64_t logDebug;

--- a/source/lib/auth_lockout/auth_lockout.cpp
+++ b/source/lib/auth_lockout/auth_lockout.cpp
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#include "auth_lockout.h"
+
+namespace AuthLockout {
+
+namespace {
+
+Entry *findEntry(Table &table, uint32_t address) {
+    for (size_t i = 0; i < AUTH_LOCKOUT_TABLE_SIZE; i++) {
+        if (table.entries[i].address == address) return &table.entries[i];
+    }
+    return nullptr;
+}
+
+const Entry *findEntry(const Table &table, uint32_t address) {
+    for (size_t i = 0; i < AUTH_LOCKOUT_TABLE_SIZE; i++) {
+        if (table.entries[i].address == address) return &table.entries[i];
+    }
+    return nullptr;
+}
+
+// A free slot if there is one, otherwise the least recently active entry. Evicting under a
+// many-source flood is a real weakness - an attacker can push a genuine lockout out of the
+// table - but the alternative is unbounded memory on a path an attacker controls. The
+// generic rate limiter is what covers flooding; this table covers guessing.
+Entry &claimSlot(Table &table, uint32_t address, uint64_t nowMs) {
+    Entry *chosen = nullptr;
+
+    for (size_t i = 0; i < AUTH_LOCKOUT_TABLE_SIZE; i++) {
+        if (table.entries[i].address == 0) {
+            chosen = &table.entries[i];
+            break;
+        }
+        if (chosen == nullptr || table.entries[i].lastSeenMs < chosen->lastSeenMs) {
+            chosen = &table.entries[i];
+        }
+    }
+
+    chosen->address = address;
+    chosen->lockedUntilMs = 0;
+    chosen->lastSeenMs = nowMs;
+    chosen->lockCount = 0;
+    chosen->consecutiveFailures = 0;
+    return *chosen;
+}
+
+}  // namespace
+
+void init(Table &table) {
+    for (size_t i = 0; i < AUTH_LOCKOUT_TABLE_SIZE; i++) {
+        table.entries[i].address = 0;
+        table.entries[i].lockedUntilMs = 0;
+        table.entries[i].lastSeenMs = 0;
+        table.entries[i].lockCount = 0;
+        table.entries[i].consecutiveFailures = 0;
+    }
+}
+
+uint32_t lockoutSecondsFor(uint16_t lockCount) {
+    // lockCount 1 -> base, 2 -> 2x, 3 -> 4x ... capped. Escalation is what makes sustained
+    // guessing unproductive without making a single typo expensive.
+    uint32_t seconds = AUTH_LOCKOUT_BASE_SECONDS;
+
+    for (uint16_t i = 1; i < lockCount; i++) {
+        if (seconds >= AUTH_LOCKOUT_MAX_SECONDS / 2) return AUTH_LOCKOUT_MAX_SECONDS;
+        seconds *= 2;
+    }
+
+    return seconds > AUTH_LOCKOUT_MAX_SECONDS ? AUTH_LOCKOUT_MAX_SECONDS : seconds;
+}
+
+bool isLocked(const Table &table, uint32_t address, uint64_t nowMs, uint32_t &retryAfterSeconds) {
+    retryAfterSeconds = 0;
+
+    if (address == AUTH_LOCKOUT_LOOPBACK_IP) return false;
+
+    const Entry *entry = findEntry(table, address);
+    if (entry == nullptr || entry->lockedUntilMs == 0) return false;
+    if (nowMs >= entry->lockedUntilMs) return false;  // expired; recordFailure/Success tidies up
+
+    uint64_t remainingMs = entry->lockedUntilMs - nowMs;
+    // Round up, and never report 0 - a Retry-After of zero invites an immediate retry.
+    retryAfterSeconds = (uint32_t)((remainingMs + 999) / 1000);
+    if (retryAfterSeconds == 0) retryAfterSeconds = 1;
+
+    return true;
+}
+
+void recordFailure(Table &table, uint32_t address, uint64_t nowMs) {
+    if (address == AUTH_LOCKOUT_LOOPBACK_IP) return;
+
+    Entry *entry = findEntry(table, address);
+    if (entry == nullptr) entry = &claimSlot(table, address, nowMs);
+
+    entry->lastSeenMs = nowMs;
+
+    // A lockout that has run its course is cleared here rather than by a sweep, so the
+    // failure that follows it starts a fresh count toward the next (longer) lockout.
+    if (entry->lockedUntilMs != 0 && nowMs >= entry->lockedUntilMs) {
+        entry->lockedUntilMs = 0;
+        entry->consecutiveFailures = 0;
+    }
+
+    // Already locked: nothing to escalate until this one expires, and not counting keeps a
+    // flood of requests during a lockout from inflating the next one.
+    if (entry->lockedUntilMs != 0) return;
+
+    if (entry->consecutiveFailures < 0xFF) entry->consecutiveFailures++;
+
+    if (entry->consecutiveFailures >= AUTH_LOCKOUT_MAX_FAILURES) {
+        if (entry->lockCount < 0xFFFF) entry->lockCount++;
+        entry->lockedUntilMs = nowMs + (uint64_t)lockoutSecondsFor(entry->lockCount) * 1000ULL;
+        entry->consecutiveFailures = 0;
+    }
+}
+
+void recordSuccess(Table &table, uint32_t address, uint64_t nowMs) {
+    if (address == AUTH_LOCKOUT_LOOPBACK_IP) return;
+
+    Entry *entry = findEntry(table, address);
+    if (entry == nullptr) return;  // nothing held against this source
+
+    // Free the slot outright. Keeping lockCount would mean a user who once mistyped their way
+    // into a lockout carries a longer next one forever, which punishes the owner rather than
+    // an attacker - an attacker never reaches this path.
+    entry->address = 0;
+    entry->lockedUntilMs = 0;
+    entry->lastSeenMs = nowMs;
+    entry->lockCount = 0;
+    entry->consecutiveFailures = 0;
+}
+
+}  // namespace AuthLockout

--- a/source/lib/auth_lockout/auth_lockout.cpp
+++ b/source/lib/auth_lockout/auth_lockout.cpp
@@ -88,8 +88,8 @@ bool isLocked(const Table &table, uint32_t address, uint64_t nowMs, uint32_t &re
     return true;
 }
 
-void recordFailure(Table &table, uint32_t address, uint64_t nowMs) {
-    if (address == AUTH_LOCKOUT_LOOPBACK_IP) return;
+bool recordFailure(Table &table, uint32_t address, uint64_t nowMs) {
+    if (address == AUTH_LOCKOUT_LOOPBACK_IP) return false;
 
     Entry *entry = findEntry(table, address);
     if (entry == nullptr) entry = &claimSlot(table, address, nowMs);
@@ -105,7 +105,7 @@ void recordFailure(Table &table, uint32_t address, uint64_t nowMs) {
 
     // Already locked: nothing to escalate until this one expires, and not counting keeps a
     // flood of requests during a lockout from inflating the next one.
-    if (entry->lockedUntilMs != 0) return;
+    if (entry->lockedUntilMs != 0) return false;
 
     if (entry->consecutiveFailures < 0xFF) entry->consecutiveFailures++;
 
@@ -113,7 +113,10 @@ void recordFailure(Table &table, uint32_t address, uint64_t nowMs) {
         if (entry->lockCount < 0xFFFF) entry->lockCount++;
         entry->lockedUntilMs = nowMs + (uint64_t)lockoutSecondsFor(entry->lockCount) * 1000ULL;
         entry->consecutiveFailures = 0;
+        return true;  // just crossed into locked - the caller logs/counts this once
     }
+
+    return false;
 }
 
 void recordSuccess(Table &table, uint32_t address, uint64_t nowMs) {

--- a/source/lib/auth_lockout/auth_lockout.cpp
+++ b/source/lib/auth_lockout/auth_lockout.cpp
@@ -113,7 +113,7 @@ bool recordFailure(Table &table, uint32_t address, uint64_t nowMs) {
         if (entry->lockCount < 0xFFFF) entry->lockCount++;
         entry->lockedUntilMs = nowMs + (uint64_t)lockoutSecondsFor(entry->lockCount) * 1000ULL;
         entry->consecutiveFailures = 0;
-        return true;  // just crossed into locked - the caller logs/counts this once
+        return true;
     }
 
     return false;
@@ -123,7 +123,7 @@ void recordSuccess(Table &table, uint32_t address, uint64_t nowMs) {
     if (address == AUTH_LOCKOUT_LOOPBACK_IP) return;
 
     Entry *entry = findEntry(table, address);
-    if (entry == nullptr) return;  // nothing held against this source
+    if (entry == nullptr) return;
 
     // Free the slot outright. Keeping lockCount would mean a user who once mistyped their way
     // into a lockout carries a longer next one forever, which punishes the owner rather than

--- a/source/lib/auth_lockout/auth_lockout.h
+++ b/source/lib/auth_lockout/auth_lockout.h
@@ -58,7 +58,7 @@ struct Table {
     Entry entries[AUTH_LOCKOUT_TABLE_SIZE];
 };
 
-// Clears every slot. Must be called before the table is used.
+// Must be called before the table is used.
 void init(Table &table);
 
 // True when this source is currently locked out. When it returns true,

--- a/source/lib/auth_lockout/auth_lockout.h
+++ b/source/lib/auth_lockout/auth_lockout.h
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// Pure, dependency-free per-source lockout for repeated failed logins.
+//
+// The web password is the only thing between a LAN host and the whole device, and
+// before this existed nothing slowed guessing down: digestAuth short-circuits on
+// failure, so the rate limiter registered after it never ran on a 401. Measured on
+// hardware: 400 consecutive failed logins, zero 429.
+//
+// The rule that decides whether a source is locked out lives here and only here.
+// customserver.cpp supplies the clock and the address and acts on the answer - it
+// must not restate any threshold or duration. Same discipline as web_auth_gate, for
+// the same reason.
+//
+// Knows nothing about Arduino, lwIP or sockets: addresses are plain uint32_t in host
+// byte order, time is milliseconds from a monotonic clock.
+
+namespace AuthLockout {
+
+// How many consecutive credentialed failures from one source before it is locked out.
+// Low enough to bite an attacker quickly, high enough to survive a fat-fingered password.
+#define AUTH_LOCKOUT_MAX_FAILURES 5
+
+// First lockout. Short on purpose - the common case for hitting it is a human mistyping,
+// and the cost of that should be an annoyance rather than a support call.
+#define AUTH_LOCKOUT_BASE_SECONDS 30
+
+// Ceiling for the doubling. A source is never barred permanently: someone locked out of
+// their own meter must always be able to wait it out, because the alternatives are a
+// reboot or the physical button and neither is convenient.
+#define AUTH_LOCKOUT_MAX_SECONDS 900  // 15 minutes
+
+// Distinct sources tracked at once. Fixed, in .bss - a flood from many addresses must not
+// grow memory. When full, the least recently active entry is evicted.
+#define AUTH_LOCKOUT_TABLE_SIZE 8
+
+// 127.0.0.1 in host byte order. The device probes its own health endpoint from here; that
+// route skips the whole middleware chain so this can never be reached in practice, but the
+// consequence of being wrong is the restart-loop-into-firmware-rollback failure documented
+// in the default-password work, and one structural guarantee is not enough for that.
+#define AUTH_LOCKOUT_LOOPBACK_IP 0x7F000001u
+
+struct Entry {
+    uint32_t address;              // 0 means the slot is free
+    uint64_t lockedUntilMs;        // 0 when not currently locked
+    uint64_t lastSeenMs;           // for eviction
+    uint16_t lockCount;            // how many times this source has been locked; drives escalation
+    uint8_t consecutiveFailures;
+};
+
+struct Table {
+    Entry entries[AUTH_LOCKOUT_TABLE_SIZE];
+};
+
+// Clears every slot. Must be called before the table is used.
+void init(Table &table);
+
+// True when this source is currently locked out. When it returns true,
+// retryAfterSeconds is set to the whole seconds remaining, never zero - a
+// Retry-After of 0 would invite an immediate retry.
+//
+// Loopback is never locked out (AUTH_LOCKOUT_LOOPBACK_IP).
+bool isLocked(const Table &table, uint32_t address, uint64_t nowMs, uint32_t &retryAfterSeconds);
+
+// Records one genuine credential failure.
+//
+// "Genuine" is the caller's job and it is the crux of the whole feature: a 401 answering a
+// request that carried no credentials is the ordinary opening leg of a digest handshake, and
+// counting those would lock out every normal user within a few page loads. Only pass a
+// rejection of credentials that were actually supplied.
+void recordFailure(Table &table, uint32_t address, uint64_t nowMs);
+
+// Records a successful authentication, clearing the source outright - a user who mistypes and
+// then succeeds carries no penalty forward.
+void recordSuccess(Table &table, uint32_t address, uint64_t nowMs);
+
+// How long the Nth lockout lasts, in seconds. Exposed for testing the escalation curve
+// directly rather than inferring it from the table.
+uint32_t lockoutSecondsFor(uint16_t lockCount);
+
+}  // namespace AuthLockout

--- a/source/lib/auth_lockout/auth_lockout.h
+++ b/source/lib/auth_lockout/auth_lockout.h
@@ -68,13 +68,15 @@ void init(Table &table);
 // Loopback is never locked out (AUTH_LOCKOUT_LOOPBACK_IP).
 bool isLocked(const Table &table, uint32_t address, uint64_t nowMs, uint32_t &retryAfterSeconds);
 
-// Records one genuine credential failure.
+// Records one genuine credential failure. Returns true only on the transition into a locked
+// state - the single failure that crosses the threshold - so the caller can log and count a
+// lockout exactly once, not on every failure and not on every subsequent request while locked.
 //
 // "Genuine" is the caller's job and it is the crux of the whole feature: a 401 answering a
 // request that carried no credentials is the ordinary opening leg of a digest handshake, and
 // counting those would lock out every normal user within a few page loads. Only pass a
 // rejection of credentials that were actually supplied.
-void recordFailure(Table &table, uint32_t address, uint64_t nowMs);
+bool recordFailure(Table &table, uint32_t address, uint64_t nowMs);
 
 // Records a successful authentication, clearing the source outright - a user who mistypes and
 // then succeeds carries no penalty forward.

--- a/source/lib/issue_logic/issue_logic.cpp
+++ b/source/lib/issue_logic/issue_logic.cpp
@@ -28,6 +28,7 @@ static constexpr CodeDescriptor CODE_TABLE[] = {
     {"voltage_out_of_range",        Severity::Warning}, // Code::VoltageOutOfRange
     {"grid_frequency_out_of_range", Severity::Warning}, // Code::GridFrequencyOutOfRange
     {"ade7953_read_failures",       Severity::Warning}, // Code::Ade7953ReadFailures
+    {"auth_brute_force",            Severity::Warning}, // Code::AuthBruteForce
 };
 static_assert(sizeof(CODE_TABLE) / sizeof(CODE_TABLE[0]) == (size_t)Code::Count,
               "every IssueLogic::Code needs a CODE_TABLE row");

--- a/source/lib/issue_logic/issue_logic.h
+++ b/source/lib/issue_logic/issue_logic.h
@@ -39,6 +39,7 @@ enum class Code : uint8_t {
     VoltageOutOfRange,        // sustained deviation from nominal mains voltage
     GridFrequencyOutOfRange,  // sustained deviation from nominal grid frequency
     Ade7953ReadFailures,      // sustained meter reading failures
+    AuthBruteForce,           // event: a source was locked out for repeated failed web logins
     Count
 };
 

--- a/source/src/customserver.cpp
+++ b/source/src/customserver.cpp
@@ -25,6 +25,7 @@ namespace CustomServer
     static CustomMiddleware customMiddleware;
     static DefaultPasswordGuardMiddleware defaultPasswordGuard;
     static AuthLockoutMiddleware authLockout;
+    static UnauthenticatedRateLimitMiddleware unauthRateLimit;
 
     // Whether the stored web password is still the shipped default. Read on the AsyncTCP
     // task for every request to every path, so it must never become an NVS read: it is
@@ -300,9 +301,12 @@ namespace CustomServer
         rateLimit.setMaxRequests(WEBSERVER_MAX_REQUESTS);
         rateLimit.setWindowSize(WEBSERVER_WINDOW_SIZE_SECONDS);
 
-        server.addMiddleware(&rateLimit);
+        // Only unauthenticated requests count toward the ceiling - the owner's authenticated
+        // traffic is never throttled. See UnauthenticatedRateLimitMiddleware.
+        unauthRateLimit.setInner(&rateLimit);
+        server.addMiddleware(&unauthRateLimit);
 
-        LOG_DEBUG("Rate limiting configured: max requests = %d, window size = %d seconds", WEBSERVER_MAX_REQUESTS, WEBSERVER_WINDOW_SIZE_SECONDS);
+        LOG_DEBUG("Rate limiting (unauthenticated only) configured: max requests = %d, window size = %d seconds", WEBSERVER_MAX_REQUESTS, WEBSERVER_WINDOW_SIZE_SECONDS);
 
         server.addMiddleware(&digestAuth);
 

--- a/source/src/customserver.cpp
+++ b/source/src/customserver.cpp
@@ -24,6 +24,7 @@ namespace CustomServer
     static AsyncRateLimitMiddleware rateLimit;
     static CustomMiddleware customMiddleware;
     static DefaultPasswordGuardMiddleware defaultPasswordGuard;
+    static AuthLockoutMiddleware authLockout;
 
     // Whether the stored web password is still the shipped default. Read on the AsyncTCP
     // task for every request to every path, so it must never become an NVS read: it is
@@ -281,18 +282,31 @@ namespace CustomServer
         digestAuth.setAuthType(AsyncAuthType::AUTH_DIGEST);
         digestAuth.generateHash(); // precompute hash for better performance
 
-        server.addMiddleware(&digestAuth);
+        // ---- Auth Lockout Setup ----
+        // Ahead of everything else that can refuse a request, so a source already locked out
+        // for guessing costs a table scan rather than a digest MD5.
+        authLockout.begin([]() { return millis64(); });
+        server.addMiddleware(&authLockout);
 
-        LOG_DEBUG("Digest authentication configured");
+        LOG_DEBUG("Auth lockout configured: %d consecutive failures -> %d s, doubling to %d s",
+                  AUTH_LOCKOUT_MAX_FAILURES, AUTH_LOCKOUT_BASE_SECONDS, AUTH_LOCKOUT_MAX_SECONDS);
 
         // ---- Rate Limiting Middleware Setup ----
-        // Set rate limiting to prevent abuse
+        // BEFORE digestAuth, deliberately. AsyncAuthenticationMiddleware::run short-circuits
+        // with requestAuthentication() instead of calling next() (Middleware.cpp:143), so
+        // anything registered after it never runs on a 401 - which meant the limiter was not
+        // merely mistuned on the failed-login path, it was unreachable. Measured before this
+        // change: 400 consecutive failed logins, zero 429 (issue #197).
         rateLimit.setMaxRequests(WEBSERVER_MAX_REQUESTS);
         rateLimit.setWindowSize(WEBSERVER_WINDOW_SIZE_SECONDS);
 
         server.addMiddleware(&rateLimit);
 
         LOG_DEBUG("Rate limiting configured: max requests = %d, window size = %d seconds", WEBSERVER_MAX_REQUESTS, WEBSERVER_WINDOW_SIZE_SECONDS);
+
+        server.addMiddleware(&digestAuth);
+
+        LOG_DEBUG("Digest authentication configured");
 
         // ---- Default Password Lockdown Setup ----
         // Registered last, and that position is load-bearing in both directions.

--- a/source/src/customserver.cpp
+++ b/source/src/customserver.cpp
@@ -1351,6 +1351,22 @@ namespace CustomServer
     // _handleOtaUploadComplete/_handleFileUploadData bail on request->getResponse().
     static bool _rejectUploadIfNotPermitted(AsyncWebServerRequest *request)
     {
+        // Throttle before authenticating. This runs during body parsing, ahead of the lockout
+        // middleware, so without this an attacker could move password guessing to the upload
+        // routes and never be slowed: every attempt would run a full digest check here, and a
+        // correct guess would reach Update.begin() before the middleware's 429 could mask it.
+        // The middleware still records the failure afterwards from the 401 this leaves set.
+        uint32_t retryAfterSeconds = 0;
+        if (authLockout.isSourceLocked(request, retryAfterSeconds))
+        {
+            LOG_WARNING("Refused an upload from a locked-out source before authenticating");
+            AsyncWebServerResponse *response = request->beginResponse(HTTP_CODE_TOO_MANY_REQUESTS, "application/json",
+                "{\"success\":false,\"error\":\"Too many failed login attempts. Try again later.\"}");
+            response->addHeader("Retry-After", String(retryAfterSeconds));
+            request->send(response);
+            return true;
+        }
+
         char storedPassword[WEB_PASSWORD_BUFFER_SIZE];
         bool passwordReadable = _getWebPasswordFromPreferences(storedPassword, sizeof(storedPassword));
 

--- a/source/src/issueregistry.cpp
+++ b/source/src/issueregistry.cpp
@@ -60,6 +60,7 @@ namespace IssueRegistry
     static uint16_t _frequencyStreak = 0;
     static uint16_t _readFailureStreak = 0;
     static uint64_t _prevAde7953Failures = 0;
+    static uint64_t _prevAuthLockouts = 0;
     static bool _littleFsCondition = false;
     static bool _firstTick = true;
 
@@ -472,6 +473,23 @@ namespace IssueRegistry
                      failureDelta);
         }
         _updateInstance(IssueLogic::Code::Ade7953ReadFailures, ISSUE_GLOBAL_SCOPE, readsFailing, message);
+
+        // --- auth_brute_force
+        // A lockout is a discrete security event, so it pulses (raised for the window it
+        // happened in, then lingering in ClearedUnacked until the owner acks it) rather than
+        // tracking a sustained condition. That way an attack that has since stopped is still
+        // visible after the fact, in the REST issues list and the cloud shadow. The firmware
+        // log carries the per-source detail; the issue is the "someone tried" headline.
+        uint64_t lockoutDelta = IssueLogic::counterDelta(_prevAuthLockouts, statistics.webServerAuthLockouts);
+        _prevAuthLockouts = statistics.webServerAuthLockouts;
+        bool lockoutPulse = (lockoutDelta > 0);
+        message[0] = '\0';
+        if (lockoutPulse) {
+            snprintf(message, sizeof(message),
+                     "Repeated failed web logins were locked out (%llu lockout%s in the last window, %llu total)",
+                     lockoutDelta, lockoutDelta == 1 ? "" : "s", (unsigned long long)statistics.webServerAuthLockouts);
+        }
+        _updateInstance(IssueLogic::Code::AuthBruteForce, ISSUE_GLOBAL_SCOPE, lockoutPulse, message);
     }
 
     // Instance table management

--- a/source/src/issueregistry.cpp
+++ b/source/src/issueregistry.cpp
@@ -480,14 +480,18 @@ namespace IssueRegistry
         // tracking a sustained condition. That way an attack that has since stopped is still
         // visible after the fact, in the REST issues list and the cloud shadow. The firmware
         // log carries the per-source detail; the issue is the "someone tried" headline.
-        uint64_t lockoutDelta = IssueLogic::counterDelta(_prevAuthLockouts, statistics.webServerAuthLockouts);
-        _prevAuthLockouts = statistics.webServerAuthLockouts;
+        // Snapshot once: the AsyncTCP task may increment between reads, and using two separate
+        // reads for the delta and the _prev update would drop that lockout from this window's
+        // delta and, via the advanced _prev, from every future window too.
+        uint64_t authLockoutsNow = statistics.webServerAuthLockouts;
+        uint64_t lockoutDelta = IssueLogic::counterDelta(_prevAuthLockouts, authLockoutsNow);
+        _prevAuthLockouts = authLockoutsNow;
         bool lockoutPulse = (lockoutDelta > 0);
         message[0] = '\0';
         if (lockoutPulse) {
             snprintf(message, sizeof(message),
                      "Repeated failed web logins were locked out (%llu lockout%s in the last window, %llu total)",
-                     lockoutDelta, lockoutDelta == 1 ? "" : "s", (unsigned long long)statistics.webServerAuthLockouts);
+                     lockoutDelta, lockoutDelta == 1 ? "" : "s", (unsigned long long)authLockoutsNow);
         }
         _updateInstance(IssueLogic::Code::AuthBruteForce, ISSUE_GLOBAL_SCOPE, lockoutPulse, message);
     }

--- a/source/test/test_auth_lockout/test_auth_lockout.cpp
+++ b/source/test/test_auth_lockout/test_auth_lockout.cpp
@@ -225,6 +225,21 @@ void test_an_unknown_source_success_is_harmless(void) {
     TEST_ASSERT_FALSE(isLocked(table, kBob, 0, retryAfter));
 }
 
+// isLocked is a pure query with no side effect - the upload handlers call it before doing
+// their own auth, and calling it must not itself advance or reset any counter. A defense
+// that changed state just by being *checked* would be a footgun.
+void test_isLocked_is_a_pure_query(void) {
+    for (int i = 0; i < AUTH_LOCKOUT_MAX_FAILURES - 1; i++) recordFailure(table, kAlice, 0);
+
+    uint32_t retryAfter = 0;
+    for (int i = 0; i < 50; i++) {
+        TEST_ASSERT_FALSE(isLocked(table, kAlice, 0, retryAfter));  // still one short
+    }
+    // The pending failures are intact: one more locks, checking did not consume them.
+    recordFailure(table, kAlice, 0);
+    TEST_ASSERT_TRUE(isLocked(table, kAlice, 0, retryAfter));
+}
+
 // --- Large clock values -----------------------------------------------------------------
 //
 // millis64() does not wrap in any practical uptime, but the arithmetic should not assume a
@@ -265,6 +280,7 @@ int main(int, char **) {
     RUN_TEST(test_more_sources_than_slots_stays_within_the_table);
     RUN_TEST(test_eviction_takes_the_least_recently_active);
     RUN_TEST(test_an_unknown_source_success_is_harmless);
+    RUN_TEST(test_isLocked_is_a_pure_query);
 
     RUN_TEST(test_large_clock_values_behave);
 

--- a/source/test/test_auth_lockout/test_auth_lockout.cpp
+++ b/source/test/test_auth_lockout/test_auth_lockout.cpp
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2025 Jibril Sharafi
+//
+// Host unit tests for the per-source auth lockout. Run with:
+//   pio test -e native          (from WSL - Windows native toolchain is unreliable)
+
+#include <unity.h>
+#include "auth_lockout.h"
+
+using namespace AuthLockout;
+
+namespace {
+
+constexpr uint32_t kAlice = 0xC0A80102u;  // 192.168.1.2
+constexpr uint32_t kBob = 0xC0A80103u;    // 192.168.1.3
+constexpr uint64_t kSecond = 1000ULL;
+
+Table table;
+
+uint32_t failUntilLocked(uint32_t address, uint64_t nowMs) {
+    uint32_t retryAfter = 0;
+    for (int i = 0; i < AUTH_LOCKOUT_MAX_FAILURES; i++) {
+        recordFailure(table, address, nowMs);
+    }
+    isLocked(table, address, nowMs, retryAfter);
+    return retryAfter;
+}
+
+}  // namespace
+
+void setUp(void) { init(table); }
+void tearDown(void) {}
+
+// --- Threshold -----------------------------------------------------------------------
+
+void test_a_fresh_source_is_not_locked(void) {
+    uint32_t retryAfter = 99;
+    TEST_ASSERT_FALSE(isLocked(table, kAlice, 0, retryAfter));
+    TEST_ASSERT_EQUAL_UINT32(0, retryAfter);
+}
+
+void test_one_short_of_the_threshold_does_not_lock(void) {
+    uint32_t retryAfter = 0;
+    for (int i = 0; i < AUTH_LOCKOUT_MAX_FAILURES - 1; i++) {
+        recordFailure(table, kAlice, 0);
+        TEST_ASSERT_FALSE(isLocked(table, kAlice, 0, retryAfter));
+    }
+}
+
+void test_the_threshold_locks(void) {
+    uint32_t retryAfter = failUntilLocked(kAlice, 0);
+    uint32_t dummy = 0;
+    TEST_ASSERT_TRUE(isLocked(table, kAlice, 0, dummy));
+    TEST_ASSERT_EQUAL_UINT32(AUTH_LOCKOUT_BASE_SECONDS, retryAfter);
+}
+
+// --- Success clears ------------------------------------------------------------------
+
+void test_success_clears_the_count_at_every_point_below_the_threshold(void) {
+    uint32_t retryAfter = 0;
+    for (int failures = 1; failures < AUTH_LOCKOUT_MAX_FAILURES; failures++) {
+        init(table);
+        for (int i = 0; i < failures; i++) recordFailure(table, kAlice, 0);
+        recordSuccess(table, kAlice, 0);
+
+        // Having cleared, a full fresh run of failures should be needed to lock.
+        for (int i = 0; i < AUTH_LOCKOUT_MAX_FAILURES - 1; i++) {
+            recordFailure(table, kAlice, 0);
+            TEST_ASSERT_FALSE(isLocked(table, kAlice, 0, retryAfter));
+        }
+    }
+}
+
+// A user who mistypes and then gets it right must carry nothing forward. An attacker never
+// reaches this path, so a generous reset costs nothing defensively.
+void test_success_also_clears_the_escalation_history(void) {
+    failUntilLocked(kAlice, 0);
+    recordSuccess(table, kAlice, 60 * kSecond);
+
+    uint32_t retryAfter = failUntilLocked(kAlice, 60 * kSecond);
+    TEST_ASSERT_EQUAL_UINT32(AUTH_LOCKOUT_BASE_SECONDS, retryAfter);
+}
+
+// --- Expiry --------------------------------------------------------------------------
+
+void test_the_lockout_expires_on_its_own(void) {
+    failUntilLocked(kAlice, 0);
+    uint32_t retryAfter = 0;
+
+    uint64_t deadline = (uint64_t)AUTH_LOCKOUT_BASE_SECONDS * kSecond;
+    TEST_ASSERT_TRUE(isLocked(table, kAlice, deadline - 1, retryAfter));
+    TEST_ASSERT_FALSE(isLocked(table, kAlice, deadline, retryAfter));
+    TEST_ASSERT_FALSE(isLocked(table, kAlice, deadline + 1, retryAfter));
+}
+
+// Nobody should ever be told to retry in zero seconds.
+void test_retry_after_is_never_zero_while_locked(void) {
+    failUntilLocked(kAlice, 0);
+    uint64_t deadline = (uint64_t)AUTH_LOCKOUT_BASE_SECONDS * kSecond;
+
+    for (uint64_t now = 0; now < deadline; now += 250) {
+        uint32_t retryAfter = 0;
+        TEST_ASSERT_TRUE(isLocked(table, kAlice, now, retryAfter));
+        TEST_ASSERT_GREATER_THAN_UINT32(0, retryAfter);
+    }
+}
+
+// --- Escalation ----------------------------------------------------------------------
+
+void test_each_lockout_is_longer_than_the_last(void) {
+    uint32_t previous = 0;
+    uint64_t now = 0;
+
+    for (int round = 0; round < 5; round++) {
+        uint32_t retryAfter = failUntilLocked(kAlice, now);
+        if (round > 0) TEST_ASSERT_GREATER_THAN_UINT32(previous, retryAfter);
+        previous = retryAfter;
+        now += (uint64_t)retryAfter * kSecond + kSecond;  // wait it out
+    }
+}
+
+void test_escalation_stops_at_the_ceiling(void) {
+    // No source may ever be barred permanently - someone locked out of their own meter has to
+    // be able to wait it out.
+    for (uint16_t lockCount = 1; lockCount < 1000; lockCount++) {
+        TEST_ASSERT_LESS_OR_EQUAL_UINT32(AUTH_LOCKOUT_MAX_SECONDS, lockoutSecondsFor(lockCount));
+    }
+    TEST_ASSERT_EQUAL_UINT32(AUTH_LOCKOUT_MAX_SECONDS, lockoutSecondsFor(999));
+}
+
+void test_the_escalation_curve_starts_at_the_base_and_doubles(void) {
+    TEST_ASSERT_EQUAL_UINT32(AUTH_LOCKOUT_BASE_SECONDS, lockoutSecondsFor(1));
+    TEST_ASSERT_EQUAL_UINT32(AUTH_LOCKOUT_BASE_SECONDS * 2, lockoutSecondsFor(2));
+    TEST_ASSERT_EQUAL_UINT32(AUTH_LOCKOUT_BASE_SECONDS * 4, lockoutSecondsFor(3));
+}
+
+// Hammering while already locked must not inflate the next lockout - otherwise an attacker
+// could drive their own lockout to the ceiling and, more importantly, the arithmetic could
+// overflow.
+void test_failures_during_a_lockout_do_not_escalate_it(void) {
+    uint32_t first = failUntilLocked(kAlice, 0);
+    for (int i = 0; i < 500; i++) recordFailure(table, kAlice, 1000);
+
+    uint32_t retryAfter = 0;
+    TEST_ASSERT_TRUE(isLocked(table, kAlice, 1000, retryAfter));
+
+    uint64_t afterExpiry = (uint64_t)first * kSecond + kSecond;
+    uint32_t second = failUntilLocked(kAlice, afterExpiry);
+    TEST_ASSERT_EQUAL_UINT32(AUTH_LOCKOUT_BASE_SECONDS * 2, second);
+}
+
+// --- Isolation between sources --------------------------------------------------------
+
+void test_locking_one_source_does_not_lock_another(void) {
+    failUntilLocked(kAlice, 0);
+    uint32_t retryAfter = 0;
+    TEST_ASSERT_TRUE(isLocked(table, kAlice, 0, retryAfter));
+    TEST_ASSERT_FALSE(isLocked(table, kBob, 0, retryAfter));
+}
+
+// --- Loopback -------------------------------------------------------------------------
+//
+// The device probes its own health endpoint from 127.0.0.1. That route skips the middleware
+// chain so this is unreachable in practice, but five failed health checks request a restart
+// and the loop ends in a firmware rollback and an NVS wipe - one structural guarantee is not
+// enough for that.
+void test_loopback_is_never_locked_out(void) {
+    uint32_t retryAfter = 0;
+    for (int i = 0; i < AUTH_LOCKOUT_MAX_FAILURES * 20; i++) {
+        recordFailure(table, AUTH_LOCKOUT_LOOPBACK_IP, (uint64_t)i);
+        TEST_ASSERT_FALSE(isLocked(table, AUTH_LOCKOUT_LOOPBACK_IP, (uint64_t)i, retryAfter));
+    }
+}
+
+void test_loopback_never_consumes_a_slot(void) {
+    for (int i = 0; i < 100; i++) recordFailure(table, AUTH_LOCKOUT_LOOPBACK_IP, (uint64_t)i);
+
+    // Every slot must still be available to real sources.
+    for (uint32_t i = 0; i < AUTH_LOCKOUT_TABLE_SIZE; i++) {
+        failUntilLocked(0x0A000001u + i, 0);
+    }
+    uint32_t retryAfter = 0;
+    for (uint32_t i = 0; i < AUTH_LOCKOUT_TABLE_SIZE; i++) {
+        TEST_ASSERT_TRUE(isLocked(table, 0x0A000001u + i, 0, retryAfter));
+    }
+}
+
+// --- Table pressure --------------------------------------------------------------------
+
+void test_more_sources_than_slots_stays_within_the_table(void) {
+    // Fill beyond capacity; the point is that it does not misbehave, not that every source
+    // is remembered. Eviction is a documented limitation (design D5).
+    for (uint32_t i = 0; i < AUTH_LOCKOUT_TABLE_SIZE * 4; i++) {
+        failUntilLocked(0x0A000001u + i, (uint64_t)i * kSecond);
+    }
+
+    uint32_t retryAfter = 0;
+    uint32_t lockedCount = 0;
+    for (uint32_t i = 0; i < AUTH_LOCKOUT_TABLE_SIZE * 4; i++) {
+        if (isLocked(table, 0x0A000001u + i, (uint64_t)AUTH_LOCKOUT_TABLE_SIZE * 4 * kSecond, retryAfter)) {
+            lockedCount++;
+        }
+    }
+    TEST_ASSERT_LESS_OR_EQUAL_UINT32(AUTH_LOCKOUT_TABLE_SIZE, lockedCount);
+}
+
+// The most recent offenders are the ones worth remembering.
+void test_eviction_takes_the_least_recently_active(void) {
+    for (uint32_t i = 0; i < AUTH_LOCKOUT_TABLE_SIZE; i++) {
+        failUntilLocked(0x0A000001u + i, (uint64_t)i * kSecond);
+    }
+
+    uint64_t later = (uint64_t)(AUTH_LOCKOUT_TABLE_SIZE + 10) * kSecond;
+    failUntilLocked(0xC0A80199u, later);
+
+    uint32_t retryAfter = 0;
+    TEST_ASSERT_TRUE(isLocked(table, 0xC0A80199u, later, retryAfter));
+    // The oldest (index 0, seen at t=0) is the one that should have gone.
+    TEST_ASSERT_FALSE(isLocked(table, 0x0A000001u, later, retryAfter));
+}
+
+void test_an_unknown_source_success_is_harmless(void) {
+    recordSuccess(table, kBob, 0);
+    uint32_t retryAfter = 0;
+    TEST_ASSERT_FALSE(isLocked(table, kBob, 0, retryAfter));
+}
+
+// --- Large clock values -----------------------------------------------------------------
+//
+// millis64() does not wrap in any practical uptime, but the arithmetic should not assume a
+// small clock either.
+void test_large_clock_values_behave(void) {
+    uint64_t huge = 1000ULL * 60 * 60 * 24 * 365 * 10;  // ~10 years of uptime
+    uint32_t retryAfter = failUntilLocked(kAlice, huge);
+    TEST_ASSERT_EQUAL_UINT32(AUTH_LOCKOUT_BASE_SECONDS, retryAfter);
+
+    uint32_t dummy = 0;
+    TEST_ASSERT_TRUE(isLocked(table, kAlice, huge, dummy));
+    TEST_ASSERT_FALSE(isLocked(table, kAlice, huge + (uint64_t)AUTH_LOCKOUT_BASE_SECONDS * kSecond, dummy));
+}
+
+int main(int, char **) {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_a_fresh_source_is_not_locked);
+    RUN_TEST(test_one_short_of_the_threshold_does_not_lock);
+    RUN_TEST(test_the_threshold_locks);
+
+    RUN_TEST(test_success_clears_the_count_at_every_point_below_the_threshold);
+    RUN_TEST(test_success_also_clears_the_escalation_history);
+
+    RUN_TEST(test_the_lockout_expires_on_its_own);
+    RUN_TEST(test_retry_after_is_never_zero_while_locked);
+
+    RUN_TEST(test_each_lockout_is_longer_than_the_last);
+    RUN_TEST(test_escalation_stops_at_the_ceiling);
+    RUN_TEST(test_the_escalation_curve_starts_at_the_base_and_doubles);
+    RUN_TEST(test_failures_during_a_lockout_do_not_escalate_it);
+
+    RUN_TEST(test_locking_one_source_does_not_lock_another);
+
+    RUN_TEST(test_loopback_is_never_locked_out);
+    RUN_TEST(test_loopback_never_consumes_a_slot);
+
+    RUN_TEST(test_more_sources_than_slots_stays_within_the_table);
+    RUN_TEST(test_eviction_takes_the_least_recently_active);
+    RUN_TEST(test_an_unknown_source_success_is_harmless);
+
+    RUN_TEST(test_large_clock_values_behave);
+
+    return UNITY_END();
+}

--- a/source/test/test_auth_lockout/test_auth_lockout.cpp
+++ b/source/test/test_auth_lockout/test_auth_lockout.cpp
@@ -54,6 +54,39 @@ void test_the_threshold_locks(void) {
     TEST_ASSERT_EQUAL_UINT32(AUTH_LOCKOUT_BASE_SECONDS, retryAfter);
 }
 
+// recordFailure returns true only on the failure that crosses the threshold, so the caller
+// can log and count a lockout exactly once - not on every failure, not on every request while
+// already locked.
+void test_recordFailure_signals_the_lockout_edge_exactly_once(void) {
+    for (int i = 0; i < AUTH_LOCKOUT_MAX_FAILURES - 1; i++) {
+        TEST_ASSERT_FALSE(recordFailure(table, kAlice, 0));  // below threshold
+    }
+    TEST_ASSERT_TRUE(recordFailure(table, kAlice, 0));       // the crossing failure
+
+    // Hammering while locked must not re-signal.
+    for (int i = 0; i < 20; i++) {
+        TEST_ASSERT_FALSE(recordFailure(table, kAlice, 100));
+    }
+}
+
+// A fresh lockout after an expired one signals again - it is a new event worth logging.
+void test_recordFailure_signals_again_on_a_later_lockout(void) {
+    uint32_t first = failUntilLocked(kAlice, 0);
+    uint64_t afterExpiry = (uint64_t)first * 1000ULL + 1000ULL;
+
+    for (int i = 0; i < AUTH_LOCKOUT_MAX_FAILURES - 1; i++) {
+        TEST_ASSERT_FALSE(recordFailure(table, kAlice, afterExpiry));
+    }
+    TEST_ASSERT_TRUE(recordFailure(table, kAlice, afterExpiry));
+}
+
+// Loopback never locks, so it never signals.
+void test_loopback_recordFailure_never_signals(void) {
+    for (int i = 0; i < AUTH_LOCKOUT_MAX_FAILURES * 5; i++) {
+        TEST_ASSERT_FALSE(recordFailure(table, AUTH_LOCKOUT_LOOPBACK_IP, (uint64_t)i));
+    }
+}
+
 // --- Success clears ------------------------------------------------------------------
 
 void test_success_clears_the_count_at_every_point_below_the_threshold(void) {
@@ -260,6 +293,9 @@ int main(int, char **) {
     RUN_TEST(test_a_fresh_source_is_not_locked);
     RUN_TEST(test_one_short_of_the_threshold_does_not_lock);
     RUN_TEST(test_the_threshold_locks);
+    RUN_TEST(test_recordFailure_signals_the_lockout_edge_exactly_once);
+    RUN_TEST(test_recordFailure_signals_again_on_a_later_lockout);
+    RUN_TEST(test_loopback_recordFailure_never_signals);
 
     RUN_TEST(test_success_clears_the_count_at_every_point_below_the_threshold);
     RUN_TEST(test_success_also_clears_the_escalation_history);


### PR DESCRIPTION
Closes #197.

## The bug

`_setupMiddleware()` registered `digestAuth` before `rateLimit`, and `AsyncAuthenticationMiddleware::run()` short-circuits with `requestAuthentication()` instead of calling `next()` (`Middleware.cpp:143`). So the rate limiter was not mistuned on the failed-login path — it was structurally unreachable.

**Measured before, on the bench device: 400 consecutive failed logins → 400× 401, zero 429.**

## The fix

Two parts:

1. **Reorder** so `rateLimit` precedes `digestAuth`. Chain is now `customMiddleware → authLockout → rateLimit → digestAuth → defaultPasswordGuard` — cheap throttles first, then authentication, then authorization.
2. **A per-source lockout** (`source/lib/auth_lockout/`, pure + unit-tested): 5 consecutive credentialed failures lock a source for an escalating, self-expiring, bounded window (30→60→…→900s cap), answered `429` with `Retry-After` before the digest MD5 runs. Any success clears it.

**The decision the whole feature turns on:** a 401 counts as a failed login only if the request carried an `Authorization` header. Every digest handshake opens with a credential-less 401 — a browser does this on every fresh session — so counting those would lock out the legitimate owner within a few page loads. An attacker must supply credentials to test a password, so nothing defensive is given up.

## Verified on hardware

- **The bug is gone**: 5 failed logins → 429 with `Retry-After: 30`.
- **The false-positive case holds** (this matters most): 25 correct logins in fresh sessions never lock out.
- Lockout expires on its own; correct password works after; second lockout without an intervening success is 60s (doubled); health probe unaffected; no crash or restart.
- 431/431 native tests, clean build, cppcheck clean.

## Adversarial testing — three attacker agents

Each was briefed to *break* the defense, not confirm it, and run read-only against the live device.

**A (bypass): could not defeat the single-IP throttle.** Header/Host spoofing (`X-Forwarded-For` etc. collapse onto the one real socket IP), credential-less interleave, cross-path accumulation, health-reset — all correctly handled. The only bypass is 8-slot table eviction, which needs ≥8 *genuine* source IPs and is documented (design D5).

**A also found one real gap, now fixed** (d5b4860): the upload routes (OTA, restore) authenticate inside their own handler — they must, because a middleware auth check arrives after `Update.begin()` has erased the partition — and that ran *ahead of* the lockout middleware. So guessing could move to the upload routes unthrottled, and a correct guess would reach `Update.begin()` before the masking 429. `_rejectUploadIfNotPermitted` now consults the lockout before authenticating. Re-verified: locked → OTA upload and restore both return 429 without the password check running.

**B (DoS): could not lock out the owner** in the local-first deployment. Keyed on the unspoofable socket IP, escalation capped at 15 min, state RAM-only, health exempt and never degraded. Caveat, now documented: behind a reverse proxy / CGNAT that collapses many clients to one source IP, they share a lockout entry — do not deploy behind shared egress.

**C (disclosure): the headline 401-vs-403 default-password oracle is refuted** — the `digestAuth`-before-guard ordering means 403 only ever reaches an already-authenticated caller. No username oracle, no usable timing oracle. `Retry-After` magnitude leaks a source's own escalation tier (per-source, minor). Separately surfaced a pre-existing digest-replay weakness (nonce issued but never validated), filed as #222 — out of scope here.

All three agents ran concurrently against the device; it survived with crashCount 0 and health answering throughout.

## Scope

Out of scope, stated in the design: plaintext password storage, digest-over-HTTP (#222), and a distributed multi-IP attacker (bounded only by the generic rate limiter, not the per-IP table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CybqtGNjBQ5btVJaDmT75B