### PR TITLE
Added environments for ESP32-N16R8 variant. Built and uploaded the

### DIFF
--- a/source/platformio.ini
+++ b/source/platformio.ini
@@ -223,6 +223,69 @@ board_build.embed_txtfiles = ${common.board_build.embed_txtfiles}
 
 
 ; ============================================================================
+; Development Environment - ESP32-S3-N16R8 (Octal PSRAM)
+; Use for: Local development/debugging on N16R8 boards (8MB octal PSRAM)
+; instead of the project's default N16R2 (2MB quad PSRAM). Only the PSRAM
+; interface mode differs from esp32s3-dev - everything else is identical.
+; NOT part of default_envs on purpose: this is a personal/local override,
+; not something `pio run` should build by default for other contributors.
+; ============================================================================
+[env:esp32s3-dev-n16r8]
+; Platform Configuration
+platform = ${common.platform}
+board = ${common.board}
+framework = ${common.framework}
+
+; Static Analysis Tools
+check_tool = cppcheck, clangtidy
+
+; Build Configuration
+build_flags =
+	${common.common_suppress_lib_warnings}
+	${common.common_build_flags}
+
+	; === Compilation & Debug Options ===
+	-g3
+	-O0
+	-fstack-usage
+
+	; === Application Defines ===
+	-DENV_DEV
+
+	; === ESP32 Debug Configuration ===
+	-DCORE_DEBUG_LEVEL=4
+	-DDEBUG_ESP_PORT=Serial
+	-DDEBUG_ESP_CORE
+
+; Source-only compiler warnings (excludes libraries)
+build_src_flags =
+	${common.common_build_src_flags}
+
+; Hardware Configuration
+; NOTE: Overrides memory_type/psram_type for octal PSRAM (N16R8).
+; Flash mode, flash size, and partition table are unchanged from N16R2 -
+; flash is identical (16MB) between the two variants, only PSRAM differs.
+board_build.arduino.memory_type = qio_opi      ; Octal PSRAM (N16R8) - overrides common's qio_qspi
+board_build.psram_type = opi                   ; Octal PSRAM (N16R8) - overrides common's qio
+board_build.flash_mode = ${common.board_build.flash_mode}
+board_upload.flash_size = ${common.board_upload.flash_size}
+board_upload.maximum_size = ${common.board_upload.maximum_size}
+board_build.partitions = ${common.board_build.partitions}
+
+; Development Tools
+monitor_speed = ${common.monitor_speed}
+monitor_filters = ${common.monitor_filters}
+
+; Library Configuration
+lib_compat_mode = ${common.lib_compat_mode}
+lib_ldf_mode = ${common.lib_ldf_mode}
+lib_deps = ${common.lib_deps}
+
+; Embedded Files
+board_build.embed_txtfiles = ${common.board_build.embed_txtfiles}
+
+
+; ============================================================================
 ; Production Environment (ESP32-S3)
 ; Use for: Production deployment, releases
 ; Features: Size optimization, minimal logging, assertions disabled
@@ -261,6 +324,69 @@ build_src_flags =
 ; Hardware Configuration
 board_build.arduino.memory_type = ${common.board_build.arduino.memory_type}
 board_build.psram_type = ${common.board_build.psram_type}
+board_build.flash_mode = ${common.board_build.flash_mode}
+board_upload.flash_size = ${common.board_upload.flash_size}
+board_upload.maximum_size = ${common.board_upload.maximum_size}
+board_build.partitions = ${common.board_build.partitions}
+
+; Development Tools
+monitor_speed = ${common.monitor_speed}
+monitor_filters = ${common.monitor_filters}
+
+; Library Configuration
+lib_compat_mode = ${common.lib_compat_mode}
+lib_ldf_mode = ${common.lib_ldf_mode}
+lib_deps = ${common.lib_deps}
+
+; Embedded Files
+board_build.embed_txtfiles = ${common.board_build.embed_txtfiles}
+
+
+; ============================================================================
+; Production Environment - ESP32-S3-N16R8 (Octal PSRAM)
+; Use for: Production deployment on N16R8 boards (8MB octal PSRAM) instead
+; of the project's default N16R2 (2MB quad PSRAM). Only the PSRAM interface
+; mode differs from esp32s3-prod - everything else is identical.
+; NOT part of default_envs on purpose: this is a personal/local override,
+; not something `pio run` should build by default for other contributors.
+; ============================================================================
+[env:esp32s3-prod-n16r8]
+; Platform Configuration
+platform = ${common.platform}
+board = ${common.board}
+framework = ${common.framework}
+
+; Static Analysis Tools
+check_tool = cppcheck, clangtidy
+
+; Build Configuration
+build_flags =
+	${common.common_suppress_lib_warnings}
+	${common.common_build_flags}
+
+	; === Compilation & Optimization Options ===
+	-Os
+	-DNDEBUG
+
+	; === Application Defines ===
+	-DENV_PROD
+
+	; === Logging ===
+	-DADVANCED_LOGGER_DISABLE_VERBOSE
+
+	; === ESP32 Debug Configuration ===
+	-DCORE_DEBUG_LEVEL=2
+
+; Source-only compiler warnings (excludes libraries)
+build_src_flags =
+	${common.common_build_src_flags}
+
+; Hardware Configuration
+; NOTE: Overrides memory_type/psram_type for octal PSRAM (N16R8).
+; Flash mode, flash size, and partition table are unchanged from N16R2 -
+; flash is identical (16MB) between the two variants, only PSRAM differs.
+board_build.arduino.memory_type = qio_opi      ; Octal PSRAM (N16R8) - overrides common's qio_qspi
+board_build.psram_type = opi                   ; Octal PSRAM (N16R8) - overrides common's qio
 board_build.flash_mode = ${common.board_build.flash_mode}
 board_upload.flash_size = ${common.board_upload.flash_size}
 board_upload.maximum_size = ${common.board_upload.maximum_size}


### PR DESCRIPTION
Changed the PlateformIO configuration for the code to compile and work on an ESP32 S3 N16R8 variant.

<img width="953" height="823" alt="image" src="https://github.com/user-attachments/assets/46b25c4c-a0c3-41e8-9297-67f30f54cc31" />

This is a "testing" board made up with spares and parts recovered from other circuits, sizes of SMD components are not correct (used 805 resistors and capacitors) but were welded and are "operational"