### PR TITLE
docs(manual): channel 0 clarity, new provisioning flow, CT placement diagrams

### DIFF
--- a/manual/01-installation.md
+++ b/manual/01-installation.md
@@ -93,6 +93,15 @@ The device comes with **two wires already connected** to the internal power term
 
 The CT on **Channel 0** is the most accurate channel and should be used to measure the total energy entering your home.
 
+> **ⓘ NOTE: Why Channel 0 updates faster than the rest**  
+> Channel 0 is sampled about every 200 ms, always. Channels 1-15 share a single multiplexed input, so each one only gets a slice of the sampling time; the device dynamically prioritises active/high-power channels and can leave a quiet, constant-low-power channel sampled as infrequently as every 15 s. This is normal, not a fault: if a branch channel feels slow to update, especially once you have many channels active, it's the multiplexer allocating time to where it matters more, not something wrong with the install.
+
+> **✅ TIP: Spend Channel 0's extra speed where it matters**  
+> If you're choosing between the main grid line and something else (e.g., a solar inverter) for your one non-multiplexed channel, prefer the grid line. It's the channel whose fast, accurate readings matter most (import/export, billing, dynamic pricing), while a PV inverter's output changes slowly enough that a multiplexed branch channel keeps up fine. Any load can still go on Channel 0 electrically, this is purely about getting the most value out of its higher sample rate.
+
+> **ⓘ NOTE: Channel 0 doesn't need a CT clamped on it, but it can't be switched off**  
+> Clamping a CT here is optional: if you'd rather not track your whole-home total, you can leave Channel 0 unclamped and it will simply read ~0 W. What you can't do is disable it in the software; unlike every other channel, its **Active** toggle in [§4.5](02-setup.md#45-configure-each-channel) can't be unticked. This is because Channel 0 isn't routed through the channel multiplexer like Channels 1-15: it's wired directly to the ADE7953's one voltage input, which doubles as the voltage reference every other channel's power calculation depends on, so it's always read regardless of whether anything is clamped to it.
+
 1. Take **one** of the CT clamps from the kit (any of them, they're all identical).
 2. Identify the **main line conductor** downstream of the main breaker (typically the brown/black wire coming from the kWh meter into the panel).
 3. Open the CT clamp.
@@ -105,6 +114,9 @@ The CT on **Channel 0** is the most accurate channel and should be used to measu
 
 > **⚠ Three-phase main supply**  
 > If your main supply is three-phase, the CT on Channel 0 goes on **one of the three phases**, and you'll need additional CTs on the other two phases (on free branch channels). See **[Appendix B](appendices.md#appendix-b-three-phase-configuration)**.
+
+> **⚠ WARNING: Channel 0 must be on the same phase as the device's own power feed**  
+> The device measures voltage only once, from its own **L/N power connection** ([§3.2](#32-connect-the-power-supply-l-and-n)), and uses that single reading as the voltage reference for every channel's power calculation. On a single-phase home there is only one phase, so this is automatic. On a **three-phase supply**, the phase that powers the device (its brown L wire) and the phase that Channel 0's CT is clamped on **must be the same physical conductor**. If Channel 0 ends up on a different phase than the device's own power feed, its power and power factor readings will be wrong, since the voltage and current being multiplied together come from two conductors that are ~120° apart. See **[Appendix B.1](appendices.md#b1-three-phase-main-supply)**.
 
 ### 3.4 Install the CTs on the branch channels (1 to 15): Critical step ⚠
 
@@ -120,6 +132,9 @@ Inside an electrical panel, breakers can be fed in **daisy-chain** on the **inpu
 The wire on the **OUTPUT (bottom) side** of the breaker carries **only** the current of the loads connected to that specific breaker. **This is where the CT must go.**
 
 ![CT Placement](assets/ct_placement_breaker.svg)
+
+> **✅ TIP: Turning this into a feature**  
+> Clamping a shared wire is only a mistake when it's accidental. If you deliberately want one CT to read several breakers combined, for example when you have more circuits than free channels, see **[Appendix B.4](appendices.md#b4-advanced-ct-placement-subsets-and-summed-breakers)** for the subset and summed-breaker patterns.
 
 #### 3.4.2 The rule
 
@@ -160,13 +175,16 @@ Before turning the main breaker back ON:
 
 | Check | OK? |
 | --- | --- |
-| All CT jacks are fully inserted in the device (1 on Channel 0, the others on Channels 1-15) | ☐ |
+| All CT jacks are **pushed in firmly until they click**, not just resting in the socket (1 on Channel 0, the others on Channels 1-15) | ☐ |
 | Brown (L) and Blue (N) wires from the device are tightly connected, no copper visible | ☐ |
 | Channel 0 CT is on the main Line conductor | ☐ |
 | Each branch CT is on the OUTPUT side of its breaker (not on the comb bar) | ☐ |
 | No tools or screws left inside the panel | ☐ |
 | Channel map ([Appendix A](appendices.md#appendix-a-channel-map)) filled in (where known) and photographed | ☐ |
 | Panel cover ready to be re-installed | ☐ |
+
+> **⚠ WARNING: The jack sockets sit close together; give each one a firm, deliberate push**  
+> The 3.5 mm jacks are packed tightly to fit up to 16 of them on the device, and a jack that only seated partway can work itself loose from vibration or from the panel cover pressing against the cables. A loose jack shows up later as a channel that suddenly reads zero, spikes erratically, or (in rare cases) trips the device's own error-recovery reset. If you ever see that on a channel that was previously working fine, check this connection before assuming a CT or hardware fault.
 
 ### 3.6 First power-on
 
@@ -181,9 +199,12 @@ After boot, three outcomes are possible:
 
 | LED behaviour | Meaning | Next step |
 | --- | --- | --- |
-| 🔵 Blue, fast blink | No Wi-Fi configured yet; captive portal active | Go to **[§4.1](02-setup.md#41-connect-to-the-devices-wi-fi-captive-portal)** |
+| 🔵 Blue, fast blink | No Wi-Fi configured yet; the device's own setup network is up | Go to **[§4.1](02-setup.md#41-connect-to-the-devices-wi-fi-setup-network)** |
 | 🔵 Blue, slow pulse | Known Wi-Fi found but not yet connected (e.g. router still booting) | Wait up to 60 s; LED should settle to solid green |
-| 🟢 Solid green | Connected to home Wi-Fi, monitoring | Go to **[§4.3](02-setup.md#43-access-the-web-interface)** (skip [§4.1](02-setup.md#41-connect-to-the-devices-wi-fi-captive-portal) and [§4.2](02-setup.md#42-configure-your-home-wi-fi)) |
+| 🟢 Solid green | Connected to home Wi-Fi, monitoring | Go to **[§4.3](02-setup.md#43-access-the-web-interface)** (skip [§4.1](02-setup.md#41-connect-to-the-devices-wi-fi-setup-network) and [§4.2](02-setup.md#42-configure-your-home-wi-fi)) |
+
+> **ⓘ NOTE: A device that later loses its Wi-Fi behaves the same way**  
+> If an already-configured device can't reach your router (router replaced, password changed, moved out of range), after several failed attempts it raises its own setup network again, same blue fast blink. The difference: since this device already holds your data and settings, its setup pages require your admin login this time, not the open access a brand-new device gives. Log in and repeat [§4.1](02-setup.md#41-connect-to-the-devices-wi-fi-setup-network)-[§4.2](02-setup.md#42-configure-your-home-wi-fi) to give it new Wi-Fi credentials.
 
 > **⚠ WARNING**  
 > If you smell anything burning, hear buzzing, or see smoke: **switch the main breaker OFF immediately** and contact support before doing anything else.

--- a/manual/02-setup.md
+++ b/manual/02-setup.md
@@ -4,11 +4,16 @@ From now on, the work can be done by the end user. The electrical panel can stay
 
 ---
 
+> **⚠ WARNING: Devices on firmware older than 2.3.0 use the older WiFiManager portal**  
+> Firmware **2.3.0** replaced the previous WiFiManager-based captive portal with the flow described in this chapter. The core idea is the same either way: connect to the device's own Wi-Fi network, pick your home network from a list, submit, so this chapter still gets you there. Expect it to look less polished (no Welcome/Device screens from [§4.1](#41-connect-to-the-devices-wi-fi-setup-network), and the setup network is AP-only during configuration rather than staying up alongside your home Wi-Fi). The real gap is enforcement: the mandatory password gate and login lockout in [§4.4](#44-change-the-default-password) were both added in 2.3.0. On older firmware, the default password (`energyme`) is only a dismissible dashboard alert; nothing stops anyone on your network from using it as long as it's unchanged. Update to the latest firmware first if you can ([§4.8](#48-firmware-updates)); if you set the device up on an older version, go to **Configuration** and change the default password manually right after connecting.
+
+---
+
 ## 4. Software configuration
 
-### 4.1 Connect to the device's Wi-Fi (captive portal)
+### 4.1 Connect to the device's Wi-Fi (setup network)
 
-On first power-on, or after a Wi-Fi reset, the device broadcasts its own Wi-Fi network so you can configure it.
+On first power-on, or after a Wi-Fi reset, the device broadcasts its own Wi-Fi network so you can configure it. This setup network and your home Wi-Fi both run at the same time on the device (it does not switch between them), so the device stays reachable on its own network throughout setup.
 
 1. On your phone or laptop, open Wi-Fi settings.
 2. Look for a network named **`EnergyMe-<DEVICE_ID>`**, where `<DEVICE_ID>` is the 12-character code printed on the label inside the device case.
@@ -17,20 +22,28 @@ On first power-on, or after a Wi-Fi reset, the device broadcasts its own Wi-Fi n
    - **Community devices** (self-built): the `DEVICE_ID` itself (same 12-character code as the network name).
 4. A configuration page opens automatically. If it does not, open a browser and navigate to **`http://172.31.42.1`**.
 
+> **ⓘ NOTE: The address is usually `172.31.42.1`, but not guaranteed**  
+> The device picks this address by default, but automatically falls back to a different one if it would clash with your home network's own address range (rare, but possible if your router happens to use `172.31.x.x`). If `172.31.42.1` doesn't load, let the page open automatically instead of typing an address, or check **Device** on the welcome screen (see below) for the exact "Setup network" address once you're connected to it.
+
 > **ⓘ NOTE: If the network doesn't appear**  
-> Wait 60 seconds after power-on. If it still isn't visible, hold the button for 10-15 seconds until the LED turns orange (Wi-Fi reset), then release. The device will restart and open the portal again. See **[Appendix D](appendices.md#appendix-d-user-button-reference)** for the full button reference.
+> Wait 60 seconds after power-on. If it still isn't visible, hold the button for 10-15 seconds until the LED turns orange (Wi-Fi reset), then release. The device will restart and open its setup network again. See **[Appendix D](appendices.md#appendix-d-user-button-reference)** for the full button reference.
+
+The page opens on a **Welcome** screen with two options: **Connect it to WiFi** (goes to §4.2 below) and **See the device** (shows the device model, ID, firmware version, uptime, and current network status, useful for confirming you're talking to the right device before you touch anything).
 
 ### 4.2 Configure your home Wi-Fi
 
-On the setup page:
+From **Connect it to WiFi**, the device scans for nearby networks and lists them (signal strength and lock icon shown for each):
 
-1. Select your home Wi-Fi network from the list, or type its name in if it is hidden.
-2. Enter your Wi-Fi password.
+1. Select your home Wi-Fi network from the list, or type its name in if it is hidden or didn't show up in the scan.
+2. Enter your Wi-Fi password (leave it blank for an open network).
 3. Tap **Connect**.
 4. The device joins your home network without restarting. The page reports the address to use afterwards, and the LED stops blinking blue and settles to **solid green** once connected.
 
 > **ⓘ NOTE: The setup network drops for a few seconds**  
-> To join your Wi-Fi, the meter has to move its own network to the same radio channel as your router, so `EnergyMe-<DEVICE_ID>` disappears briefly right after you tap **Connect**. This is expected. Stay on the setup page; most phones rejoin on their own, and the page keeps waiting for the result. If it reports a failure, it shows the reason your router gave, such as a wrong password.
+> To join your Wi-Fi, the meter has to move its own network to the same radio channel as your router (the chip has one radio and can't run its own network and your router's network on two different channels at once), so `EnergyMe-<DEVICE_ID>` disappears briefly right after you tap **Connect**. This is expected. Stay on the setup page; most phones rejoin on their own, and the page keeps waiting for the result. If it reports a failure, it shows the reason your router gave, such as a wrong password.
+
+> **ⓘ NOTE: The setup network stays up for a few minutes after connecting**  
+> Once the device joins your home Wi-Fi, its own `EnergyMe-<DEVICE_ID>` network stays up for about **5 more minutes** before it shuts down on its own. This is deliberate: it gives you time to read the new address off the confirmation screen (or reconnect to the setup network if something looks wrong) without immediately losing access to the device.
 
 > **✅ TIP: 2.4 GHz only**  
 > *EnergyMe Home* uses **2.4 GHz Wi-Fi**. If your router shows separate 2.4 GHz and 5 GHz networks, pick the 2.4 GHz one. If your router uses a single combined name ("band steering"), it will usually work fine, but if you have connection problems, ask your router's admin page to expose the 2.4 GHz band as a separate SSID.
@@ -53,17 +66,18 @@ On the setup page:
 
 ### 4.4 Change the default password
 
-> **⚠ Do this before anything else.** The device ships with a known default password. Until you change it, anyone on your home network can access the interface.
+> **⚠ Mandatory, not just a suggestion.** The device ships with a known default password (`energyme`). Until you change it, the device refuses **everything else**: the API, the web UI, integrations, all of it. This isn't a dashboard reminder you can dismiss, it's enforced by the device itself.
 
-1. In the top menu, go to **Configuration**.
-2. Scroll to **Change Password**.
-3. Enter the current password (`energyme`), then your new password twice. The new password must be at least 8 characters.
-4. Click **Save**.
-
-The device will remind you with a pop-up on the dashboard every time you open it, until the password has been changed.
+1. After logging in during [§4.3](#43-access-the-web-interface), the device shows a **Choose a password** page automatically; you can't reach anything else until this is done.
+2. Enter your new password twice (minimum 8 characters, and it can't be `energyme` again).
+3. Click **Set password**.
+4. Your browser will ask you to sign in again with the new password. The username stays `admin`.
 
 > **ⓘ NOTE: Forgot your password?**  
-> Hold the button for 5-10 seconds until the LED turns yellow (password reset), then release. The password is reset to `energyme`. Log back in and set a new one straight away. See **[Appendix D](appendices.md#appendix-d-user-button-reference)** for the full button reference.
+> Hold the button for 5-10 seconds until the LED turns yellow (password reset), then release. The password is reset to `energyme`, which immediately re-opens the mandatory password-change gate above. Log back in and set a new one straight away. See **[Appendix D](appendices.md#appendix-d-user-button-reference)** for the full button reference.
+
+> **ⓘ NOTE: Repeated wrong passwords temporarily lock you out**  
+> After 5 consecutive failed login attempts from the same address, the device refuses further login attempts from it for a short cooldown (starting around 30 seconds, doubling if it happens again). This is a brute-force protection, not a bug: if you mistype your password a few times in a row, wait a moment and try again. It resets as soon as you log in successfully.
 
 ### 4.5 Configure each channel
 
@@ -76,9 +90,12 @@ Each channel has the following fields:
 | **Label** | A free-text name (e.g., "Grid", "Kitchen", "EV charger"). It's the name that will appear on the dashboard |
 | **Phase** | The AC phase the CT is clamped on. Use `1` for European single-phase and for standard 120 V North American loads. Use `2` or `3` for the other two phases of a three-phase system (see [Appendix B](appendices.md#appendix-b-three-phase-configuration)). Use **`240V (Split Phase)`** for a North American 240 V circuit that spans both legs L1-L2 (see [Appendix B.3](appendices.md#b3-north-american-120240-v-split-phase)); the firmware automatically applies a 2× voltage multiplier because the voltage reference is line-to-neutral (≈120 V) while the circuit is line-to-line (240 V). |
 | **Reverse** | Flips the sign of a channel. Normally you won't need this: EnergyMe auto-detects reversed CTs on first activation and corrects them automatically. Manual toggle is available if needed (e.g., a channel role changes). Flips the sign instantly, no need to reopen the panel |
-| **Active** | Enables the channel. Untick for unused channels |
+| **Active** | Enables the channel. Untick for unused channels. **Channel 0 is the exception:** it's always active and this can't be unticked, even if you never clamped a CT on it (see [§3.3](01-installation.md#33-install-the-ct-on-channel-0-main-line)) |
 | **Grouping** | Channels sharing the same group label are combined into one card on the home dashboard. Use this for multi-phase loads: set all three phase CTs of your oven to "Oven" and the dashboard will show total power for the whole appliance |
 | **Role** | What the channel represents (see table below) |
+
+> **⚠ WARNING: Every channel in a group must have the same Role**  
+> The device refuses to save a channel whose Role doesn't match the other channels already sharing its Grouping label (e.g., one channel set to `Load` and another to `Grid (+ import, - export)` under the same group). The save silently fails with no visible reason in the UI; only the device's **Logs** page shows the actual cause ("Group '...' role mismatch"). This most often happens by accident: the default Grouping values are `Group 0`, `Group 1`, etc. per channel, and changing a channel's Role without first giving it its own group can collide with a leftover default on another channel. If a channel's settings won't save, check that every channel sharing its Grouping label also shares its Role.
 
 #### Role values
 
@@ -91,6 +108,9 @@ Each channel has the following fields:
 | `Inverter (PV + Battery DC-coupled)` | A hybrid inverter where PV and battery share a single AC output |
 
 #### Configuration for a typical single-phase home
+
+> **ⓘ NOTE: Channel 0's Role doesn't have to be Grid**  
+> The table below shows the common case: most single-phase homes want their most accurate, highest-sample-rate channel ([§3.3](01-installation.md#33-install-the-ct-on-channel-0-main-line)) on the main line. But Channel 0 is a normal channel for every purpose except being the voltage reference; give it whatever Role actually matches what's clamped to it (`Load`, `PV / Solar`, etc.) if you'd rather dedicate it to something else, for example if you already get whole-home totals from a utility meter integration and want Channel 0 on a specific branch instead.
 
 **Channel 0 (main line):**
 
@@ -129,6 +149,9 @@ You need to visit the **Calibration** page if:
 - You ordered higher-rated CTs (75 A, 150 A) for high-current circuits; **or**
 - You are using a community build with self-sourced CTs.
 
+> **ⓘ NOTE: Cheap generic clamps vary more from unit to unit**  
+> Common SCT-013-type clamps work fine (any CT with a voltage output and 3.5 mm jack does), but their calibration can differ noticeably between individual units, more so than higher-quality CTs. This matters less for one or two channels, but on a full 16-channel build it means each clamp may need its own small correction. If your readings are consistently off on some channels but not others with identical CTs, per-channel **Scaling Factor** below is exactly the tool for that: compare each channel against a known load and trim the offset per channel rather than assuming one clamp's calibration applies to all of them.
+
 #### How to calibrate
 
 1. In the top menu, go to **Calibration**.
@@ -160,6 +183,9 @@ Repeat for every channel that uses a non-standard CT.
 > **ⓘ NOTE: The Reverse checkbox is your friend**  
 > Most reversed CTs are auto-corrected by EnergyMe on first activation. But if a channel ever reads with the wrong sign (e.g., shows -8 W when you expect +8 W), you don't need to reopen the panel. Just tick **Reverse** for that channel in [§4.5](#45-configure-each-channel); the sign flips instantly.
 
+> **ⓘ NOTE: Three-phase installs — a low power factor can mean a wrong Phase setting**  
+> See the power-factor check in **[Appendix B.1](appendices.md#b1-three-phase-main-supply)** if a channel's numbers look plausible but off.
+
 > **✅ TIP: The "kettle test" (instant verification)**  
 > Turn on a single high-power load on a known circuit (e.g., a kettle in the kitchen). You should see the instantaneous power increase **on that one branch channel** and on Channel 0 by approximately the same amount.
 >
@@ -169,15 +195,23 @@ Repeat for every channel that uses a non-standard CT.
 
 ### 4.8 Firmware updates
 
-The device checks for available firmware updates automatically. When a new version is available, a **bell icon (🔔)** appears next to the Firmware Update button in the top navigation bar.
+> **✅ Always keep the device on the latest firmware.** Updates aren't only new features: past releases have shipped fixes for measurement accuracy, security (the mandatory password gate and login lockout in [§4.4](#44-change-the-default-password) were both added this way), and stability. Check **[GitHub Releases](https://github.com/jibrilsharafi/EnergyMe-Home/releases/latest)** for what changed in each version.
 
-To update:
+> **✅ TIP: Let the device update itself**  
+> On an EnergyMe device (not a community/self-built one), enable **Cloud Services** in **Configuration**. Once enabled, new firmware is fetched and installed automatically in the background, no bell icon to watch for and no manual step on the Update page.
+
+> **⚠ WARNING: An EnergyMe device with Cloud Services off gets no update notification at all**  
+> Updates on these devices are assumed to be handled through the cloud, so the bell icon below only ever appears on **community (self-built)** devices. If you keep Cloud Services disabled, check [GitHub Releases](https://github.com/jibrilsharafi/EnergyMe-Home/releases/latest) yourself now and then, since nothing on the device will tell you a new version exists.
+
+On community devices, the device checks for available firmware updates on its own whenever it has internet access. When a new version is available, a **bell icon (🔔)** appears next to the Firmware Update button in the top navigation bar.
+
+To update manually:
 
 1. Go to **Update** in the top menu.
 2. Follow the on-screen instructions.
 
 > **ⓘ NOTE: Community devices**  
-> Automatic update notifications require cloud services to be enabled. For community (self-built) devices, updates are always manual: download the latest firmware binary from [GitHub Releases](https://github.com/jibrilsharafi/EnergyMe-Home/releases) and upload it via the Update page.
+> Community (self-built) devices have no factory-provisioned cloud credentials, so **Cloud Services** can't be enabled and updates are always manual: download the latest firmware binary from [GitHub Releases](https://github.com/jibrilsharafi/EnergyMe-Home/releases/latest) and upload it via the Update page. Consider watching the repository (GitHub's "Watch" button, Releases only) so you hear about new versions without having to check manually.
 
 ### 4.9 Integrations
 

--- a/manual/03-troubleshooting.md
+++ b/manual/03-troubleshooting.md
@@ -5,8 +5,8 @@
 A full symptom-driven troubleshooting guide is being prepared. Anticipated sections:
 
 - **LED behaviour** — what each colour and pattern means (cross-reference: [Appendix C](appendices.md#appendix-c-led-status-reference))
-- **Wi-Fi & connectivity** — captive portal doesn't appear, `energyme.local` unreachable, device drops off the network
-- **Login & access** — forgot password, default credentials not accepted
+- **Wi-Fi & connectivity** — setup network doesn't appear, `energyme.local` unreachable, device drops off the network
+- **Login & access** — forgot password, default credentials not accepted, temporarily locked out after repeated wrong passwords
 - **Readings** — negative power values, no readings on a channel, branch sum greater than main, all zeros
 - **CT placement** — symptoms suggesting a misclamped or inverted CT (cross-reference: the kettle test in [§4.7](02-setup.md#47-verification))
 - **Reset procedures** — when and how to use restart, password reset, Wi-Fi reset, factory reset (cross-reference: [Appendix D](appendices.md#appendix-d-user-button-reference))

--- a/manual/appendices.md
+++ b/manual/appendices.md
@@ -27,10 +27,15 @@ Fill in during installation (where known), take a photo before closing the panel
 1. Take **3 CTs** from the kit (or expansion kit).
 2. Clamp each CT around **one of the three phase conductors** (L1, L2, L3), never around the neutral.
 3. Plug them into the device:
-   - **Phase L1** → Channel `0` (the main reference channel)
-   - **Phase L2** → any free branch channel (e.g., Channel `1`)
-   - **Phase L3** → any free branch channel (e.g., Channel `2`)
+   - **The same phase that powers the device** (the panel conductor the device's own brown L wire is connected to, [§3.2](01-installation.md#32-connect-the-power-supply-l-and-n)) → Channel `0`. Call this "L1" for labelling purposes; it does not need to be your panel's actual L1 busbar, just whichever phase the device itself draws power from.
+   - The second phase → any free branch channel (e.g., Channel `1`), labelled "L2"
+   - The third phase → any free branch channel (e.g., Channel `2`), labelled "L3"
 4. **Write down which physical phase is on which channel;** you'll need it for the software step.
+
+> **✅ TIP: Identifying which conductor is which phase**  
+> If the panel isn't labelled, a multimeter tells you in seconds: measure the voltage **between two candidate phase conductors**. The same phase reads close to 0 V; two different phases read the full phase-to-phase voltage (roughly 400 V on a 230 V three-phase system; the exact figure depends on your grid). Repeat across all conductors you're considering to map out which is which before you start clamping.
+
+> **⚠ Channel 0 is not just "any" phase.** The device has a single voltage input, wired to its own L/N power terminal. Every channel's power is computed against that one voltage reading, so Channel 0's CT **must** be on the same conductor that feeds the device, not an arbitrary phase. Getting this wrong produces plausible-looking but incorrect power and power factor readings on every channel, since the reference voltage and the measured current would be ~120° out of phase with each other. See the warning in [§3.3](01-installation.md#33-install-the-ct-on-channel-0-main-line).
 
 #### Software
 
@@ -45,6 +50,9 @@ In **Channels** ([§4.5](02-setup.md#45-configure-each-channel)), set up the thr
 The three channels share the same **Grouping** value (`Grid`), so the dashboard will show a single "Grid" card with the **total three-phase power** of the main supply.
 
 > **ⓘ Override the default group.** The Grouping field is pre-filled with `Group 0`, `Group 1`, `Group 2`, etc., by default. For three-phase grouping you must **replace** the default value with the shared group name (e.g., `Grid`) on each of the three channels.
+
+> **✅ TIP: Use power factor to catch a wrong phase assignment**  
+> A channel with the wrong `Phase` setting still shows plausible-looking numbers, just wrong ones, so it's easy to miss. The fast check: put a purely resistive load on the circuit (a kettle, a resistive heater) and look at its power factor. A resistive load should read **close to 100% PF**. If it instead reads **close to 50% PF**, that channel is very likely on the wrong phase (each phase is 120° apart, and being 120° off collapses a 100% PF load to almost exactly 50%). Try the other phase settings and watch the power factor climb back towards 100%.
 
 ### B.2 Three-phase branch load (e.g., EV charger, heat pump, oven)
 
@@ -119,6 +127,45 @@ In **Channels** ([§4.5](02-setup.md#45-configure-each-channel)), set:
 
 > **⚠ Do not use `240V (Split Phase)` outside North American split-phase systems.** It is a numerical shortcut for the specific 120/240 V split-phase topology and would produce wrong readings on a European 230 V single-phase or any three-phase system.
 
+> **⚠ WARNING: A single CT with `240V (Split Phase)` only sees that one leg's current, doubled**  
+> This setting assumes the whole breaker's load runs line-to-line (240 V, both legs equally). If the same breaker also feeds 120 V line-to-neutral loads on the leg you didn't clamp, such as a sub-panel with a mix of 240 V and 120 V circuits, or an appliance (e.g. an HVAC unit) with a 240 V compressor and a 120 V control board, those loads are on the other leg and this CT never sees them. If you know or suspect a breaker feeds mixed 240 V/120 V loads, don't use a single clamp with `240V (Split Phase)`; instead put a separate CT on **each** leg, set both to Phase `1`, and put them in the same Grouping. Since both legs are referenced to the same Neutral, their sum is the true total for that breaker regardless of how the individual loads inside it are split between legs. This is the same pattern already used for the whole-home main in the table above ("Main supply, both legs separately"), just applied to one branch instead of the panel's main feed.
+
+### B.4 Advanced CT placement: subsets and summed breakers
+
+A CT clamp reads whatever current flows through the conductor(s) inside its jaw at that point in the wiring; it has no notion of "one breaker." Beyond the standard one-CT-per-breaker installation, two placement patterns let you cover more circuits than you have free channels for.
+
+> **ⓘ NOTE: Already covered elsewhere, not repeated here**
+>
+> - Grid CT on the main line: [§3.3](01-installation.md#33-install-the-ct-on-channel-0-main-line).
+> - CT on a single breaker: [§3.4](01-installation.md#34-install-the-cts-on-the-branch-channels-1-to-15-critical-step-).
+> - CT reading zero (L+N clamped together): [§3.3 step 4](01-installation.md#33-install-the-ct-on-channel-0-main-line) and the mistakes table in [§3.4.3](01-installation.md#343-step-by-step-for-each-branch-ct).
+
+#### CT on a subset of the panel (sub-feed / shared tap)
+
+If a group of breakers is fed from a common upstream tap, a wire that branches off the main bus into a local comb or sub-bus before reaching those breakers individually, a single CT clamped on that shared tap wire reads the sum of everything fed from it. This is the same physical situation described as a mistake in [§3.4.1](01-installation.md#341-the-shared-input-wire-problem) ("the wire on the input side carries the sum of the breakers downstream of it"), except here it's intentional: the tap is deliberately chosen upstream of a *specific* group of breakers, not upstream of the whole panel.
+
+![CT on a subset of the panel](assets/ct_placement_subset.svg)
+
+Use this when you have more breakers than free channels: group low-priority or related breakers (a sub-panel feed, a lighting comb, a group of outlets) behind one CT, and keep individual channels for the circuits you actually want to see separately.
+
+> **⚠ WARNING**  
+> Once combined at the tap, the device cannot separate the individual breakers again. Everything downstream of the CT is measured, named, and displayed as a single channel.
+
+#### CT measuring the sum of two or more breakers
+
+Instead of one CT per breaker, you can bundle two (or more) breaker **output** wires together and clamp a single CT around the bundle. The clamp reads the vector sum of the currents through it, regardless of how many separate conductors are inside its jaw.
+
+![CT clamped around two breaker outputs](assets/ct_placement_sum_breakers.svg)
+
+> **⚠ WARNING: Three conditions must hold**
+>
+> - **Physical fit:** all bundled conductors must fit through the clamp's jaw opening together. The standard 30 A clamp has a small jaw; check it against your wire gauge and count before planning this. It may not be physically possible for thicker cables or more than two or three wires.
+> - **Same direction:** every bundled conductor must run through the clamp with the same current-direction convention (all "load-bound" the same way). If one runs the opposite way, its current partially or fully cancels the rest instead of adding, the same physics as clamping L and N together (see [§3.3 step 4](01-installation.md#33-install-the-ct-on-channel-0-main-line)), just with more than two conductors.
+> - **Same phase:** only sum breakers on the same phase/leg. In a three-phase panel, bundling breakers from different legs at the clamp does not give a meaningful reading; see [B.1](#b1-three-phase-main-supply) and [B.2](#b2-three-phase-branch-load-eg-ev-charger-heat-pump-oven) for how phases are meant to be combined instead.
+
+> **ⓘ NOTE: This is different from the software Grouping field**  
+> [Grouping](02-setup.md#45-configure-each-channel) combines **already-separate channels** on the dashboard: each CT still measures its own breaker independently, and the device adds the numbers together in software after the fact. Summing at the clamp is a **hardware-level sum**: the CT itself only ever sees one merged current, before the device measures anything. There is no internal-calculation bug either way, Modbus, the API, and the dashboard all report a correct total for that channel. What you lose by summing at the clamp is the ability to see the bundled breakers individually: the device never measured them separately, so it cannot un-sum them afterwards.
+
 ---
 
 ## Appendix C: LED status reference
@@ -134,7 +181,10 @@ The LED on the front of the device communicates the system state at a glance.
 | --- | --- | --- |
 | 🟢 Green, solid | Connected | Wi-Fi connected, monitoring normally |
 | 🔵 Blue, slow pulse | Connecting | Wi-Fi credentials configured but not currently connected (first boot, router still booting, or temporary connection loss). Reconnects automatically; usually resolves within 60 s |
-| 🔵 Blue, fast blink | Portal active | No Wi-Fi configured; captive portal is open ([§4.1](02-setup.md#41-connect-to-the-devices-wi-fi-captive-portal)) |
+| 🔵 Blue, fast blink | Setup network active | No working Wi-Fi connection; the device's own setup network is open ([§4.1](02-setup.md#41-connect-to-the-devices-wi-fi-setup-network)). Also shown by an already-configured device that lost its network; its setup pages then require your admin login instead of being open to anyone |
+
+> **ⓘ NOTE: Seeing something not listed here?**  
+> The LED colour and pattern can also be set directly through the API (custom colours, and a "disco" pattern for fun), documented on the **Integrations** page in the web interface. If the LED is doing something unexpected, check there before assuming a fault; someone (maybe you, maybe an automation) may have set a custom pattern.
 
 ### Alerts
 
@@ -150,7 +200,7 @@ The LED on the front of the device communicates the system state at a glance.
 | ⚪ White | Press registered but below action threshold. Release for no action |
 | 🔵 Cyan | Restart |
 | 🟡 Yellow | Password reset to default |
-| 🟠 Orange | Wi-Fi reset (re-opens captive portal) |
+| 🟠 Orange | Wi-Fi reset (re-opens the device's own setup network) |
 | 🔴 Red | Factory reset: all data and settings will be erased |
 | ⚪ White (again) | Held too long. Release and try again |
 
@@ -167,7 +217,7 @@ The button on the front of the device lets you recover from common situations wi
 | < 2 s | White | No action |
 | 2-5 s | **Cyan** | **Restart:** equivalent to a power cycle |
 | 5-10 s | **Yellow** | **Password reset:** resets the web password to `energyme` |
-| 10-15 s | **Orange** | **Wi-Fi reset:** clears Wi-Fi credentials and reopens the captive portal ([§4.1](02-setup.md#41-connect-to-the-devices-wi-fi-captive-portal)). Energy data and channel configuration are preserved |
+| 10-15 s | **Orange** | **Wi-Fi reset:** clears Wi-Fi credentials and reopens the device's own setup network ([§4.1](02-setup.md#41-connect-to-the-devices-wi-fi-setup-network)). Energy data and channel configuration are preserved |
 | 15-20 s | **Red** | **Factory reset** ⚠: erases all data, configuration, and credentials. Use only as a last resort |
 | > 20 s | White | No action. Release and try again |
 

--- a/manual/assets/ct_placement_subset.svg
+++ b/manual/assets/ct_placement_subset.svg
@@ -1,0 +1,78 @@
+<svg width="680" viewBox="0 0 680 460" xmlns="http://www.w3.org/2000/svg" font-family="Arial, sans-serif">
+  <title>CT on a subset of the panel — shared tap feeding a group of breakers</title>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="680" height="460" fill="#ffffff"/>
+
+  <!-- Panel dashed border -->
+  <rect x="28" y="28" width="452" height="392" rx="10" fill="none" stroke="#888" stroke-width="1" stroke-dasharray="6 4"/>
+  <text x="254" y="450" text-anchor="middle" font-size="12" fill="#666">Electrical panel — CT on a subset (sub-feed) of breakers</text>
+
+  <!-- Supply label + wire -->
+  <text x="88" y="52" text-anchor="end" font-size="12" fill="#444">Supply</text>
+  <line x1="115" y1="28" x2="115" y2="90" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
+
+  <!-- Main bus -->
+  <line x1="115" y1="90" x2="350" y2="90" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
+
+  <!-- Individually-monitored breaker, faded: not the focus of this diagram -->
+  <g opacity="0.5">
+    <line x1="115" y1="90" x2="115" y2="130" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
+    <rect x="73" y="130" width="84" height="52" rx="6" fill="#f0ede8" stroke="#9e9c94" stroke-width="0.8"/>
+    <text x="115" y="153" text-anchor="middle" font-size="13" font-weight="500" fill="#2c2c2a">Breaker 1</text>
+    <text x="115" y="170" text-anchor="middle" font-size="10" fill="#5f5e5a">(see §3.4)</text>
+    <line x1="115" y1="182" x2="115" y2="356" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
+    <rect x="73" y="356" width="84" height="38" rx="6" fill="#e6f1fb" stroke="#185fa5" stroke-width="0.8"/>
+    <text x="115" y="378" text-anchor="middle" font-size="12" fill="#0c447c">Load 1</text>
+  </g>
+
+  <!-- Drop to the shared tap -->
+  <line x1="350" y1="90" x2="350" y2="140" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
+
+  <!-- Subset CT on the tap wire (correct/intentional) -->
+  <ellipse cx="350" cy="140" rx="20" ry="12" fill="#EAF3DE" stroke="#639922" stroke-width="2.5"/>
+  <polyline points="344,140 348,145 357,133" fill="none" stroke="#3B6D11" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+  <line x1="370" y1="140" x2="392" y2="140" stroke="#639922" stroke-width="1" stroke-dasharray="3 2"/>
+  <circle cx="394" cy="140" r="3" fill="#639922"/>
+
+  <line x1="350" y1="152" x2="350" y2="230" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
+
+  <!-- Nested sub-feed group -->
+  <rect x="250" y="170" width="210" height="225" rx="8" fill="none" stroke="#888" stroke-width="1" stroke-dasharray="4 3"/>
+  <text x="260" y="187" font-size="11" fill="#666">Sub-feed group (shared tap)</text>
+
+  <!-- inner local bus -->
+  <line x1="300" y1="230" x2="410" y2="230" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+  <line x1="300" y1="230" x2="300" y2="250" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+  <line x1="355" y1="230" x2="355" y2="250" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+  <line x1="410" y1="230" x2="410" y2="250" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+
+  <!-- 3 breakers sharing the tap -->
+  <rect x="277" y="250" width="46" height="34" rx="5" fill="#f0ede8" stroke="#9e9c94" stroke-width="0.8"/>
+  <text x="300" y="271" text-anchor="middle" font-size="10" fill="#2c2c2a">Brk A</text>
+  <rect x="332" y="250" width="46" height="34" rx="5" fill="#f0ede8" stroke="#9e9c94" stroke-width="0.8"/>
+  <text x="355" y="271" text-anchor="middle" font-size="10" fill="#2c2c2a">Brk B</text>
+  <rect x="387" y="250" width="46" height="34" rx="5" fill="#f0ede8" stroke="#9e9c94" stroke-width="0.8"/>
+  <text x="410" y="271" text-anchor="middle" font-size="10" fill="#2c2c2a">Brk C</text>
+
+  <!-- outputs to loads -->
+  <line x1="300" y1="284" x2="300" y2="370" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+  <line x1="355" y1="284" x2="355" y2="370" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+  <line x1="410" y1="284" x2="410" y2="370" stroke="#333" stroke-width="3" stroke-linecap="round"/>
+  <text x="355" y="388" text-anchor="middle" font-size="10" fill="#666">to loads (A, B, C)</text>
+
+  <!-- Callout -->
+  <rect x="490" y="95" width="165" height="110" rx="8" fill="#EAF3DE" stroke="#3B6D11" stroke-width="0.8"/>
+  <text x="572" y="118" text-anchor="middle" font-size="14" font-weight="500" fill="#173404">SUBSET CT</text>
+  <text x="572" y="136" text-anchor="middle" font-size="12" fill="#3B6D11">Reads everything fed</text>
+  <text x="572" y="153" text-anchor="middle" font-size="12" fill="#3B6D11">from this tap combined</text>
+  <text x="572" y="170" text-anchor="middle" font-size="12" fill="#3B6D11">(Breakers A–C as one)</text>
+
+  <!-- Leader: subset CT -> callout -->
+  <path d="M 394 140 L 420 140 L 488 150" fill="none" stroke="#639922" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arrow)"/>
+</svg>

--- a/manual/assets/ct_placement_sum_breakers.svg
+++ b/manual/assets/ct_placement_sum_breakers.svg
@@ -1,0 +1,73 @@
+<svg width="680" viewBox="0 0 680 460" xmlns="http://www.w3.org/2000/svg" font-family="Arial, sans-serif">
+  <title>CT clamped around two breaker outputs — summed reading</title>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M2 1L8 5L2 9" fill="none" stroke="context-stroke" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="680" height="460" fill="#ffffff"/>
+
+  <!-- Panel dashed border -->
+  <rect x="28" y="28" width="452" height="392" rx="10" fill="none" stroke="#888" stroke-width="1" stroke-dasharray="6 4"/>
+  <text x="254" y="450" text-anchor="middle" font-size="12" fill="#666">Electrical panel — CT summing two breaker outputs</text>
+
+  <!-- Supply / bus feeding both breakers -->
+  <text x="88" y="52" text-anchor="end" font-size="12" fill="#444">Supply</text>
+  <line x1="182" y1="28" x2="182" y2="70" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="182" y1="70" x2="322" y2="70" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="182" y1="70" x2="182" y2="90" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
+  <line x1="322" y1="70" x2="322" y2="90" stroke="#333" stroke-width="3.5" stroke-linecap="round"/>
+
+  <!-- Breakers -->
+  <rect x="140" y="90" width="84" height="52" rx="6" fill="#f0ede8" stroke="#9e9c94" stroke-width="0.8"/>
+  <text x="182" y="113" text-anchor="middle" font-size="13" font-weight="500" fill="#2c2c2a">Breaker 1</text>
+  <text x="182" y="130" text-anchor="middle" font-size="11" fill="#5f5e5a">15 A</text>
+
+  <rect x="280" y="90" width="84" height="52" rx="6" fill="#f0ede8" stroke="#9e9c94" stroke-width="0.8"/>
+  <text x="322" y="113" text-anchor="middle" font-size="13" font-weight="500" fill="#2c2c2a">Breaker 2</text>
+  <text x="322" y="130" text-anchor="middle" font-size="11" fill="#5f5e5a">20 A</text>
+
+  <!-- Direction arrows: both conductors run the same way -->
+  <polygon points="178,188 186,188 182,198" fill="#333"/>
+  <polygon points="318,188 326,188 322,198" fill="#333"/>
+
+  <!-- Output wires converging into one shared clamp -->
+  <path d="M 182 142 L 182 210 L 232 225 L 232 265 L 182 285 L 182 356" fill="none" stroke="#333" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M 322 142 L 322 210 L 272 225 L 272 265 L 322 285 L 322 356" fill="none" stroke="#333" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- Shared CT clamp around both conductors -->
+  <ellipse cx="252" cy="245" rx="45" ry="15" fill="#EAF3DE" stroke="#639922" stroke-width="2.5"/>
+
+  <!-- Loads -->
+  <rect x="140" y="356" width="84" height="38" rx="6" fill="#e6f1fb" stroke="#185fa5" stroke-width="0.8"/>
+  <text x="182" y="378" text-anchor="middle" font-size="12" fill="#0c447c">Load 1</text>
+
+  <rect x="280" y="356" width="84" height="38" rx="6" fill="#e6f1fb" stroke="#185fa5" stroke-width="0.8"/>
+  <text x="322" y="378" text-anchor="middle" font-size="12" fill="#0c447c">Load 2</text>
+
+  <!-- CORRECT callout -->
+  <rect x="490" y="95" width="165" height="110" rx="8" fill="#EAF3DE" stroke="#3B6D11" stroke-width="0.8"/>
+  <text x="572" y="118" text-anchor="middle" font-size="14" font-weight="500" fill="#173404">CORRECT</text>
+  <text x="572" y="136" text-anchor="middle" font-size="12" fill="#3B6D11">Same direction:</text>
+  <text x="572" y="153" text-anchor="middle" font-size="12" fill="#3B6D11">currents add</text>
+  <text x="572" y="170" text-anchor="middle" font-size="12" fill="#3B6D11">(reads B1 + B2)</text>
+
+  <!-- Leader: clamp -> callout -->
+  <path d="M 297 245 L 297 150 L 488 150" fill="none" stroke="#639922" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arrow)"/>
+
+  <!-- WRONG inset: opposing direction cancels -->
+  <rect x="490" y="230" width="165" height="150" rx="8" fill="#FCEBEB" stroke="#A32D2D" stroke-width="0.8"/>
+  <text x="572" y="253" text-anchor="middle" font-size="14" font-weight="500" fill="#791f1f">WRONG</text>
+
+  <line x1="545" y1="270" x2="545" y2="310" stroke="#333" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="600" y1="270" x2="600" y2="310" stroke="#333" stroke-width="2.5" stroke-linecap="round"/>
+  <polygon points="541,278 549,278 545,288" fill="#333"/>
+  <polygon points="596,302 604,302 600,292" fill="#333"/>
+  <ellipse cx="572" cy="290" rx="32" ry="11" fill="#FCEBEB" stroke="#E24B4A" stroke-width="2"/>
+
+  <text x="572" y="330" text-anchor="middle" font-size="12" fill="#A32D2D">Opposing direction</text>
+  <text x="572" y="347" text-anchor="middle" font-size="12" fill="#A32D2D">currents cancel</text>
+  <text x="572" y="364" text-anchor="middle" font-size="11" fill="#A32D2D">(partial or full)</text>
+</svg>

--- a/source/src/mqtt.cpp
+++ b/source/src/mqtt.cpp
@@ -1626,6 +1626,16 @@ namespace Mqtt
         JsonVariant forceVariant = doc["execution"]["jobDocument"]["force"];
         bool force = forceVariant.is<bool>() ? forceVariant.as<bool>() : false;
 
+        // This job is the one currently being validated post-reboot: its target
+        // version now equals FIRMWARE_BUILD_VERSION, which would otherwise hit the
+        // "already up to date" branch below and publish REJECTED - a terminal status
+        // that then makes the validation task's later SUCCEEDED publish be refused
+        // by AWS IoT Jobs (terminal states cannot transition again).
+        if (_otaValidationTaskHandle != nullptr && strcmp(jobId, _otaCurrentJobId) == 0) {
+            LOG_DEBUG("Job '%s' is the one currently being validated, skipping re-evaluation", jobId);
+            return;
+        }
+
         // Additional validation for operation type (validation function only checks existence)
         if (strcmp(operation, "ota_update") != 0) {
             LOG_WARNING("Job operation '%s' is not supported, rejecting job %s.", operation, jobId);


### PR DESCRIPTION
## Summary
- Clarify that Channel 0 must share the power feed's phase and can't be deactivated (CT clamp itself is optional)
- Document the 2.3.0 provisioning rewrite: unified AP+STA setup flow, mandatory password gate, login lockout; add a compatibility note for devices still on pre-2.3.0 firmware (WiFiManager portal, no enforced password change)
- Add "always update firmware" guidance and Cloud Services auto-update tip
- Add Appendix B.4 with new diagrams for subset/shared-tap and summed-breaker CT placement, plus a power-factor check for wrong phase assignment in Appendix B.1

Closes #231
Closes #228
Closes #203

## Test plan
- [x] Manual proofread against current firmware behavior (customwifi.cpp, ade7953.cpp, mqtt.cpp, customserver.cpp) rather than assumed
- [x] Jibril to review before merge (per repo convention: code-review + simplification pass before merging to development)